### PR TITLE
Corrected geometry when replacing a junction

### DIFF
--- a/src/netedit/GNENet.cpp
+++ b/src/netedit/GNENet.cpp
@@ -1613,8 +1613,6 @@ GNENet::replaceJunctionByGeometry(GNEJunction* junction, GNEUndoList* undoList) 
         for (auto con : connections) {
             undoList->add(new GNEChange_Connection(begin, con, false, false), true);
         }
-        // replace incoming edge
-        replaceIncomingEdge(continuation, begin, undoList);
         // fix shape of replaced edge
         PositionVector newShape = begin->getNBEdge()->getInnerGeometry();
         if (begin->getNBEdge()->hasDefaultGeometryEndpointAtNode(begin->getNBEdge()->getToNode())) {
@@ -1627,6 +1625,9 @@ GNENet::replaceJunctionByGeometry(GNEJunction* junction, GNEUndoList* undoList) 
         } else {
             newShape.push_back_noDoublePos(continuation->getNBEdge()->getGeometry()[0]);
         }
+        // replace incoming edge
+        replaceIncomingEdge(continuation, begin, undoList);
+
         newShape.append(continuation->getNBEdge()->getInnerGeometry());
         begin->setAttribute(GNE_ATTR_SHAPE_END, continuation->getAttribute(GNE_ATTR_SHAPE_END), undoList);
         begin->setAttribute(SUMO_ATTR_SHAPE, toString(newShape), undoList);


### PR DESCRIPTION
The Netedit junction context option "Replace by geometry point" produces unexpected results due to getting the geometry points only after some edge changes. This can be fixed by moving the call to replaceIncomingEdge after the geometry calculation.

Before the operation:
![before](https://user-images.githubusercontent.com/33294728/43368869-fb7b8680-9363-11e8-866f-896c42e18de7.png)
After the operation:
![after](https://user-images.githubusercontent.com/33294728/43368871-fdc8ebee-9363-11e8-8553-50940c023459.png)
After the operation using the fix:
![corrected](https://user-images.githubusercontent.com/33294728/43368891-776d9f30-9364-11e8-93ab-8d0307b0c991.png)

Signed-off-by: m-kro <m.barthauer@t-online.de>