### PR TITLE
Detector vType filter checks for vtype distributions

### DIFF
--- a/src/microsim/MSVehicleControl.cpp
+++ b/src/microsim/MSVehicleControl.cpp
@@ -266,6 +266,9 @@ MSVehicleControl::removeVType(const MSVehicleType* vehType) {
     assert(vehType != 0);
     assert(myVTypeDict.find(vehType->getID()) != myVTypeDict.end());
     myVTypeDict.erase(vehType->getID());
+    if (myVTypeToDist.find(vehType->getID()) != myVTypeToDist.end()) {
+        myVTypeToDist.erase(vehType->getID());
+    }
     delete vehType;
 }
 
@@ -274,6 +277,15 @@ bool
 MSVehicleControl::addVTypeDistribution(const std::string& id, RandomDistributor<MSVehicleType*>* vehTypeDistribution) {
     if (checkVType(id)) {
         myVTypeDistDict[id] = vehTypeDistribution;
+        std::vector<MSVehicleType*> vehTypes = vehTypeDistribution->getVals();
+        for (auto vehType : vehTypes) {
+            if (myVTypeToDist.find(vehType->getID()) != myVTypeToDist.end()) {
+                myVTypeToDist[vehType->getID()].insert(id);
+            }
+            else {
+                myVTypeToDist[vehType->getID()] = { id };
+            }
+        }
         return true;
     }
     return false;
@@ -320,6 +332,16 @@ MSVehicleControl::insertVTypeIDs(std::vector<std::string>& into) const {
     for (VTypeDistDictType::const_iterator i = myVTypeDistDict.begin(); i != myVTypeDistDict.end(); ++i) {
         into.push_back((*i).first);
     }
+}
+
+
+std::set<std::string>
+MSVehicleControl::getVTypeDistributionMembership(const std::string& id) const {
+    std::map<std::string, std::set<std::string>>::const_iterator it = myVTypeToDist.find(id);
+    if (it == myVTypeToDist.end()) {
+        return std::set<std::string>();
+    }
+    return it->second;
 }
 
 

--- a/src/microsim/MSVehicleControl.h
+++ b/src/microsim/MSVehicleControl.h
@@ -385,6 +385,13 @@ public:
      * @param[in] into The vector to fill with ids
      */
     void insertVTypeIDs(std::vector<std::string>& into) const;
+
+
+    /** @brief Return the distribution IDs the vehicle type is a member of
+    * @param[in] vehType The vehicle type to look for membership in distributions
+    */
+    std::set<std::string> getVTypeDistributionMembership(const std::string& id) const;
+
     /// @}
 
     /// @brief Adds a vehicle to the list of waiting vehiclse to a given edge
@@ -570,6 +577,9 @@ private:
     typedef std::map< std::string, RandomDistributor<MSVehicleType*>* > VTypeDistDictType;
     /// @brief A distribution of vehicle types (probability->vehicle type)
     VTypeDistDictType myVTypeDistDict;
+
+    /// @brief Inverse lookup from vehicle type to distributions it is a member of
+    std::map<std::string, std::set<std::string>> myVTypeToDist;
 
     /// @brief Whether the default vehicle type was already used or can still be replaced
     bool myDefaultVTypeMayBeDeleted;

--- a/src/microsim/output/MSDetectorFileOutput.h
+++ b/src/microsim/output/MSDetectorFileOutput.h
@@ -35,6 +35,8 @@
 #include <utils/iodevices/OutputDevice.h>
 #include <utils/vehicle/SUMOVehicle.h>
 #include <microsim/MSVehicleType.h>
+#include <microsim/MSVehicleControl.h>
+#include <microsim/MSNet.h>
 
 
 // ===========================================================================
@@ -137,7 +139,18 @@ public:
     * @return whether it should be measured
     */
     bool vehicleApplies(const SUMOVehicle& veh) const {
-        return myVehicleTypes.empty() || myVehicleTypes.count(veh.getVehicleType().getID()) > 0;
+        if (myVehicleTypes.empty() || myVehicleTypes.count(veh.getVehicleType().getID()) > 0) {
+            return true;
+        }
+        else {
+            std::set<std::string> vTypeDists = MSNet::getInstance()->getVehicleControl().getVTypeDistributionMembership(veh.getVehicleType().getID());
+            for (auto vTypeDist : vTypeDists) {
+                if (myVehicleTypes.count(vTypeDist) > 0) {
+                    return true;
+                }
+            }
+            return false;
+        }      
     }
 
 


### PR DESCRIPTION
I need the feature mentioned in issue #4329 so I coded some solution for it: A data structure has been added to MSVehicleControl for a faster lookup which vehicle distributions a vehicle type is a member of. Those get passed to the detector to check whether it matches its vtypes filter. 
I have the feeling it can still be optimized but don't understand enough SUMO details do figure it out. One option would have been to store the distribution membership within VehicleType instances.




