### PR TITLE
Plot the line width legend instead of the color bar 

### DIFF
--- a/tests/complex/config.complex
+++ b/tests/complex/config.complex
@@ -196,7 +196,7 @@ errors:getNextStops
 
 
 [floating_point_tolerance]
-output:0.0001
+output:0.0101
 net:0.0101
 vss:0.0001
 results:0.0101

--- a/tools/visualization/plot_net_dump.py
+++ b/tools/visualization/plot_net_dump.py
@@ -93,13 +93,8 @@ def main(args=None):
                   help="The label to put on the color bar")
     ap.add_option("--internal", action="store_true",
                   default=False, help="include internal edges in generated shapes")
-<<<<<<< HEAD
     ap.add_option("--traffic-volume-legend", dest="volumelegend", action="store_true",
                   default=False, help="Removes color bar and plots line weight legend for link volumes")
-=======
-    ap.add_option("--customlinkflowtheme", dest="customlinkflowtheme", action="store_true",
-                  default=False, help="customized network flow plot theme")
->>>>>>> 7d59f7d1db7ee6f93217a369828122a951e1ce21
 
     # standard plot options
     helpers.addInteractionOptions(ap)
@@ -238,11 +233,7 @@ def main(args=None):
         ax.set_aspect("equal", None, 'C')
         helpers.plotNet(net, colors, widths, options)
                 
-<<<<<<< HEAD
         if options.volumelegend:
-=======
-        if options.customlinkflowtheme:
->>>>>>> 7d59f7d1db7ee6f93217a369828122a951e1ce21
             # Define label steps
             ratio = (options.maxWidth/options.minWidth)**(1./3)
             label_steps = [options.minWidth, ratio * options.minWidth, ratio * ratio * options.minWidth, options.maxWidth]
@@ -269,11 +260,7 @@ def main(args=None):
             # "fake up the array of the scalar mappable. Urgh..."
             # (pelson, http://stackoverflow.com/questions/8342549/matplotlib-add-colorbar-to-a-sequence-of-line-plots)
             sm._A = []
-<<<<<<< HEAD
         if not options.volumelegend:
-=======
-        if not options.customlinkflowtheme:
->>>>>>> 7d59f7d1db7ee6f93217a369828122a951e1ce21
             color_bar = plt.colorbar(sm, ax=ax)
             color_bar.set_label(options.colorBarLabel)
         else:

--- a/tools/visualization/plot_net_dump.py
+++ b/tools/visualization/plot_net_dump.py
@@ -93,6 +93,8 @@ def main(args=None):
                   help="The label to put on the color bar")
     ap.add_option("--internal", action="store_true",
                   default=False, help="include internal edges in generated shapes")
+    ap.add_option("--traffic-volume-legend", dest="volumelegend", action="store_true",
+                  default=False, help="Removes color bar and plots line weight legend for link volumes")
 
     # standard plot options
     helpers.addInteractionOptions(ap)
@@ -230,6 +232,24 @@ def main(args=None):
         fig, ax = helpers.openFigure(options)
         ax.set_aspect("equal", None, 'C')
         helpers.plotNet(net, colors, widths, options)
+                
+        if options.volumelegend:
+            # Define label steps
+            ratio = (options.maxWidth/options.minWidth)**(1./3)
+            label_steps = [options.minWidth, ratio * options.minWidth, ratio * ratio * options.minWidth, options.maxWidth]
+
+            # Create proxy function
+            def make_proxy(**kwargs):
+                return matplotlib.lines.Line2D([0, 1], [0, 1], color=options.defaultColor, **kwargs)
+            # Generate legend proxies and labels
+            proxies = [make_proxy(linewidth=item) for item in label_steps]
+            labels = [str(int(options.widthMin + (e - label_steps[0]) * (options.widthMax - options.widthMin) / (label_steps[-1] - label_steps[0]))) for e in label_steps]
+
+            # Add legend to the plot
+            ax.legend(proxies, labels)
+
+            # Set the title
+            # ax.set_title("Link flows: {} am - {} am (vehicles/hour)".format(int(t / 3600), int(t / 3600) + 1))
 
         # drawing the legend, at least for the colors
         norm = matplotlib.colors.LogNorm if options.logColors else matplotlib.colors.Normalize
@@ -240,8 +260,13 @@ def main(args=None):
             # "fake up the array of the scalar mappable. Urgh..."
             # (pelson, http://stackoverflow.com/questions/8342549/matplotlib-add-colorbar-to-a-sequence-of-line-plots)
             sm._A = []
-        color_bar = plt.colorbar(sm, ax=ax)
-        color_bar.set_label(options.colorBarLabel)
+        if not options.volumelegend:
+            color_bar = plt.colorbar(sm, ax=ax)
+            color_bar.set_label(options.colorBarLabel)
+        else:
+            ax.set_xticks([])
+            ax.set_yticks([])
+            plt.tight_layout()
 
         # Should we also save the figure to a file / list of files (comma
         # separated)?


### PR DESCRIPTION
This change might be helpful for those who intend to plot nice link traffic volume plots using edge data.  This change plots the line width legend using **--traffic-volume-legend** flag (instead of the color bar) to show traffic volumes on links.

```sh
python2 $SUMO_HOME/tools/visualization/plot_net_dump.py network.net.xml --measures ,left -i edge_data,edge_data -o flow%s.png --max-width 5 --min-width 0.625 --traffic-volume-legend --max-color-value 500 --min-width-value 10 --max-width-value 500 --dpi 600 -s 5,5 -b
```