### PR TITLE
Implemented getIntervalVehicleNumber in InductionLoopScope for the Traci-API on the client-side

### DIFF
--- a/src/libsumo/TraCIConstants.h
+++ b/src/libsumo/TraCIConstants.h
@@ -704,9 +704,6 @@ TRACI_CONST int AUTOMATIC_CONTEXT_SUBSCRIPTION = 0x03;
 // generic attributes (get/set: all)
 TRACI_CONST int GENERIC_ATTRIBUTE = 0x03;
 
-// The number of vehicles (or persons, if so configured) that passed the detector during the current interval
-TRACI_CONST int INTERVAL_NUMBER = 0x25;
-
 // last step vehicle number (get: induction loops, multi-entry/multi-exit detector, lanes, edges)
 TRACI_CONST int LAST_STEP_VEHICLE_NUMBER = 0x10;
 

--- a/src/libsumo/TraCIConstants.h
+++ b/src/libsumo/TraCIConstants.h
@@ -704,6 +704,9 @@ TRACI_CONST int AUTOMATIC_CONTEXT_SUBSCRIPTION = 0x03;
 // generic attributes (get/set: all)
 TRACI_CONST int GENERIC_ATTRIBUTE = 0x03;
 
+// The number of vehicles (or persons, if so configured) that passed the detector during the current interval
+TRACI_CONST int INTERVAL_NUMBER = 0x25;
+
 // last step vehicle number (get: induction loops, multi-entry/multi-exit detector, lanes, edges)
 TRACI_CONST int LAST_STEP_VEHICLE_NUMBER = 0x10;
 

--- a/src/utils/traci/TraCIAPI.cpp
+++ b/src/utils/traci/TraCIAPI.cpp
@@ -723,6 +723,11 @@ TraCIAPI::GUIScope::trackVehicle(const std::string& viewID, const std::string& v
 // ---------------------------------------------------------------------------
 // TraCIAPI::InductionLoopScope-methods
 // ---------------------------------------------------------------------------
+
+int TraCIAPI::InductionLoopScope::getIntervalVehicleNumber(const std::string &loopID) const {
+    return getInt(libsumo::INTERVAL_NUMBER, loopID);
+}
+
 double
 TraCIAPI::InductionLoopScope::getPosition(const std::string& loopID) const {
     return getDouble(libsumo::VAR_POSITION, loopID);

--- a/src/utils/traci/TraCIAPI.cpp
+++ b/src/utils/traci/TraCIAPI.cpp
@@ -725,7 +725,7 @@ TraCIAPI::GUIScope::trackVehicle(const std::string& viewID, const std::string& v
 // ---------------------------------------------------------------------------
 
 int TraCIAPI::InductionLoopScope::getIntervalVehicleNumber(const std::string &loopID) const {
-    return getInt(libsumo::INTERVAL_NUMBER, loopID);
+    return getInt(libsumo::VAR_LAST_INTERVAL_NUMBER, loopID);
 }
 
 double

--- a/src/utils/traci/TraCIAPI.h
+++ b/src/utils/traci/TraCIAPI.h
@@ -228,6 +228,11 @@ public:
         InductionLoopScope(TraCIAPI& parent) : TraCIScopeWrapper(parent, libsumo::CMD_GET_INDUCTIONLOOP_VARIABLE, -1, libsumo::CMD_SUBSCRIBE_INDUCTIONLOOP_VARIABLE, libsumo::CMD_SUBSCRIBE_INDUCTIONLOOP_CONTEXT) {}
         virtual ~InductionLoopScope() {}
 
+        /**
+         * @param loopID The ID of the Induction Loop
+         * @return the number of vehicles that passed the detector during the current interval
+         */
+        int getIntervalVehicleNumber(const std::string& loopID) const;
         double  getPosition(const std::string& loopID) const;
         std::string getLaneID(const std::string& loopID) const;
         int getLastStepVehicleNumber(const std::string& loopID) const;


### PR DESCRIPTION
Hey,

I needed this for Artery and I would like to share this with you.
I am not familiar with your test-setup so I did only a little testing by hand. 