### PR TITLE
extrude walkingarea and sidewalk lanes in OSG ref #10773

### DIFF
--- a/src/osgview/GUIOSGBuilder.h
+++ b/src/osgview/GUIOSGBuilder.h
@@ -74,6 +74,9 @@ private:
 
     static void setShapeState(osg::ref_ptr<osg::ShapeDrawable> shape);
 
+	// @brief Return the Z offset applied to a specific network object type e.g. to prevent Z-fighting (defaults to 0)
+	static float getAdditionalZOffset(GUIGlObjectType type);
+
     static std::map<std::string, osg::ref_ptr<osg::Node> > myCars;
 };
 

--- a/src/osgview/GUIOSGHeader.h
+++ b/src/osgview/GUIOSGHeader.h
@@ -41,6 +41,7 @@
 
 // OSG Headers
 #include <osg/ComputeBoundsVisitor>
+#include <osg/FrontFace>
 #include <osg/Geode>
 #include <osg/Geometry>
 #include <osg/Group>
@@ -62,6 +63,7 @@
 #include <osgGA/TerrainManipulator>
 #include <osgGA/TrackballManipulator>
 #include <osgUtil/Tessellator>
+#include <osgUtil/SmoothingVisitor>
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
 

--- a/src/osgview/GUIOSGView.cpp
+++ b/src/osgview/GUIOSGView.cpp
@@ -136,8 +136,11 @@ GUIOSGView::GUIOSGView(
     myAdapter = new FXOSGAdapter(this, new FXCursor(parent->getApp(), CURSOR_CROSS));
 
     myViewer = new osgViewer::Viewer();
+	myViewer->setLightingMode(osg::View::LightingMode::SKY_LIGHT);
+	myViewer->getLight()->setDiffuse(osg::Vec4(0.88, 0.88, 0.88, 1.0));
     myViewer->getCamera()->setGraphicsContext(myAdapter);
     myViewer->getCamera()->setViewport(0, 0, w, h);
+	myViewer->getCamera()->setNearFarRatio(0.005);
     myViewer->setThreadingModel(osgViewer::Viewer::SingleThreaded);
 	myViewer->addEventHandler(new PickHandler(this));
 


### PR DESCRIPTION
- In order to remove the glitch of shapes with very short Z offset, walkingareas and sidewalk lanes (lanes for pedestrians only) have been raised by 0.1 from the ground and solidified with kerbs. 
- The OSG near/far ratio has been increased. As all object distances from the camera are normalised to [0;1], we gain some precision for close objects with a higher near/far ratio. This comes at the price of not seeing anymore items very close to the camera (approx. 2m?). Might be an issue for a driver perspective.

Signed-off-by: m-kro <m.barthauer@t-online.de>