### PR TITLE
Refactored train drawing code so that it can be used elsewhere

### DIFF
--- a/src/guisim/GUIVehicle.cpp
+++ b/src/guisim/GUIVehicle.cpp
@@ -57,9 +57,9 @@
 #include <microsim/devices/MSDevice_BTreceiver.h>
 #include <microsim/devices/MSDevice_ElecHybrid.h>
 #include <microsim/devices/MSDevice_Battery.h>
+#include <microsim/transportables/MSTrainHelper.h>
 #include <gui/GUIApplicationWindow.h>
 #include <gui/GUIGlobals.h>
-
 #include "GUIVehicle.h"
 #include "GUIPerson.h"
 #include "GUIContainer.h"
@@ -309,61 +309,23 @@ GUIVehicle::drawAction_drawLinkItems(const GUIVisualizationSettings& s) const {
 
 void
 GUIVehicle::drawAction_drawCarriageClass(const GUIVisualizationSettings& s, bool asImage) const {
-    const bool s2 = s.secondaryShape;
     RGBColor current = GLHelper::getColor();
     RGBColor darker = current.changedBrightness(-51);
     const double exaggeration = (s.vehicleSize.getExaggeration(s, this)
                                  * s.vehicleScaler.getScheme().getColor(getScaleValue(s, s.vehicleScaler.getActive())));
-    const double totalLength = getVType().getLength();
-    double upscaleLength = exaggeration;
-    if (exaggeration > 1 && totalLength > 5) {
-        // reduce the length/width ratio because this is not useful at high zoom
-        const double widthLengthFactor = totalLength / 5;
-        const double shrinkFactor = MIN2(widthLengthFactor, sqrt(upscaleLength));
-        upscaleLength /= shrinkFactor;
-    }
-    const double locomotiveLength = getVehicleType().getParameter().locomotiveLength * upscaleLength;
     if (exaggeration == 0) {
         return;
     }
-    const double defaultLength = getVehicleType().getParameter().carriageLength * upscaleLength;
-    const double carriageGap = getVehicleType().getParameter().carriageGap * upscaleLength;
-    const double length = totalLength * upscaleLength;
-    const double halfWidth = getVehicleType().getWidth() / 2.0 * exaggeration;
-    GLHelper::popMatrix(); // undo initial translation and rotation
-    const double xCornerCut = 0.3 * exaggeration;
-    const double yCornerCut = 0.4 * exaggeration;
-    // round to closest integer
-    const int numCarriages = MAX2(1, 1 + (int)((length - locomotiveLength) / (defaultLength + carriageGap) + 0.5));
-    assert(numCarriages > 0);
-    double carriageLengthWithGap = length / numCarriages;
-    double carriageLength = carriageLengthWithGap - carriageGap;
-    double firstCarriageLength = carriageLength;
-    if (defaultLength != locomotiveLength && numCarriages > 1) {
-        firstCarriageLength = locomotiveLength;
-        carriageLengthWithGap = (length - locomotiveLength) / (numCarriages - 1);
-        carriageLength = carriageLengthWithGap - carriageGap;
-    }
-    const int firstPassengerCarriage = defaultLength == locomotiveLength || numCarriages == 1
+    // bool reversed = 
+    MSTrainHelper trainHelper(this, isReversed() && s.drawReversed, s.secondaryShape);
+    int numCarriages = trainHelper.getNumCarriages();
+    const int firstPassengerCarriage = trainHelper.getDefaultLength() == trainHelper.getLocomotiveLength() || numCarriages == 1
                                        || (getVClass() & (SVC_RAIL_ELECTRIC | SVC_RAIL_FAST | SVC_RAIL)) == 0 ? 0 : 1;
     const int noPersonsBackCarriages = (getVehicleType().getGuiShape() == SUMOVehicleShape::TRUCK_SEMITRAILER || getVehicleType().getGuiShape() == SUMOVehicleShape::TRUCK_1TRAILER) && numCarriages > 1 ? 1 : 0;
     const int firstContainerCarriage = numCarriages == 1 || getVehicleType().getGuiShape() == SUMOVehicleShape::TRUCK_1TRAILER ? 0 : 1;
     const int seatsPerCarriage = (int)ceil(getVType().getPersonCapacity() / (numCarriages - firstPassengerCarriage - noPersonsBackCarriages));
     const int containersPerCarriage = (int)ceil(getVType().getContainerCapacity() / (numCarriages - firstContainerCarriage));
-    // lane on which the carriage front is situated
-    MSLane* lane = myLane;
-    int furtherIndex = 0;
-    // lane on which the carriage back is situated
-    MSLane* backLane = myLane;
-    int backFurtherIndex = furtherIndex;
-    // offsets of front and back
-    double carriageOffset = myState.pos();
-    if (getLaneChangeModel().isOpposite()) {
-        // @note this still produces some artifacts while not fully on the current lane
-        carriageOffset = MIN2(carriageOffset + getLength(), lane->getLength());
-    }
-    double carriageBackOffset = carriageOffset - firstCarriageLength;
-    // handle seats
+    // Handle seats.
     int requiredSeats = getNumPassengers();
     int requiredPositions = getNumContainers();
     if (requiredSeats > 0) {
@@ -372,65 +334,24 @@ GUIVehicle::drawAction_drawCarriageClass(const GUIVisualizationSettings& s, bool
     if (requiredPositions > 0) {
         myContainerPositions.clear();
     }
+    GLHelper::popMatrix(); // undo initial translation and rotation
+    const double xCornerCut = 0.3 * exaggeration;
+    const double yCornerCut = 0.4 * exaggeration;
     Position front, back;
-    double angle = 0.;
-    // position parking vehicle beside the road or track
-    const double lateralOffset = (isParking() && getNextStopParameter()->posLat == INVALID_DOUBLE
-                                  ? (getLane()->getWidth() * (MSGlobals::gLefthand ? -1 : 1))
-                                  : -getLateralPositionOnLane());
-
-    // draw individual carriages
-    double curCLength = firstCarriageLength;
-    int firstCarriageNo = 0;  // default case - we're going forwards
-    const bool reversed = drawReversed(s) || getLaneChangeModel().isOpposite();
-    if (reversed) {
-        firstCarriageNo = numCarriages - 1;
-        if (numCarriages > 1) {
-            carriageBackOffset = carriageOffset - carriageLength;
-        }
-    }
-
-    //std::cout << SIMTIME << " veh=" << getID() << " curCLength=" << curCLength << " loc=" << locomotiveLength << " car=" << carriageLength << " tlen=" << totalLength << " len=" << length << "\n";
+    double angle = 0.0;
+    double curCLength = trainHelper.getFirstCarriageLength();
+    std::vector<MSTrainHelper::Carriage*> carriages = trainHelper.getCarriages();
     for (int i = 0; i < numCarriages; ++i) {
-        if (i == firstCarriageNo) {
-            curCLength = firstCarriageLength;
-            if (firstCarriageNo > 0) {
-                // previous loop iteration has adjusted backpos for a normal carriage so have to correct
-                carriageBackOffset += carriageLengthWithGap;
-                carriageBackOffset -= firstCarriageLength + carriageGap;
-            }
-        } else {
-            curCLength = carriageLength;
-        }
-        while (carriageOffset < 0) {
-            MSLane* prev = getPreviousLane(lane, furtherIndex);
-            if (prev != lane) {
-                carriageOffset += prev->getLength();
-            } else {
-                // no lane available for drawing.
-                carriageOffset = 0;
-            }
-            lane = prev;
-        }
-        while (carriageBackOffset < 0) {
-            MSLane* prev = getPreviousLane(backLane, backFurtherIndex);
-            if (prev != backLane) {
-                carriageBackOffset += prev->getLength();
-            } else {
-                // no lane available for drawing.
-                carriageBackOffset = 0;
-            }
-            backLane = prev;
-        }
-        front = lane->getShape(s2).positionAtOffset(carriageOffset * lane->getLengthGeometryFactor(s2), lateralOffset);
-        back = backLane->getShape(s2).positionAtOffset(carriageBackOffset * lane->getLengthGeometryFactor(s2), lateralOffset);
+        front = carriages[i]->front;
+        back = carriages[i]->back;
         if (front == back) {
-            // no place for drawing available
+            // No place for drawing available.
             continue;
         }
         const double drawnCarriageLength = front.distanceTo2D(back);
         angle = atan2((front.x() - back.x()), (back.y() - front.y())) * (double) 180.0 / (double) M_PI;
         // if we are in reverse 'first' carriages are drawn last so the >= test doesn't work
+        const bool reversed = trainHelper.isReversed();
         if (reversed) {
             if (i <= numCarriages - firstPassengerCarriage) {
                 computeSeats(back, front, SUMO_const_waitingPersonWidth, seatsPerCarriage, exaggeration, requiredSeats, mySeatPositions);
@@ -446,14 +367,16 @@ GUIVehicle::drawAction_drawCarriageClass(const GUIVisualizationSettings& s, bool
                 computeSeats(front, back, SUMO_const_waitingContainerWidth, containersPerCarriage, exaggeration, requiredPositions, myContainerPositions);
             }
         }
+        curCLength = (i == trainHelper.getFirstCarriageNo() ? trainHelper.getFirstCarriageLength() : trainHelper.getCarriageLength());
         GLHelper::pushMatrix();
         glTranslated(front.x(), front.y(), getType());
         glRotated(angle, 0, 0, 1);
+        double halfWidth = trainHelper.getHalfWidth();
         if (!asImage || !GUIBaseVehicleHelper::drawAction_drawVehicleAsImage(s, getVType().getImgFile(), this, getVType().getWidth() * exaggeration, curCLength)) {
             switch (getVType().getGuiShape()) {
                 case SUMOVehicleShape::TRUCK_SEMITRAILER:
                 case SUMOVehicleShape::TRUCK_1TRAILER:
-                    if (i == firstCarriageNo) {  // at the moment amReversed is only ever set for rail - so has no impact in this call
+                    if (i == trainHelper.getFirstCarriageNo()) {  // at the moment amReversed is only ever set for rail - so has no impact in this call
                         GUIBaseVehicleHelper::drawAction_drawVehicleAsPoly(s, getVType().getGuiShape(), getVType().getWidth() * exaggeration, curCLength, 0, false, reversed);
                     } else {
                         GLHelper::setColor(current);
@@ -461,7 +384,7 @@ GUIVehicle::drawAction_drawCarriageClass(const GUIVisualizationSettings& s, bool
                     }
                     break;
                 default: {
-                    if (i == firstCarriageNo) {
+                    if (i == trainHelper.getFirstCarriageNo()) {
                         GLHelper::setColor(darker);
                     } else {
                         GLHelper::setColor(current);
@@ -478,7 +401,7 @@ GUIVehicle::drawAction_drawCarriageClass(const GUIVisualizationSettings& s, bool
                     glVertex2d(halfWidth - xCornerCut, 0);
                     glEnd();
                     // indicate front of the head of the train
-                    if (i == firstCarriageNo) {
+                    if (i == trainHelper.getFirstCarriageNo()) {
                         glTranslated(0, 0, 0.1);
                         glColor3d(0, 0, 0);
                         glBegin(GL_TRIANGLE_FAN);
@@ -500,8 +423,6 @@ GUIVehicle::drawAction_drawCarriageClass(const GUIVisualizationSettings& s, bool
             }
         }
         GLHelper::popMatrix();
-        carriageOffset -= (curCLength + carriageGap);
-        carriageBackOffset -= carriageLengthWithGap;
     }
     if (getVType().getGuiShape() == SUMOVehicleShape::RAIL_CAR) {
         GLHelper::pushMatrix();
@@ -517,7 +438,7 @@ GUIVehicle::drawAction_drawCarriageClass(const GUIVisualizationSettings& s, bool
     glTranslated(front.x(), front.y(), getType());
     const double degAngle = RAD2DEG(getAngle() + M_PI / 2.);
     glRotated(degAngle, 0, 0, 1);
-    glScaled(exaggeration, upscaleLength, 1);
+    glScaled(exaggeration, trainHelper.getUpscaleLength(), 1);
     if (mySeatPositions.size() == 0) {
         mySeatPositions.push_back(Seat(back, DEG2RAD(angle)));
     }
@@ -782,60 +703,6 @@ GUIVehicle::drawRouteHelper(const GUIVisualizationSettings& s, ConstMSRoutePtr r
     }
     drawStopLabels(s, noLoop, col);
     drawParkingInfo(s, col);
-}
-
-
-MSLane*
-GUIVehicle::getPreviousLane(MSLane* current, int& furtherIndex) const {
-    if (furtherIndex < (int)myFurtherLanes.size()) {
-        return myFurtherLanes[furtherIndex++];
-    } else {
-        // try to use route information
-        int routeIndex = getRoutePosition();
-        bool resultInternal;
-        if (MSGlobals::gUsingInternalLanes && MSNet::getInstance()->hasInternalLinks()) {
-            if (myLane->isInternal()) {
-                if (furtherIndex % 2 == 0) {
-                    routeIndex -= (furtherIndex + 0) / 2;
-                    resultInternal = false;
-                } else {
-                    routeIndex -= (furtherIndex + 1) / 2;
-                    resultInternal = false;
-                }
-            } else {
-                if (furtherIndex % 2 != 0) {
-                    routeIndex -= (furtherIndex + 1) / 2;
-                    resultInternal = false;
-                } else {
-                    routeIndex -= (furtherIndex + 2) / 2;
-                    resultInternal = true;
-                }
-            }
-        } else {
-            routeIndex -= furtherIndex;
-            resultInternal = false;
-        }
-        furtherIndex++;
-        if (routeIndex >= 0) {
-            if (resultInternal) {
-                const MSEdge* prevNormal = myRoute->getEdges()[routeIndex];
-                for (MSLane* cand : prevNormal->getLanes()) {
-                    for (MSLink* link : cand->getLinkCont()) {
-                        if (link->getLane() == current) {
-                            if (link->getViaLane() != nullptr) {
-                                return link->getViaLane();
-                            } else {
-                                return const_cast<MSLane*>(link->getLaneBefore());
-                            }
-                        }
-                    }
-                }
-            } else {
-                return myRoute->getEdges()[routeIndex]->getLanes()[0];
-            }
-        }
-    }
-    return current;
 }
 
 

--- a/src/guisim/GUIVehicle.h
+++ b/src/guisim/GUIVehicle.h
@@ -184,12 +184,6 @@ private:
      * passengerSeats are computed beginning at firstPassengerCarriage */
     void drawAction_drawCarriageClass(const GUIVisualizationSettings& s, bool asImage) const;
 
-    /* @brief return the previous lane in this vehicles route including internal lanes
-     * @param[in] current The lane of which the predecessor should be returned
-     * @param[in,out] routeIndex The index of the current or previous non-internal edge in the route
-     */
-    MSLane* getPreviousLane(MSLane* current, int& furtherIndex) const;
-
     /// @brief retrieve information about the current stop state
     std::string getStopInfo() const;
 

--- a/src/microsim/MSVehicle.h
+++ b/src/microsim/MSVehicle.h
@@ -2056,7 +2056,12 @@ public:
     inline double accelThresholdForWaiting() const {
         return 0.5 * getCarFollowModel().getMaxAccel();
     }
-
+    
+    /* @brief return the previous lane in this vehicles route including internal lanes
+     * @param[in] current The lane of which the predecessor should be returned
+     * @param[in,out] routeIndex The index of the current or previous non-internal edge in the route
+     */
+    const MSLane* getPreviousLane(const MSLane* current, int& furtherIndex) const;
 
 protected:
 

--- a/src/microsim/transportables/CMakeLists.txt
+++ b/src/microsim/transportables/CMakeLists.txt
@@ -31,6 +31,8 @@ set(microsim_transportables_STAT_SRCS
         MSTransportable.h
         MSTransportableControl.cpp
         MSTransportableControl.h
+        MSTrainHelper.cpp
+        MSTrainHelper.h
         ${microsim_transportables_JPS_SRCS}
         )
 

--- a/src/microsim/transportables/MSTrainHelper.cpp
+++ b/src/microsim/transportables/MSTrainHelper.cpp
@@ -1,0 +1,147 @@
+/****************************************************************************/
+// Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.dev/sumo
+// Copyright (C) 2001-2024 German Aerospace Center (DLR) and others.
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0/
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License 2.0 are satisfied: GNU General Public License, version 2
+// or later which is available at
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+/****************************************************************************/
+/// @file    MSTrainHelper.cpp
+/// @author  Benjamin Coueraud
+/// @date    Fri, 8 Feb 2024
+///
+// A class that helps computing positions of a train's carriages.
+/****************************************************************************/
+#include <config.h>
+
+#include <microsim/MSLane.h>
+#include <microsim/lcmodels/MSAbstractLaneChangeModel.h>
+#include <microsim/MSVehicle.h>
+#include "MSTrainHelper.h"
+
+// ===========================================================================
+// method definitions
+// ===========================================================================
+std::vector<PositionVector> 
+MSTrainHelper::getCarriageShapes(void) {
+    std::vector<PositionVector> carriageShapes;
+    for (const Carriage* carriage: myCarriages) {
+        Position direction = carriage->front - carriage->back;
+        Position perp = Position(-direction.y(), direction.x());
+        PositionVector shape;
+        shape.push_back(carriage->front + perp*myHalfWidth);
+        shape.push_back(carriage->front - perp*myHalfWidth); 
+        shape.push_back(carriage->back - perp*myHalfWidth); 
+        shape.push_back(carriage->back + perp*myHalfWidth);
+        carriageShapes.push_back(shape);
+    }
+    return carriageShapes;
+}
+
+
+void 
+MSTrainHelper::computeTrainDimensions(double exaggeration) {
+    const MSVehicleType& vtype = myTrain->getVehicleType();
+    const double totalLength = vtype.getLength();
+    myUpscaleLength = exaggeration;
+    if (exaggeration > 1 && totalLength > 5) {
+        // Reduce the length/width ratio because this is not useful at high zoom.
+        const double widthLengthFactor = totalLength / 5;
+        const double shrinkFactor = MIN2(widthLengthFactor, sqrt(myUpscaleLength));
+        myUpscaleLength /= shrinkFactor;
+    }
+    myLocomotiveLength = vtype.getParameter().locomotiveLength * myUpscaleLength;
+    myDefaultLength = vtype.getParameter().carriageLength * myUpscaleLength;
+    myCarriageGap = vtype.getParameter().carriageGap * myUpscaleLength;
+    myLength = totalLength * myUpscaleLength;
+    myHalfWidth = 0.5 * vtype.getWidth() * myUpscaleLength;
+    myNumCarriages = MAX2(1, 1 + (int)((myLength - myLocomotiveLength) / (myDefaultLength + myCarriageGap) + 0.5)); // Round to closest integer.
+    assert(myNumCarriages > 0);
+    myCarriageLengthWithGap = myLength / myNumCarriages;
+    myCarriageLength = myCarriageLengthWithGap - myCarriageGap;
+    myFirstCarriageLength = myCarriageLength;
+    if (myDefaultLength != myLocomotiveLength && myNumCarriages > 1) {
+        myFirstCarriageLength = myLocomotiveLength;
+        myCarriageLengthWithGap = (myLength - myLocomotiveLength) / (myNumCarriages - 1);
+        myCarriageLength = myCarriageLengthWithGap - myCarriageGap;
+    }
+}
+    
+
+void 
+MSTrainHelper::computeCarriages(bool secondaryShape, bool reversed) {
+    myCarriages.clear();
+
+    const MSLane* lane = myTrain->getLane(); // Lane on which the carriage's front is situated.
+    int furtherIndex = 0;
+    const MSLane* backLane = lane; // Lane on which the carriage's back is situated.
+    int backFurtherIndex = furtherIndex;
+    // Offsets of front and back parts of a carriage.
+    double carriageOffset = myTrain->getPositionOnLane();
+    if (myTrain->getLaneChangeModel().isOpposite()) {
+        // This still produces some artifacts when not fully on the current lane.
+        carriageOffset = MIN2(carriageOffset + myTrain->getLength(), lane->getLength());
+    }
+    double carriageBackOffset = carriageOffset - myFirstCarriageLength;
+
+    double curCLength = myFirstCarriageLength;
+    myFirstCarriageNo = 0;  // default case - we're going forwards
+    myIsReversed = (myTrain->isReversed() && reversed) || myTrain->getLaneChangeModel().isOpposite();
+    if (myIsReversed) {
+        myFirstCarriageNo = myNumCarriages - 1;
+        if (myNumCarriages > 1) {
+            carriageBackOffset = carriageOffset - myCarriageLength;
+        }
+    }
+
+    const double lateralOffset = (myTrain->isParking() && myTrain->getNextStopParameter()->posLat == INVALID_DOUBLE
+                                  ? (myTrain->getLane()->getWidth() * (MSGlobals::gLefthand ? -1 : 1))
+                                  : -myTrain->getLateralPositionOnLane());
+
+    for (int i = 0; i < myNumCarriages; ++i) {
+        Carriage* carriage = new Carriage();
+        if (i == myFirstCarriageNo) {
+            curCLength = myFirstCarriageLength;
+            if (myFirstCarriageNo > 0) {
+                // Previous loop iteration has adjusted backpos for a normal carriage so have to correct
+                carriageBackOffset += myCarriageLengthWithGap;
+                carriageBackOffset -= myFirstCarriageLength + myCarriageGap;
+            }
+        } else {
+            curCLength = myCarriageLength;
+        }
+        while (carriageOffset < 0) {
+            const MSLane* prev = myTrain->getPreviousLane(lane, furtherIndex);
+            if (prev != lane) {
+                carriageOffset += prev->getLength();
+            } else {
+                // No lane available.
+                carriageOffset = 0;
+            }
+            lane = prev;
+        }
+        while (carriageBackOffset < 0) {
+            const MSLane* prev = myTrain->getPreviousLane(backLane, backFurtherIndex);
+            if (prev != backLane) {
+                carriageBackOffset += prev->getLength();
+            } else {
+                // No lane available.
+                carriageBackOffset = 0;
+            }
+            backLane = prev;
+        }
+        
+        carriage->front = lane->getShape(secondaryShape).positionAtOffset(carriageOffset * lane->getLengthGeometryFactor(secondaryShape), lateralOffset);
+        carriage->back = backLane->getShape(secondaryShape).positionAtOffset(carriageBackOffset * lane->getLengthGeometryFactor(secondaryShape), lateralOffset);
+        // TODO: compute the doors.
+        myCarriages.push_back(carriage);
+
+        carriageOffset -= (curCLength + myCarriageGap);
+        carriageBackOffset -= myCarriageLengthWithGap;
+    }
+}

--- a/src/microsim/transportables/MSTrainHelper.h
+++ b/src/microsim/transportables/MSTrainHelper.h
@@ -1,0 +1,134 @@
+/****************************************************************************/
+// Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.dev/sumo
+// Copyright (C) 2014-2024 German Aerospace Center (DLR) and others.
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0/
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License 2.0 are satisfied: GNU General Public License, version 2
+// or later which is available at
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+/****************************************************************************/
+/// @file    MSTrainHelper.h
+/// @author  Benjamin Coueraud
+/// @date    Wed, 07 Fev 2024
+///
+// A class that helps computing positions of a train's carriages.
+/****************************************************************************/
+#pragma once
+#include <config.h>
+
+#include <utils/geom/Position.h>
+#include <utils/geom/PositionVector.h>
+
+
+// ===========================================================================
+// class declarations
+// ===========================================================================
+class MSVehicle;
+
+
+// ===========================================================================
+// class definitions
+// ===========================================================================
+/**
+ * @class MSTrainHelper
+ * @brief A class that helps computing positions of a train's carriages.
+ *
+ */
+class MSTrainHelper {
+public:
+    MSTrainHelper(const MSVehicle* vehicle, bool reversed, bool secondaryShape=false, double exaggeration=1.0) 
+        : myTrain(vehicle) {
+        computeTrainDimensions(exaggeration);
+        computeCarriages(secondaryShape, reversed);
+    }
+
+    ~MSTrainHelper() {
+        for (const Carriage* carriage: myCarriages) {
+            delete carriage;
+        }
+    }
+
+    inline double getUpscaleLength(void) const {
+        return myUpscaleLength;
+    }
+
+    inline double getLocomotiveLength(void) const {
+        return myLocomotiveLength;
+    } 
+
+    inline double getDefaultLength(void) const {
+        return myDefaultLength;
+    }
+
+    inline double getCarriageGap(void) const {
+        return myCarriageGap;
+    }
+
+    inline double getLength(void) const {
+        return myLength;
+    }
+
+    inline double getHalfWidth(void) const {
+        return myHalfWidth;
+    }
+
+    inline int getNumCarriages(void) const {
+        return myNumCarriages;
+    }
+
+    inline double getCarriageLengthWithGap(void) const {
+        return myCarriageLengthWithGap;
+    }
+
+    inline double getCarriageLength(void) const {
+        return myCarriageLength;
+    }
+
+    inline double getFirstCarriageLength(void) const {
+        return myFirstCarriageLength;
+    }
+
+    inline int getFirstCarriageNo(void) const {
+        return myFirstCarriageNo;
+    }
+    
+    inline bool isReversed(void) const {
+        return myIsReversed;
+    }
+
+    struct Carriage {
+        Position front;
+        Position back;
+        std::vector<Position> doors;
+    };
+
+    inline std::vector<Carriage*> getCarriages(void) const {
+        return myCarriages;
+    }
+
+    // Compute the rectangles from the front and back positions.
+    std::vector<PositionVector> getCarriageShapes(void);
+
+private:
+    const MSVehicle* myTrain;
+    double myUpscaleLength;
+    double myLocomotiveLength;
+    double myDefaultLength;
+    double myCarriageGap;
+    double myLength;
+    double myHalfWidth;
+    int myNumCarriages;
+    double myCarriageLengthWithGap;
+    double myCarriageLength;
+    double myFirstCarriageLength;
+    int myFirstCarriageNo;
+    bool myIsReversed;
+    std::vector<Carriage*> myCarriages;
+
+    void computeTrainDimensions(double exaggeration);
+    void computeCarriages(bool secondaryShape, bool reversed);
+};


### PR DESCRIPTION
Besides being used for the drawing of trains, the train helper will be used for doors computations, dynamic geometry and train ramps, which are all related to JuPedSim integration.