### PR TITLE
Plexe: Improved whole-platoon lane change procedure

### DIFF
--- a/src/microsim/cfmodels/CC_Const.h
+++ b/src/microsim/cfmodels/CC_Const.h
@@ -182,4 +182,7 @@ struct VEHICLE_DATA {
 // let the leader automatically change lane for the whole platoon if there is a speed advantage
 #define PAR_ENABLE_AUTO_LANE_CHANGE      "ccalc"
 
+// perform a lane change for a whole platoon
+#define PAR_PLATOON_FIXED_LANE           "ccpfl"
+
 }

--- a/src/microsim/cfmodels/CC_VehicleVariables.cpp
+++ b/src/microsim/cfmodels/CC_VehicleVariables.cpp
@@ -62,7 +62,8 @@ CC_VehicleVariables::CC_VehicleVariables() :
     flatbedKa(2.4), flatbedKv(0.6), flatbedKp(12), flatbedD(5), flatbedH(4),
     engine(0), engineModel(CC_ENGINE_MODEL_FOLM),
     usePrediction(false),
-    autoLaneChange(false) {
+    autoLaneChange(false),
+    platoonFixedLane(-1) {
     fakeData.frontAcceleration = 0;
     fakeData.frontControllerAcceleration = 0;
     fakeData.frontDistance = 0;

--- a/src/microsim/cfmodels/CC_VehicleVariables.h
+++ b/src/microsim/cfmodels/CC_VehicleVariables.h
@@ -203,4 +203,7 @@ public:
 
     /// @brief automatic whole platoon lane change
     bool autoLaneChange;
+
+    /// @brief whole platoon lane change (not automatic). -1 indicates no need to change lane (mechanism disabled)
+    int platoonFixedLane;
 };

--- a/src/microsim/cfmodels/MSCFModel_CC.h
+++ b/src/microsim/cfmodels/MSCFModel_CC.h
@@ -268,7 +268,10 @@ private:
     void resetConsensus(const MSVehicle* veh) const;
 
 private:
+    bool isPlatoonLaneChangeSafe(MSVehicle* const veh, bool left) const;
+    void changeWholePlatoonLane(MSVehicle* const veh, int direction) const;
     void performAutoLaneChange(MSVehicle* const veh) const;
+    void performPlatoonLaneChange(MSVehicle* const veh) const;
 
     double _v(const MSVehicle* const veh, double gap2pred, double egoSpeed, double predSpeed) const;
 


### PR DESCRIPTION
This pull request improves the lane change behavior of a whole platoon, which was known to cause collisions in some specific cases. In the updated code, the leader checks for lane change safety conditions by invoking the `getNeighbors()` method with the safety bit enabled. Only if all members agree on lane change safety the maneuver is performed.

In addition, a new API to safely move the platoon to a specific lane upon user request has been implemented.