### PR TITLE
Increased lookahead distance to find leader in gap controller

### DIFF
--- a/src/microsim/MSVehicle.cpp
+++ b/src/microsim/MSVehicle.cpp
@@ -527,7 +527,13 @@ MSVehicle::Influencer::gapControlSpeed(SUMOTime currentTime, const SUMOVehicle* 
         std::pair<const MSVehicle*, double> leaderInfo;
         if (myGapControlState->referenceVeh == nullptr) {
             // No reference vehicle specified -> use current leader as reference
-            leaderInfo = msVeh->getLeader(MAX2(desiredTargetTimeSpacing, myGapControlState->addGapCurrent)  + 20.);
+            const double brakeGap = msVeh->getBrakeGap(currentSpeed);
+            leaderInfo = msVeh->getLeader(MAX2(desiredTargetTimeSpacing, myGapControlState->addGapCurrent)  + MAX2(brakeGap, 20.0));
+#ifdef DEBUG_TRACI
+            if DEBUG_COND2(veh) {
+                std::cout <<  "  ---   no refVeh; myGapControlState->addGapCurrent: " << myGapControlState->addGapCurrent << ", brakeGap: " << brakeGap << " in simstep: " << SIMSTEP << std::endl;
+            }
+#endif            
         } else {
             // Control gap wrt reference vehicle
             const MSVehicle* leader = myGapControlState->referenceVeh;

--- a/tests/complex/traci/vehicle/openGap/testsuite.complex
+++ b/tests/complex/traci/vehicle/openGap/testsuite.complex
@@ -28,6 +28,9 @@ braking_leader_spaceGap
 # No maxDecel given, low changeRate, only space gap specified
 without_maxDecel_slow_spacegap
 
+# No maxDecel given, low changeRate, only space gap specified. ACC model increases gap differently than Krauss, but it holds up qualitatively. (lower stepLength for ACC in this test)
+without_maxDecel_slow_spacegap_ACC
+
 # Giving a smaller time headway than the original should trigger a warning
 warning_smaller_headway
 

--- a/tests/complex/traci/vehicle/openGap/without_maxDecel_slow_spacegap_ACC/input_routes.rou.xml
+++ b/tests/complex/traci/vehicle/openGap/without_maxDecel_slow_spacegap_ACC/input_routes.rou.xml
@@ -1,0 +1,8 @@
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <vType id="fast" speedFactor="1.1" sigma="0"/>
+    <vType id="slow" speedFactor="1.0" sigma="0"/>
+    <vType id="automated" speedFactor="1.1" accel="1.362" actionStepLength="0.100" carFollowModel="ACC" color="white" lcAssertive="0.668" tau="1.649"/>
+    
+    <vehicle id="leader" type="slow" route="circle" depart="0" departPos="30" departLane="0" departSpeed="max" />
+    <vehicle id="follower" type="automated" route="circle" depart="0" departPos="20" departLane="0" departSpeed="max" />
+</routes>

--- a/tests/complex/traci/vehicle/openGap/without_maxDecel_slow_spacegap_ACC/options.complex
+++ b/tests/complex/traci/vehicle/openGap/without_maxDecel_slow_spacegap_ACC/options.complex
@@ -1,0 +1,1 @@
+sumo -1 250 10 0.01 tests/complex/traci/vehicle/openGap/runner.py

--- a/tests/complex/traci/vehicle/openGap/without_maxDecel_slow_spacegap_ACC/output.complex
+++ b/tests/complex/traci/vehicle/openGap/without_maxDecel_slow_spacegap_ACC/output.complex
@@ -1,0 +1,5575 @@
+ Retrying in 1 seconds
+Fix follower's lane.
+Subscribe to leader.
+Time 0.2: Gap 'follower'->'leader' = 4.138 (headway=1.287)
+'follower' speed = 3.214132791384923
+Time 0.3: Gap 'follower'->'leader' = 5.771 (headway=1.729)
+'follower' speed = 3.338052512388828
+Time 0.4: Gap 'follower'->'leader' = 7.390 (headway=2.127)
+'follower' speed = 3.474252512388828
+Time 0.5: Gap 'follower'->'leader' = 8.996 (headway=2.492)
+'follower' speed = 3.6104525123888283
+Time 0.6: Gap 'follower'->'leader' = 10.588 (headway=2.826)
+'follower' speed = 3.7466525123888283
+Time 0.7: Gap 'follower'->'leader' = 12.166 (headway=3.133)
+'follower' speed = 3.8828525123888284
+Time 0.8: Gap 'follower'->'leader' = 13.731 (headway=3.417)
+'follower' speed = 4.0190525123888285
+Time 0.9: Gap 'follower'->'leader' = 15.283 (headway=3.678)
+'follower' speed = 4.155252512388828
+Time 1.0: Gap 'follower'->'leader' = 16.820 (headway=3.919)
+'follower' speed = 4.291452512388828
+Time 1.1: Gap 'follower'->'leader' = 18.344 (headway=4.143)
+'follower' speed = 4.4276525123888275
+Time 1.2: Gap 'follower'->'leader' = 19.855 (headway=4.350)
+'follower' speed = 4.563852512388827
+Time 1.3: Gap 'follower'->'leader' = 21.352 (headway=4.543)
+'follower' speed = 4.700052512388827
+Time 1.4: Gap 'follower'->'leader' = 22.835 (headway=4.722)
+'follower' speed = 4.8362525123888265
+Time 1.5: Gap 'follower'->'leader' = 24.304 (headway=4.888)
+'follower' speed = 4.972452512388826
+Time 1.6: Gap 'follower'->'leader' = 25.760 (headway=5.042)
+'follower' speed = 5.108652512388826
+Time 1.7: Gap 'follower'->'leader' = 27.203 (headway=5.187)
+'follower' speed = 5.244852512388825
+Time 1.8: Gap 'follower'->'leader' = 28.631 (headway=5.321)
+'follower' speed = 5.381052512388825
+Time 1.9: Gap 'follower'->'leader' = 30.046 (headway=5.446)
+'follower' speed = 5.517252512388825
+Time 2.0: Gap 'follower'->'leader' = 31.448 (headway=5.563)
+'follower' speed = 5.653452512388824
+Time 2.1: Gap 'follower'->'leader' = 32.836 (headway=5.671)
+'follower' speed = 5.789652512388824
+Time 2.2: Gap 'follower'->'leader' = 34.210 (headway=5.773)
+'follower' speed = 5.925852512388824
+Time 2.3: Gap 'follower'->'leader' = 35.570 (headway=5.868)
+'follower' speed = 6.062052512388823
+Time 2.4: Gap 'follower'->'leader' = 36.917 (headway=5.956)
+'follower' speed = 6.198252512388823
+Time 2.5: Gap 'follower'->'leader' = 38.251 (headway=6.039)
+'follower' speed = 6.334452512388823
+Time 2.6: Gap 'follower'->'leader' = 39.571 (headway=6.115)
+'follower' speed = 6.470652512388822
+Time 2.7: Gap 'follower'->'leader' = 40.877 (headway=6.187)
+'follower' speed = 6.606852512388822
+Time 2.8: Gap 'follower'->'leader' = 42.169 (headway=6.254)
+'follower' speed = 6.743052512388822
+Time 2.9: Gap 'follower'->'leader' = 43.448 (headway=6.316)
+'follower' speed = 6.879252512388821
+Time 3.0: Gap 'follower'->'leader' = 44.713 (headway=6.374)
+'follower' speed = 7.015452512388821
+Time 3.1: Gap 'follower'->'leader' = 45.965 (headway=6.427)
+'follower' speed = 7.151652512388821
+Time 3.2: Gap 'follower'->'leader' = 47.203 (headway=6.477)
+'follower' speed = 7.28785251238882
+Time 3.3: Gap 'follower'->'leader' = 48.427 (headway=6.523)
+'follower' speed = 7.42405251238882
+Time 3.4: Gap 'follower'->'leader' = 49.638 (headway=6.566)
+'follower' speed = 7.56025251238882
+Time 3.5: Gap 'follower'->'leader' = 50.835 (headway=6.605)
+'follower' speed = 7.696452512388819
+Time 3.6: Gap 'follower'->'leader' = 52.019 (headway=6.641)
+'follower' speed = 7.832652512388819
+Time 3.7: Gap 'follower'->'leader' = 53.189 (headway=6.675)
+'follower' speed = 7.9688525123888185
+Time 3.8: Gap 'follower'->'leader' = 54.345 (headway=6.705)
+'follower' speed = 8.105052512388818
+Time 3.9: Gap 'follower'->'leader' = 55.488 (headway=6.733)
+'follower' speed = 8.241252512388819
+Time 4.0: Gap 'follower'->'leader' = 56.617 (headway=6.758)
+'follower' speed = 8.37745251238882
+Time 4.1: Gap 'follower'->'leader' = 57.732 (headway=6.781)
+'follower' speed = 8.51365251238882
+Time 4.2: Gap 'follower'->'leader' = 58.834 (headway=6.802)
+'follower' speed = 8.64985251238882
+Time 4.3: Gap 'follower'->'leader' = 59.922 (headway=6.820)
+'follower' speed = 8.786052512388821
+Time 4.4: Gap 'follower'->'leader' = 60.997 (headway=6.836)
+'follower' speed = 8.922252512388821
+Time 4.5: Gap 'follower'->'leader' = 62.058 (headway=6.851)
+'follower' speed = 9.058452512388822
+Time 4.6: Gap 'follower'->'leader' = 63.105 (headway=6.863)
+'follower' speed = 9.194652512388823
+Time 4.7: Gap 'follower'->'leader' = 64.139 (headway=6.874)
+'follower' speed = 9.330852512388823
+Time 4.8: Gap 'follower'->'leader' = 65.159 (headway=6.883)
+'follower' speed = 9.467052512388824
+Time 4.9: Gap 'follower'->'leader' = 66.166 (headway=6.890)
+'follower' speed = 9.603252512388824
+Time 5.0: Gap 'follower'->'leader' = 67.158 (headway=6.896)
+'follower' speed = 9.739452512388825
+Time 5.1: Gap 'follower'->'leader' = 68.138 (headway=6.900)
+'follower' speed = 9.875652512388825
+Time 5.2: Gap 'follower'->'leader' = 69.103 (headway=6.902)
+'follower' speed = 10.011852512388826
+Time 5.3: Gap 'follower'->'leader' = 70.055 (headway=6.903)
+'follower' speed = 10.148052512388826
+Time 5.4: Gap 'follower'->'leader' = 70.994 (headway=6.903)
+'follower' speed = 10.284252512388827
+Time 5.5: Gap 'follower'->'leader' = 71.918 (headway=6.902)
+'follower' speed = 10.420452512388827
+Time 5.6: Gap 'follower'->'leader' = 72.830 (headway=6.899)
+'follower' speed = 10.556652512388828
+Time 5.7: Gap 'follower'->'leader' = 73.727 (headway=6.895)
+'follower' speed = 10.692852512388829
+Time 5.8: Gap 'follower'->'leader' = 74.611 (headway=6.890)
+'follower' speed = 10.829052512388829
+Time 5.9: Gap 'follower'->'leader' = 75.481 (headway=6.884)
+'follower' speed = 10.96525251238883
+Time 6.0: Gap 'follower'->'leader' = 76.338 (headway=6.876)
+'follower' speed = 11.10145251238883
+Time 6.1: Gap 'follower'->'leader' = 77.181 (headway=6.868)
+'follower' speed = 11.23765251238883
+Time 6.2: Gap 'follower'->'leader' = 78.010 (headway=6.859)
+'follower' speed = 11.373852512388831
+Time 6.3: Gap 'follower'->'leader' = 78.826 (headway=6.848)
+'follower' speed = 11.510052512388832
+Time 6.4: Gap 'follower'->'leader' = 79.628 (headway=6.837)
+'follower' speed = 11.646252512388832
+Time 6.5: Gap 'follower'->'leader' = 80.417 (headway=6.825)
+'follower' speed = 11.782452512388833
+Time 6.6: Gap 'follower'->'leader' = 81.192 (headway=6.812)
+'follower' speed = 11.918652512388833
+Time 6.7: Gap 'follower'->'leader' = 81.953 (headway=6.798)
+'follower' speed = 12.054852512388834
+Time 6.8: Gap 'follower'->'leader' = 82.701 (headway=6.784)
+'follower' speed = 12.191052512388834
+Time 6.9: Gap 'follower'->'leader' = 83.435 (headway=6.768)
+'follower' speed = 12.327252512388835
+Time 7.0: Gap 'follower'->'leader' = 84.156 (headway=6.752)
+'follower' speed = 12.463452512388836
+Time 7.1: Gap 'follower'->'leader' = 84.862 (headway=6.735)
+'follower' speed = 12.599652512388836
+Time 7.2: Gap 'follower'->'leader' = 85.556 (headway=6.718)
+'follower' speed = 12.735852512388837
+Time 7.3: Gap 'follower'->'leader' = 86.235 (headway=6.699)
+'follower' speed = 12.872052512388837
+Time 7.4: Gap 'follower'->'leader' = 86.901 (headway=6.680)
+'follower' speed = 13.008252512388838
+Time 7.5: Gap 'follower'->'leader' = 87.554 (headway=6.661)
+'follower' speed = 13.144452512388838
+Time 7.6: Gap 'follower'->'leader' = 88.192 (headway=6.641)
+'follower' speed = 13.280652512388839
+Time 7.7: Gap 'follower'->'leader' = 88.817 (headway=6.620)
+'follower' speed = 13.41685251238884
+Time 7.8: Gap 'follower'->'leader' = 89.429 (headway=6.598)
+'follower' speed = 13.55305251238884
+Time 7.9: Gap 'follower'->'leader' = 90.027 (headway=6.576)
+'follower' speed = 13.68925251238884
+Time 8.0: Gap 'follower'->'leader' = 90.611 (headway=6.554)
+'follower' speed = 13.825452512388841
+Time 8.1: Gap 'follower'->'leader' = 91.182 (headway=6.531)
+'follower' speed = 13.961652512388842
+Time 8.2: Gap 'follower'->'leader' = 91.739 (headway=6.507)
+'follower' speed = 14.097852512388842
+Time 8.3: Gap 'follower'->'leader' = 92.282 (headway=6.483)
+'follower' speed = 14.234052512388843
+Time 8.4: Gap 'follower'->'leader' = 92.812 (headway=6.459)
+'follower' speed = 14.370252512388843
+Time 8.5: Gap 'follower'->'leader' = 93.328 (headway=6.434)
+'follower' speed = 14.506452512388844
+Time 8.6: Gap 'follower'->'leader' = 93.831 (headway=6.408)
+'follower' speed = 14.642652512388844
+Time 8.7: Gap 'follower'->'leader' = 94.320 (headway=6.382)
+'follower' speed = 14.778852512388845
+Time 8.8: Gap 'follower'->'leader' = 94.795 (headway=6.356)
+'follower' speed = 14.915052512388845
+Time 8.9: Gap 'follower'->'leader' = 95.257 (headway=6.329)
+'follower' speed = 15.051252512388846
+Time 9.0: Gap 'follower'->'leader' = 95.705 (headway=6.302)
+'follower' speed = 15.187452512388846
+Time 9.1: Gap 'follower'->'leader' = 96.139 (headway=6.274)
+'follower' speed = 15.323652512388847
+Time 9.2: Gap 'follower'->'leader' = 96.560 (headway=6.246)
+'follower' speed = 15.459852512388848
+Time 9.3: Gap 'follower'->'leader' = 96.967 (headway=6.217)
+'follower' speed = 15.596052512388848
+Time 9.4: Gap 'follower'->'leader' = 97.361 (headway=6.189)
+'follower' speed = 15.732252512388849
+Time 9.5: Gap 'follower'->'leader' = 97.741 (headway=6.159)
+'follower' speed = 15.86845251238885
+Time 9.6: Gap 'follower'->'leader' = 98.107 (headway=6.130)
+'follower' speed = 16.004652512388848
+Time 9.7: Gap 'follower'->'leader' = 98.460 (headway=6.100)
+'follower' speed = 16.140852512388847
+Time 9.8: Gap 'follower'->'leader' = 98.799 (headway=6.070)
+'follower' speed = 16.277052512388845
+Time 9.9: Gap 'follower'->'leader' = 99.124 (headway=6.039)
+'follower' speed = 16.413252512388844
+Time 10.0: Gap 'follower'->'leader' = 99.436 (headway=6.008)
+'follower' speed = 16.549452512388843
+Time 10.1: Gap 'follower'->'leader' = 99.734 (headway=5.977)
+'follower' speed = 16.68565251238884
+Time 10.2: Gap 'follower'->'leader' = 100.019 (headway=5.946)
+'follower' speed = 16.82185251238884
+Time 10.3: Gap 'follower'->'leader' = 100.290 (headway=5.914)
+'follower' speed = 16.95805251238884
+Time 10.4: Gap 'follower'->'leader' = 100.547 (headway=5.882)
+'follower' speed = 17.094252512388838
+Time 10.5: Gap 'follower'->'leader' = 100.791 (headway=5.850)
+'follower' speed = 17.230452512388837
+Time 10.6: Gap 'follower'->'leader' = 101.021 (headway=5.817)
+'follower' speed = 17.366652512388836
+Time 10.7: Gap 'follower'->'leader' = 101.238 (headway=5.784)
+'follower' speed = 17.502852512388834
+Time 10.8: Gap 'follower'->'leader' = 101.441 (headway=5.751)
+'follower' speed = 17.639052512388833
+Time 10.9: Gap 'follower'->'leader' = 101.630 (headway=5.718)
+'follower' speed = 17.775252512388832
+Time 11.0: Gap 'follower'->'leader' = 101.806 (headway=5.684)
+'follower' speed = 17.91145251238883
+Time 11.1: Gap 'follower'->'leader' = 101.968 (headway=5.650)
+'follower' speed = 18.04765251238883
+Time 11.2: Gap 'follower'->'leader' = 102.116 (headway=5.616)
+'follower' speed = 18.183852512388828
+Time 11.3: Gap 'follower'->'leader' = 102.251 (headway=5.581)
+'follower' speed = 18.320052512388827
+Time 11.4: Gap 'follower'->'leader' = 102.372 (headway=5.547)
+'follower' speed = 18.456252512388826
+Time 11.5: Gap 'follower'->'leader' = 102.480 (headway=5.512)
+'follower' speed = 18.592452512388824
+Time 11.6: Gap 'follower'->'leader' = 102.574 (headway=5.477)
+'follower' speed = 18.728652512388823
+Time 11.7: Gap 'follower'->'leader' = 102.654 (headway=5.442)
+'follower' speed = 18.864852512388822
+Time 11.8: Gap 'follower'->'leader' = 102.721 (headway=5.406)
+'follower' speed = 19.00105251238882
+Time 11.9: Gap 'follower'->'leader' = 102.774 (headway=5.370)
+'follower' speed = 19.13725251238882
+Time 12.0: Gap 'follower'->'leader' = 102.813 (headway=5.334)
+'follower' speed = 19.27345251238882
+Time 12.1: Gap 'follower'->'leader' = 102.839 (headway=5.298)
+'follower' speed = 19.409652512388817
+Time 12.2: Gap 'follower'->'leader' = 102.851 (headway=5.262)
+'follower' speed = 19.545852512388816
+Time 12.3: Gap 'follower'->'leader' = 102.850 (headway=5.226)
+'follower' speed = 19.682052512388815
+Time 12.4: Gap 'follower'->'leader' = 102.835 (headway=5.189)
+'follower' speed = 19.818252512388813
+Time 12.5: Gap 'follower'->'leader' = 102.806 (headway=5.152)
+'follower' speed = 19.954452512388812
+Time 12.6: Gap 'follower'->'leader' = 102.764 (headway=5.115)
+'follower' speed = 20.09065251238881
+Time 12.7: Gap 'follower'->'leader' = 102.708 (headway=5.078)
+'follower' speed = 20.22685251238881
+Time 12.8: Gap 'follower'->'leader' = 102.639 (headway=5.040)
+'follower' speed = 20.36305251238881
+Time 12.9: Gap 'follower'->'leader' = 102.556 (headway=5.003)
+'follower' speed = 20.499252512388807
+Time 13.0: Gap 'follower'->'leader' = 102.459 (headway=4.965)
+'follower' speed = 20.635452512388806
+Time 13.1: Gap 'follower'->'leader' = 102.348 (headway=4.927)
+'follower' speed = 20.771652512388805
+Time 13.2: Gap 'follower'->'leader' = 102.224 (headway=4.889)
+'follower' speed = 20.907852512388803
+Time 13.3: Gap 'follower'->'leader' = 102.087 (headway=4.851)
+'follower' speed = 21.044052512388802
+Time 13.4: Gap 'follower'->'leader' = 101.936 (headway=4.813)
+'follower' speed = 21.1802525123888
+Time 13.5: Gap 'follower'->'leader' = 101.771 (headway=4.774)
+'follower' speed = 21.3164525123888
+Time 13.6: Gap 'follower'->'leader' = 101.593 (headway=4.737)
+'follower' speed = 21.445616279563357
+Time 13.7: Gap 'follower'->'leader' = 101.402 (headway=4.703)
+'follower' speed = 21.560000000000002
+Time 13.8: Gap 'follower'->'leader' = 101.206 (headway=4.694)
+'follower' speed = 21.560000000000002
+Time 13.9: Gap 'follower'->'leader' = 101.010 (headway=4.685)
+'follower' speed = 21.560000000000002
+Time 14.0: Gap 'follower'->'leader' = 100.814 (headway=4.676)
+'follower' speed = 21.560000000000002
+Time 14.1: Gap 'follower'->'leader' = 100.618 (headway=4.667)
+'follower' speed = 21.560000000000002
+Time 14.2: Gap 'follower'->'leader' = 100.422 (headway=4.658)
+'follower' speed = 21.560000000000002
+Time 14.3: Gap 'follower'->'leader' = 100.226 (headway=4.649)
+'follower' speed = 21.560000000000002
+Time 14.4: Gap 'follower'->'leader' = 100.030 (headway=4.640)
+'follower' speed = 21.560000000000002
+Time 14.5: Gap 'follower'->'leader' = 99.834 (headway=4.631)
+'follower' speed = 21.560000000000002
+Time 14.6: Gap 'follower'->'leader' = 99.638 (headway=4.621)
+'follower' speed = 21.560000000000002
+Time 14.7: Gap 'follower'->'leader' = 99.442 (headway=4.612)
+'follower' speed = 21.560000000000002
+Time 14.8: Gap 'follower'->'leader' = 99.246 (headway=4.603)
+'follower' speed = 21.560000000000002
+Time 14.9: Gap 'follower'->'leader' = 99.050 (headway=4.594)
+'follower' speed = 21.560000000000002
+Time 15.0: Gap 'follower'->'leader' = 98.854 (headway=4.585)
+'follower' speed = 21.560000000000002
+Time 15.1: Gap 'follower'->'leader' = 98.658 (headway=4.576)
+'follower' speed = 21.560000000000002
+Time 15.2: Gap 'follower'->'leader' = 98.462 (headway=4.567)
+'follower' speed = 21.560000000000002
+Time 15.3: Gap 'follower'->'leader' = 98.266 (headway=4.558)
+'follower' speed = 21.560000000000002
+Time 15.4: Gap 'follower'->'leader' = 98.070 (headway=4.549)
+'follower' speed = 21.560000000000002
+Time 15.5: Gap 'follower'->'leader' = 97.874 (headway=4.540)
+'follower' speed = 21.560000000000002
+Time 15.6: Gap 'follower'->'leader' = 97.678 (headway=4.531)
+'follower' speed = 21.560000000000002
+Time 15.7: Gap 'follower'->'leader' = 97.482 (headway=4.521)
+'follower' speed = 21.560000000000002
+Time 15.8: Gap 'follower'->'leader' = 97.286 (headway=4.512)
+'follower' speed = 21.560000000000002
+Time 15.9: Gap 'follower'->'leader' = 97.090 (headway=4.503)
+'follower' speed = 21.560000000000002
+Time 16.0: Gap 'follower'->'leader' = 96.894 (headway=4.494)
+'follower' speed = 21.560000000000002
+Time 16.1: Gap 'follower'->'leader' = 96.698 (headway=4.485)
+'follower' speed = 21.560000000000002
+Time 16.2: Gap 'follower'->'leader' = 96.502 (headway=4.476)
+'follower' speed = 21.560000000000002
+Time 16.3: Gap 'follower'->'leader' = 96.306 (headway=4.467)
+'follower' speed = 21.560000000000002
+Time 16.4: Gap 'follower'->'leader' = 96.110 (headway=4.458)
+'follower' speed = 21.560000000000002
+Time 16.5: Gap 'follower'->'leader' = 95.914 (headway=4.449)
+'follower' speed = 21.560000000000002
+Time 16.6: Gap 'follower'->'leader' = 95.718 (headway=4.440)
+'follower' speed = 21.560000000000002
+Time 16.7: Gap 'follower'->'leader' = 95.522 (headway=4.431)
+'follower' speed = 21.560000000000002
+Time 16.8: Gap 'follower'->'leader' = 95.326 (headway=4.421)
+'follower' speed = 21.560000000000002
+Time 16.9: Gap 'follower'->'leader' = 95.130 (headway=4.412)
+'follower' speed = 21.560000000000002
+Time 17.0: Gap 'follower'->'leader' = 94.934 (headway=4.403)
+'follower' speed = 21.560000000000002
+Time 17.1: Gap 'follower'->'leader' = 94.738 (headway=4.394)
+'follower' speed = 21.560000000000002
+Time 17.2: Gap 'follower'->'leader' = 94.542 (headway=4.385)
+'follower' speed = 21.560000000000002
+Time 17.3: Gap 'follower'->'leader' = 94.346 (headway=4.376)
+'follower' speed = 21.560000000000002
+Time 17.4: Gap 'follower'->'leader' = 94.150 (headway=4.367)
+'follower' speed = 21.560000000000002
+Time 17.5: Gap 'follower'->'leader' = 93.954 (headway=4.358)
+'follower' speed = 21.560000000000002
+Time 17.6: Gap 'follower'->'leader' = 93.758 (headway=4.349)
+'follower' speed = 21.560000000000002
+Time 17.7: Gap 'follower'->'leader' = 93.562 (headway=4.340)
+'follower' speed = 21.560000000000002
+Time 17.8: Gap 'follower'->'leader' = 93.366 (headway=4.331)
+'follower' speed = 21.560000000000002
+Time 17.9: Gap 'follower'->'leader' = 93.170 (headway=4.321)
+'follower' speed = 21.560000000000002
+Time 18.0: Gap 'follower'->'leader' = 92.974 (headway=4.312)
+'follower' speed = 21.560000000000002
+Time 18.1: Gap 'follower'->'leader' = 92.778 (headway=4.303)
+'follower' speed = 21.560000000000002
+Time 18.2: Gap 'follower'->'leader' = 92.582 (headway=4.294)
+'follower' speed = 21.560000000000002
+Time 18.3: Gap 'follower'->'leader' = 92.386 (headway=4.285)
+'follower' speed = 21.560000000000002
+Time 18.4: Gap 'follower'->'leader' = 92.190 (headway=4.276)
+'follower' speed = 21.560000000000002
+Time 18.5: Gap 'follower'->'leader' = 91.994 (headway=4.267)
+'follower' speed = 21.560000000000002
+Time 18.6: Gap 'follower'->'leader' = 91.798 (headway=4.258)
+'follower' speed = 21.560000000000002
+Time 18.7: Gap 'follower'->'leader' = 91.602 (headway=4.249)
+'follower' speed = 21.560000000000002
+Time 18.8: Gap 'follower'->'leader' = 91.406 (headway=4.240)
+'follower' speed = 21.560000000000002
+Time 18.9: Gap 'follower'->'leader' = 91.210 (headway=4.231)
+'follower' speed = 21.560000000000002
+Time 19.0: Gap 'follower'->'leader' = 91.014 (headway=4.221)
+'follower' speed = 21.560000000000002
+Time 19.1: Gap 'follower'->'leader' = 90.818 (headway=4.212)
+'follower' speed = 21.560000000000002
+Time 19.2: Gap 'follower'->'leader' = 90.622 (headway=4.203)
+'follower' speed = 21.560000000000002
+Time 19.3: Gap 'follower'->'leader' = 90.426 (headway=4.194)
+'follower' speed = 21.560000000000002
+Time 19.4: Gap 'follower'->'leader' = 90.230 (headway=4.185)
+'follower' speed = 21.560000000000002
+Time 19.5: Gap 'follower'->'leader' = 90.034 (headway=4.176)
+'follower' speed = 21.560000000000002
+Time 19.6: Gap 'follower'->'leader' = 89.838 (headway=4.167)
+'follower' speed = 21.560000000000002
+Time 19.7: Gap 'follower'->'leader' = 89.642 (headway=4.158)
+'follower' speed = 21.560000000000002
+Time 19.8: Gap 'follower'->'leader' = 89.446 (headway=4.149)
+'follower' speed = 21.560000000000002
+Time 19.9: Gap 'follower'->'leader' = 89.250 (headway=4.140)
+'follower' speed = 21.560000000000002
+Time 20.0: Gap 'follower'->'leader' = 89.054 (headway=4.131)
+'follower' speed = 21.560000000000002
+Time 20.1: Gap 'follower'->'leader' = 88.858 (headway=4.121)
+'follower' speed = 21.560000000000002
+Time 20.2: Gap 'follower'->'leader' = 88.662 (headway=4.112)
+'follower' speed = 21.560000000000002
+Time 20.3: Gap 'follower'->'leader' = 88.466 (headway=4.103)
+'follower' speed = 21.560000000000002
+Time 20.4: Gap 'follower'->'leader' = 88.270 (headway=4.094)
+'follower' speed = 21.560000000000002
+Time 20.5: Gap 'follower'->'leader' = 88.074 (headway=4.085)
+'follower' speed = 21.560000000000002
+Time 20.6: Gap 'follower'->'leader' = 87.878 (headway=4.076)
+'follower' speed = 21.560000000000002
+Time 20.7: Gap 'follower'->'leader' = 87.682 (headway=4.067)
+'follower' speed = 21.560000000000002
+Time 20.8: Gap 'follower'->'leader' = 87.486 (headway=4.058)
+'follower' speed = 21.560000000000002
+Time 20.9: Gap 'follower'->'leader' = 87.290 (headway=4.049)
+'follower' speed = 21.560000000000002
+Time 21.0: Gap 'follower'->'leader' = 87.094 (headway=4.040)
+'follower' speed = 21.560000000000002
+Time 21.1: Gap 'follower'->'leader' = 86.898 (headway=4.031)
+'follower' speed = 21.560000000000002
+Time 21.2: Gap 'follower'->'leader' = 86.702 (headway=4.021)
+'follower' speed = 21.560000000000002
+Time 21.3: Gap 'follower'->'leader' = 86.506 (headway=4.012)
+'follower' speed = 21.560000000000002
+Time 21.4: Gap 'follower'->'leader' = 86.310 (headway=4.003)
+'follower' speed = 21.560000000000002
+Time 21.5: Gap 'follower'->'leader' = 86.114 (headway=3.994)
+'follower' speed = 21.560000000000002
+Time 21.6: Gap 'follower'->'leader' = 85.918 (headway=3.985)
+'follower' speed = 21.560000000000002
+Time 21.7: Gap 'follower'->'leader' = 85.722 (headway=3.976)
+'follower' speed = 21.560000000000002
+Time 21.8: Gap 'follower'->'leader' = 85.526 (headway=3.967)
+'follower' speed = 21.560000000000002
+Time 21.9: Gap 'follower'->'leader' = 85.330 (headway=3.958)
+'follower' speed = 21.560000000000002
+Time 22.0: Gap 'follower'->'leader' = 85.134 (headway=3.949)
+'follower' speed = 21.560000000000002
+Time 22.1: Gap 'follower'->'leader' = 84.938 (headway=3.940)
+'follower' speed = 21.560000000000002
+Time 22.2: Gap 'follower'->'leader' = 84.742 (headway=3.931)
+'follower' speed = 21.560000000000002
+Time 22.3: Gap 'follower'->'leader' = 84.546 (headway=3.921)
+'follower' speed = 21.560000000000002
+Time 22.4: Gap 'follower'->'leader' = 84.350 (headway=3.912)
+'follower' speed = 21.560000000000002
+Time 22.5: Gap 'follower'->'leader' = 84.154 (headway=3.903)
+'follower' speed = 21.560000000000002
+Time 22.6: Gap 'follower'->'leader' = 83.958 (headway=3.894)
+'follower' speed = 21.560000000000002
+Time 22.7: Gap 'follower'->'leader' = 83.762 (headway=3.885)
+'follower' speed = 21.560000000000002
+Time 22.8: Gap 'follower'->'leader' = 83.566 (headway=3.876)
+'follower' speed = 21.560000000000002
+Time 22.9: Gap 'follower'->'leader' = 83.370 (headway=3.867)
+'follower' speed = 21.560000000000002
+Time 23.0: Gap 'follower'->'leader' = 83.174 (headway=3.858)
+'follower' speed = 21.560000000000002
+Time 23.1: Gap 'follower'->'leader' = 82.978 (headway=3.849)
+'follower' speed = 21.560000000000002
+Time 23.2: Gap 'follower'->'leader' = 82.782 (headway=3.840)
+'follower' speed = 21.560000000000002
+Time 23.3: Gap 'follower'->'leader' = 82.586 (headway=3.831)
+'follower' speed = 21.560000000000002
+Time 23.4: Gap 'follower'->'leader' = 82.390 (headway=3.821)
+'follower' speed = 21.560000000000002
+Time 23.5: Gap 'follower'->'leader' = 82.194 (headway=3.812)
+'follower' speed = 21.560000000000002
+Time 23.6: Gap 'follower'->'leader' = 81.998 (headway=3.803)
+'follower' speed = 21.560000000000002
+Time 23.7: Gap 'follower'->'leader' = 81.802 (headway=3.794)
+'follower' speed = 21.560000000000002
+Time 23.8: Gap 'follower'->'leader' = 81.606 (headway=3.785)
+'follower' speed = 21.560000000000002
+Time 23.9: Gap 'follower'->'leader' = 81.410 (headway=3.776)
+'follower' speed = 21.560000000000002
+Time 24.0: Gap 'follower'->'leader' = 81.214 (headway=3.767)
+'follower' speed = 21.560000000000002
+Time 24.1: Gap 'follower'->'leader' = 81.018 (headway=3.758)
+'follower' speed = 21.560000000000002
+Time 24.2: Gap 'follower'->'leader' = 80.822 (headway=3.749)
+'follower' speed = 21.560000000000002
+Time 24.3: Gap 'follower'->'leader' = 80.626 (headway=3.740)
+'follower' speed = 21.560000000000002
+Time 24.4: Gap 'follower'->'leader' = 80.430 (headway=3.731)
+'follower' speed = 21.560000000000002
+Time 24.5: Gap 'follower'->'leader' = 80.234 (headway=3.721)
+'follower' speed = 21.560000000000002
+Time 24.6: Gap 'follower'->'leader' = 80.038 (headway=3.712)
+'follower' speed = 21.560000000000002
+Time 24.7: Gap 'follower'->'leader' = 79.842 (headway=3.703)
+'follower' speed = 21.560000000000002
+Time 24.8: Gap 'follower'->'leader' = 79.646 (headway=3.694)
+'follower' speed = 21.560000000000002
+Time 24.9: Gap 'follower'->'leader' = 79.450 (headway=3.685)
+'follower' speed = 21.560000000000002
+Time 25.0: Gap 'follower'->'leader' = 79.254 (headway=3.676)
+'follower' speed = 21.560000000000002
+Time 25.1: Gap 'follower'->'leader' = 79.058 (headway=3.667)
+'follower' speed = 21.560000000000002
+Time 25.2: Gap 'follower'->'leader' = 78.862 (headway=3.658)
+'follower' speed = 21.560000000000002
+Time 25.3: Gap 'follower'->'leader' = 78.666 (headway=3.649)
+'follower' speed = 21.560000000000002
+Time 25.4: Gap 'follower'->'leader' = 78.470 (headway=3.640)
+'follower' speed = 21.560000000000002
+Time 25.5: Gap 'follower'->'leader' = 78.274 (headway=3.631)
+'follower' speed = 21.560000000000002
+Time 25.6: Gap 'follower'->'leader' = 78.078 (headway=3.621)
+'follower' speed = 21.560000000000002
+Time 25.7: Gap 'follower'->'leader' = 77.882 (headway=3.612)
+'follower' speed = 21.560000000000002
+Time 25.8: Gap 'follower'->'leader' = 77.686 (headway=3.603)
+'follower' speed = 21.560000000000002
+Time 25.9: Gap 'follower'->'leader' = 77.490 (headway=3.594)
+'follower' speed = 21.560000000000002
+Time 26.0: Gap 'follower'->'leader' = 77.294 (headway=3.585)
+'follower' speed = 21.560000000000002
+Time 26.1: Gap 'follower'->'leader' = 77.098 (headway=3.576)
+'follower' speed = 21.560000000000002
+Time 26.2: Gap 'follower'->'leader' = 76.902 (headway=3.567)
+'follower' speed = 21.560000000000002
+Time 26.3: Gap 'follower'->'leader' = 76.706 (headway=3.558)
+'follower' speed = 21.560000000000002
+Time 26.4: Gap 'follower'->'leader' = 76.510 (headway=3.549)
+'follower' speed = 21.560000000000002
+Time 26.5: Gap 'follower'->'leader' = 76.314 (headway=3.540)
+'follower' speed = 21.560000000000002
+Time 26.6: Gap 'follower'->'leader' = 76.118 (headway=3.531)
+'follower' speed = 21.560000000000002
+Time 26.7: Gap 'follower'->'leader' = 75.922 (headway=3.521)
+'follower' speed = 21.560000000000002
+Time 26.8: Gap 'follower'->'leader' = 75.726 (headway=3.512)
+'follower' speed = 21.560000000000002
+Time 26.9: Gap 'follower'->'leader' = 75.530 (headway=3.503)
+'follower' speed = 21.560000000000002
+Time 27.0: Gap 'follower'->'leader' = 75.334 (headway=3.494)
+'follower' speed = 21.560000000000002
+Time 27.1: Gap 'follower'->'leader' = 75.138 (headway=3.485)
+'follower' speed = 21.560000000000002
+Time 27.2: Gap 'follower'->'leader' = 74.942 (headway=3.476)
+'follower' speed = 21.560000000000002
+Time 27.3: Gap 'follower'->'leader' = 74.746 (headway=3.467)
+'follower' speed = 21.560000000000002
+Time 27.4: Gap 'follower'->'leader' = 74.550 (headway=3.458)
+'follower' speed = 21.559975991923068
+Time 27.5: Gap 'follower'->'leader' = 74.354 (headway=3.449)
+'follower' speed = 21.55917006765118
+Time 27.6: Gap 'follower'->'leader' = 74.159 (headway=3.440)
+'follower' speed = 21.557650103985626
+Time 27.7: Gap 'follower'->'leader' = 73.963 (headway=3.431)
+'follower' speed = 21.555478399059325
+Time 27.8: Gap 'follower'->'leader' = 73.768 (headway=3.423)
+'follower' speed = 21.552712129392216
+Time 27.9: Gap 'follower'->'leader' = 73.572 (headway=3.414)
+'follower' speed = 21.549403769507506
+Time 28.0: Gap 'follower'->'leader' = 73.378 (headway=3.406)
+'follower' speed = 21.545601477175595
+Time 28.1: Gap 'follower'->'leader' = 73.183 (headway=3.397)
+'follower' speed = 21.541349447101123
+Time 28.2: Gap 'follower'->'leader' = 72.989 (headway=3.389)
+'follower' speed = 21.536688235638124
+Time 28.3: Gap 'follower'->'leader' = 72.796 (headway=3.381)
+'follower' speed = 21.531655058906427
+Time 28.4: Gap 'follower'->'leader' = 72.603 (headway=3.373)
+'follower' speed = 21.526284066488078
+Time 28.5: Gap 'follower'->'leader' = 72.411 (headway=3.365)
+'follower' speed = 21.52060659270411
+Time 28.6: Gap 'follower'->'leader' = 72.219 (headway=3.357)
+'follower' speed = 21.5146513873081
+Time 28.7: Gap 'follower'->'leader' = 72.028 (headway=3.349)
+'follower' speed = 21.50844482728256
+Time 28.8: Gap 'follower'->'leader' = 71.837 (headway=3.341)
+'follower' speed = 21.502011111286073
+Time 28.9: Gap 'follower'->'leader' = 71.648 (headway=3.333)
+'follower' speed = 21.495372438172307
+Time 29.0: Gap 'follower'->'leader' = 71.458 (headway=3.325)
+'follower' speed = 21.48854917088561
+Time 29.1: Gap 'follower'->'leader' = 71.270 (headway=3.318)
+'follower' speed = 21.481559986931057
+Time 29.2: Gap 'follower'->'leader' = 71.082 (headway=3.310)
+'follower' speed = 21.47442201651867
+Time 29.3: Gap 'follower'->'leader' = 70.895 (headway=3.302)
+'follower' speed = 21.467150969391426
+Time 29.4: Gap 'follower'->'leader' = 70.709 (headway=3.295)
+'follower' speed = 21.45976125126403
+Time 29.5: Gap 'follower'->'leader' = 70.523 (headway=3.287)
+'follower' speed = 21.452266070723464
+Time 29.6: Gap 'follower'->'leader' = 70.338 (headway=3.280)
+'follower' speed = 21.44467753737259
+Time 29.7: Gap 'follower'->'leader' = 70.154 (headway=3.273)
+'follower' speed = 21.43700675193415
+Time 29.8: Gap 'follower'->'leader' = 69.971 (headway=3.265)
+'follower' speed = 21.429263888973676
+Time 29.9: Gap 'follower'->'leader' = 69.788 (headway=3.258)
+'follower' speed = 21.421458272845946
+Time 30.0: Gap 'follower'->'leader' = 69.606 (headway=3.251)
+'follower' speed = 21.41359844742005
+Time 30.1: Gap 'follower'->'leader' = 69.425 (headway=3.243)
+'follower' speed = 21.40569224009268
+Time 30.2: Gap 'follower'->'leader' = 69.245 (headway=3.236)
+'follower' speed = 21.39774682055753
+Time 30.3: Gap 'follower'->'leader' = 69.066 (headway=3.229)
+'follower' speed = 21.389768754760315
+Time 30.4: Gap 'follower'->'leader' = 68.887 (headway=3.222)
+'follower' speed = 21.381764054433813
+Time 30.5: Gap 'follower'->'leader' = 68.710 (headway=3.215)
+'follower' speed = 21.373738222574943
+Time 30.6: Gap 'follower'->'leader' = 68.533 (headway=3.208)
+'follower' speed = 21.365696295196322
+Time 30.7: Gap 'follower'->'leader' = 68.356 (headway=3.201)
+'follower' speed = 21.35764287965743
+Time 30.8: Gap 'follower'->'leader' = 68.181 (headway=3.194)
+'follower' speed = 21.34958218985557
+Time 30.9: Gap 'follower'->'leader' = 68.007 (headway=3.187)
+'follower' speed = 21.34151807853389
+Time 31.0: Gap 'follower'->'leader' = 67.833 (headway=3.180)
+'follower' speed = 21.333454066942547
+Time 31.1: Gap 'follower'->'leader' = 67.660 (headway=3.173)
+'follower' speed = 21.325393372069872
+Time 31.2: Gap 'follower'->'leader' = 67.488 (headway=3.166)
+'follower' speed = 21.31733893164259
+Time 31.3: Gap 'follower'->'leader' = 67.316 (headway=3.159)
+'follower' speed = 21.309293427077804
+Time 31.4: Gap 'follower'->'leader' = 67.146 (headway=3.152)
+'follower' speed = 21.301259304554566
+Time 31.5: Gap 'follower'->'leader' = 66.976 (headway=3.145)
+'follower' speed = 21.293238794359027
+Time 31.6: Gap 'follower'->'leader' = 66.807 (headway=3.139)
+'follower' speed = 21.285233928644598
+Time 31.7: Gap 'follower'->'leader' = 66.639 (headway=3.132)
+'follower' speed = 21.277246557736973
+Time 31.8: Gap 'follower'->'leader' = 66.472 (headway=3.125)
+'follower' speed = 21.26927836510319
+Time 31.9: Gap 'follower'->'leader' = 66.305 (headway=3.119)
+'follower' speed = 21.261330881094153
+Time 32.0: Gap 'follower'->'leader' = 66.139 (headway=3.112)
+'follower' speed = 21.253405495561125
+Time 32.1: Gap 'follower'->'leader' = 65.975 (headway=3.105)
+'follower' speed = 21.245503469438383
+Time 32.2: Gap 'follower'->'leader' = 65.810 (headway=3.099)
+'follower' speed = 21.237625945376767
+Time 32.3: Gap 'follower'->'leader' = 65.647 (headway=3.092)
+'follower' speed = 21.229773957505827
+Time 32.4: Gap 'follower'->'leader' = 65.484 (headway=3.086)
+'follower' speed = 21.221948440395984
+Time 32.5: Gap 'follower'->'leader' = 65.323 (headway=3.079)
+'follower' speed = 21.2141502372862
+Time 32.6: Gap 'follower'->'leader' = 65.162 (headway=3.073)
+'follower' speed = 21.20638010763738
+Time 32.7: Gap 'follower'->'leader' = 65.001 (headway=3.066)
+'follower' speed = 21.19863873406664
+Time 32.8: Gap 'follower'->'leader' = 64.842 (headway=3.060)
+'follower' speed = 21.190926728713293
+Time 32.9: Gap 'follower'->'leader' = 64.683 (headway=3.054)
+'follower' speed = 21.183244639082968
+Time 33.0: Gap 'follower'->'leader' = 64.525 (headway=3.047)
+'follower' speed = 21.17559295341271
+Time 33.1: Gap 'follower'->'leader' = 64.368 (headway=3.041)
+'follower' speed = 21.167972105596256
+Time 33.2: Gap 'follower'->'leader' = 64.212 (headway=3.035)
+'follower' speed = 21.160382479705515
+Time 33.3: Gap 'follower'->'leader' = 64.056 (headway=3.028)
+'follower' speed = 21.152824414141346
+Time 33.4: Gap 'follower'->'leader' = 63.901 (headway=3.022)
+'follower' speed = 21.145298205444004
+Time 33.5: Gap 'follower'->'leader' = 63.747 (headway=3.016)
+'follower' speed = 21.1378041117911
+Time 33.6: Gap 'follower'->'leader' = 63.593 (headway=3.010)
+'follower' speed = 21.13034235620872
+Time 33.7: Gap 'follower'->'leader' = 63.441 (headway=3.003)
+'follower' speed = 21.122913129519148
+Time 33.8: Gap 'follower'->'leader' = 63.289 (headway=2.997)
+'follower' speed = 21.11551659304684
+Time 33.9: Gap 'follower'->'leader' = 63.138 (headway=2.991)
+'follower' speed = 21.108152881102377
+Time 34.0: Gap 'follower'->'leader' = 62.987 (headway=2.985)
+'follower' speed = 21.100822103262626
+Time 34.1: Gap 'follower'->'leader' = 62.838 (headway=2.979)
+'follower' speed = 21.093524346463813
+Time 34.2: Gap 'follower'->'leader' = 62.689 (headway=2.973)
+'follower' speed = 21.086259676922804
+Time 34.3: Gap 'follower'->'leader' = 62.540 (headway=2.967)
+'follower' speed = 21.079028141900693
+Time 34.4: Gap 'follower'->'leader' = 62.393 (headway=2.961)
+'follower' speed = 21.071829771321593
+Time 34.5: Gap 'follower'->'leader' = 62.246 (headway=2.955)
+'follower' speed = 21.064664579258515
+Time 34.6: Gap 'follower'->'leader' = 62.100 (headway=2.949)
+'follower' speed = 21.057532565297215
+Time 34.7: Gap 'follower'->'leader' = 61.954 (headway=2.943)
+'follower' speed = 21.050433715787996
+Time 34.8: Gap 'follower'->'leader' = 61.810 (headway=2.937)
+'follower' speed = 21.04336800499466
+Time 34.9: Gap 'follower'->'leader' = 61.666 (headway=2.931)
+'follower' speed = 21.03633539614903
+Time 35.0: Gap 'follower'->'leader' = 61.522 (headway=2.926)
+'follower' speed = 21.029335842418767
+Time 35.1: Gap 'follower'->'leader' = 61.380 (headway=2.920)
+'follower' speed = 21.022369287795616
+Time 35.2: Gap 'follower'->'leader' = 61.238 (headway=2.914)
+'follower' speed = 21.01543566791057
+Time 35.3: Gap 'follower'->'leader' = 61.097 (headway=2.908)
+'follower' speed = 21.008534910781947
+Time 35.4: Gap 'follower'->'leader' = 60.956 (headway=2.902)
+'follower' speed = 21.001666937501895
+Time 35.5: Gap 'follower'->'leader' = 60.816 (headway=2.897)
+'follower' speed = 20.994831662866346
+Time 35.6: Gap 'follower'->'leader' = 60.677 (headway=2.891)
+'follower' speed = 20.988028995953066
+Time 35.7: Gap 'follower'->'leader' = 60.539 (headway=2.885)
+'follower' speed = 20.981258840652043
+Time 35.8: Gap 'follower'->'leader' = 60.401 (headway=2.880)
+'follower' speed = 20.974521096152145
+Time 35.9: Gap 'follower'->'leader' = 60.264 (headway=2.874)
+'follower' speed = 20.9678156573876
+Time 36.0: Gap 'follower'->'leader' = 60.127 (headway=2.869)
+'follower' speed = 20.961142415447604
+Time 36.1: Gap 'follower'->'leader' = 59.992 (headway=2.863)
+'follower' speed = 20.954501257952078
+Time 36.2: Gap 'follower'->'leader' = 59.857 (headway=2.857)
+'follower' speed = 20.947892069396353
+Time 36.3: Gap 'follower'->'leader' = 59.722 (headway=2.852)
+'follower' speed = 20.94131473146733
+Time 36.4: Gap 'follower'->'leader' = 59.588 (headway=2.846)
+'follower' speed = 20.934769123333435
+Time 36.5: Gap 'follower'->'leader' = 59.455 (headway=2.841)
+'follower' speed = 20.928255121910546
+Time 36.6: Gap 'follower'->'leader' = 59.323 (headway=2.835)
+'follower' speed = 20.921772602105822
+Time 36.7: Gap 'follower'->'leader' = 59.191 (headway=2.830)
+'follower' speed = 20.915321437041307
+Time 36.8: Gap 'follower'->'leader' = 59.060 (headway=2.825)
+'follower' speed = 20.90890149825889
+Time 36.9: Gap 'follower'->'leader' = 58.929 (headway=2.819)
+'follower' speed = 20.90251265590821
+Time 37.0: Gap 'follower'->'leader' = 58.799 (headway=2.814)
+'follower' speed = 20.896154778918902
+Time 37.1: Gap 'follower'->'leader' = 58.670 (headway=2.809)
+'follower' speed = 20.88982773515839
+Time 37.2: Gap 'follower'->'leader' = 58.541 (headway=2.803)
+'follower' speed = 20.88353139157655
+Time 37.3: Gap 'follower'->'leader' = 58.413 (headway=2.798)
+'follower' speed = 20.877265614338178
+Time 37.4: Gap 'follower'->'leader' = 58.286 (headway=2.793)
+'follower' speed = 20.871030268944356
+Time 37.5: Gap 'follower'->'leader' = 58.159 (headway=2.787)
+'follower' speed = 20.8648252203436
+Time 37.6: Gap 'follower'->'leader' = 58.033 (headway=2.782)
+'follower' speed = 20.85865033303362
+Time 37.7: Gap 'follower'->'leader' = 57.907 (headway=2.777)
+'follower' speed = 20.85250547115446
+Time 37.8: Gap 'follower'->'leader' = 57.782 (headway=2.772)
+'follower' speed = 20.846390498573747
+Time 37.9: Gap 'follower'->'leader' = 57.658 (headway=2.767)
+'follower' speed = 20.84030527896469
+Time 38.0: Gap 'follower'->'leader' = 57.534 (headway=2.762)
+'follower' speed = 20.834249675877388
+Time 38.1: Gap 'follower'->'leader' = 57.411 (headway=2.756)
+'follower' speed = 20.82822355280407
+Time 38.2: Gap 'follower'->'leader' = 57.288 (headway=2.751)
+'follower' speed = 20.82222677323867
+Time 38.3: Gap 'follower'->'leader' = 57.167 (headway=2.746)
+'follower' speed = 20.816259200731306
+Time 38.4: Gap 'follower'->'leader' = 57.045 (headway=2.741)
+'follower' speed = 20.810320698937996
+Time 38.5: Gap 'follower'->'leader' = 56.925 (headway=2.736)
+'follower' speed = 20.804411131666047
+Time 38.6: Gap 'follower'->'leader' = 56.804 (headway=2.731)
+'follower' speed = 20.79853036291546
+Time 38.7: Gap 'follower'->'leader' = 56.685 (headway=2.726)
+'follower' speed = 20.792678256916684
+Time 38.8: Gap 'follower'->'leader' = 56.566 (headway=2.721)
+'follower' speed = 20.78685467816501
+Time 38.9: Gap 'follower'->'leader' = 56.447 (headway=2.716)
+'follower' speed = 20.7810594914519
+Time 39.0: Gap 'follower'->'leader' = 56.330 (headway=2.711)
+'follower' speed = 20.775292561893473
+Time 39.1: Gap 'follower'->'leader' = 56.212 (headway=2.706)
+'follower' speed = 20.76955375495642
+Time 39.2: Gap 'follower'->'leader' = 56.096 (headway=2.702)
+'follower' speed = 20.763842936481517
+Time 39.3: Gap 'follower'->'leader' = 55.980 (headway=2.697)
+'follower' speed = 20.75815997270498
+Time 39.4: Gap 'follower'->'leader' = 55.864 (headway=2.692)
+'follower' speed = 20.7525047302778
+Time 39.5: Gap 'follower'->'leader' = 55.749 (headway=2.687)
+'follower' speed = 20.746877076283248
+Time 39.6: Gap 'follower'->'leader' = 55.635 (headway=2.682)
+'follower' speed = 20.741276878252695
+Time 39.7: Gap 'follower'->'leader' = 55.521 (headway=2.678)
+'follower' speed = 20.73570400417989
+Time 39.8: Gap 'follower'->'leader' = 55.408 (headway=2.673)
+'follower' speed = 20.730158322533807
+Time 39.9: Gap 'follower'->'leader' = 55.295 (headway=2.668)
+'follower' speed = 20.724639702270206
+Time 40.0: Gap 'follower'->'leader' = 55.183 (headway=2.663)
+'follower' speed = 20.71914801284199
+Time 40.1: Gap 'follower'->'leader' = 55.071 (headway=2.659)
+'follower' speed = 20.71368312420848
+Time 40.2: Gap 'follower'->'leader' = 54.960 (headway=2.654)
+'follower' speed = 20.708244906843664
+Time 40.3: Gap 'follower'->'leader' = 54.849 (headway=2.649)
+'follower' speed = 20.70283323174356
+Time 40.4: Gap 'follower'->'leader' = 54.739 (headway=2.645)
+'follower' speed = 20.697447970432712
+Time 40.5: Gap 'follower'->'leader' = 54.630 (headway=2.640)
+'follower' speed = 20.6920889949699
+Time 40.6: Gap 'follower'->'leader' = 54.521 (headway=2.636)
+'follower' speed = 20.686756177953185
+Time 40.7: Gap 'follower'->'leader' = 54.412 (headway=2.631)
+'follower' speed = 20.681449392524268
+Time 40.8: Gap 'follower'->'leader' = 54.305 (headway=2.626)
+'follower' speed = 20.676168512372257
+Time 40.9: Gap 'follower'->'leader' = 54.197 (headway=2.622)
+'follower' speed = 20.67091341173691
+Time 41.0: Gap 'follower'->'leader' = 54.090 (headway=2.617)
+'follower' speed = 20.66568396541136
+Time 41.1: Gap 'follower'->'leader' = 53.984 (headway=2.613)
+'follower' speed = 20.66048004874439
+Time 41.2: Gap 'follower'->'leader' = 53.878 (headway=2.608)
+'follower' speed = 20.65530153764228
+Time 41.3: Gap 'follower'->'leader' = 53.773 (headway=2.604)
+'follower' speed = 20.65014830857029
+Time 41.4: Gap 'follower'->'leader' = 53.668 (headway=2.600)
+'follower' speed = 20.645020238553776
+Time 41.5: Gap 'follower'->'leader' = 53.564 (headway=2.595)
+'follower' speed = 20.63991720517899
+Time 41.6: Gap 'follower'->'leader' = 53.460 (headway=2.591)
+'follower' speed = 20.634839086593576
+Time 41.7: Gap 'follower'->'leader' = 53.357 (headway=2.586)
+'follower' speed = 20.62978576150683
+Time 41.8: Gap 'follower'->'leader' = 53.254 (headway=2.582)
+'follower' speed = 20.62475710918968
+Time 41.9: Gap 'follower'->'leader' = 53.152 (headway=2.578)
+'follower' speed = 20.619753009474444
+Time 42.0: Gap 'follower'->'leader' = 53.050 (headway=2.573)
+'follower' speed = 20.614773342754418
+Time 42.1: Gap 'follower'->'leader' = 52.949 (headway=2.569)
+'follower' speed = 20.60981798998323
+Time 42.2: Gap 'follower'->'leader' = 52.848 (headway=2.565)
+'follower' speed = 20.604886832674072
+Time 42.3: Gap 'follower'->'leader' = 52.748 (headway=2.561)
+'follower' speed = 20.599979752898726
+Time 42.4: Gap 'follower'->'leader' = 52.648 (headway=2.556)
+'follower' speed = 20.59509663328649
+Time 42.5: Gap 'follower'->'leader' = 52.549 (headway=2.552)
+'follower' speed = 20.59023735702296
+Time 42.6: Gap 'follower'->'leader' = 52.450 (headway=2.548)
+'follower' speed = 20.585401807848683
+Time 42.7: Gap 'follower'->'leader' = 52.352 (headway=2.544)
+'follower' speed = 20.58058987005773
+Time 42.8: Gap 'follower'->'leader' = 52.254 (headway=2.540)
+'follower' speed = 20.57580142849614
+Time 42.9: Gap 'follower'->'leader' = 52.157 (headway=2.535)
+'follower' speed = 20.571036368560303
+Time 43.0: Gap 'follower'->'leader' = 52.060 (headway=2.531)
+'follower' speed = 20.56629457619526
+Time 43.1: Gap 'follower'->'leader' = 51.964 (headway=2.527)
+'follower' speed = 20.56157593789291
+Time 43.2: Gap 'follower'->'leader' = 51.868 (headway=2.523)
+'follower' speed = 20.556880340690174
+Time 43.3: Gap 'follower'->'leader' = 51.772 (headway=2.519)
+'follower' speed = 20.55220767216709
+Time 43.4: Gap 'follower'->'leader' = 51.677 (headway=2.515)
+'follower' speed = 20.547557820444858
+Time 43.5: Gap 'follower'->'leader' = 51.583 (headway=2.511)
+'follower' speed = 20.542930674183843
+Time 43.6: Gap 'follower'->'leader' = 51.489 (headway=2.507)
+'follower' speed = 20.538326122581523
+Time 43.7: Gap 'follower'->'leader' = 51.395 (headway=2.503)
+'follower' speed = 20.533744055370406
+Time 43.8: Gap 'follower'->'leader' = 51.302 (headway=2.499)
+'follower' speed = 20.52918436281591
+Time 43.9: Gap 'follower'->'leader' = 51.209 (headway=2.495)
+'follower' speed = 20.524646935714227
+Time 44.0: Gap 'follower'->'leader' = 51.117 (headway=2.491)
+'follower' speed = 20.520131665390135
+Time 44.1: Gap 'follower'->'leader' = 51.025 (headway=2.487)
+'follower' speed = 20.515638443694808
+Time 44.2: Gap 'follower'->'leader' = 50.934 (headway=2.483)
+'follower' speed = 20.51116716300359
+Time 44.3: Gap 'follower'->'leader' = 50.843 (headway=2.479)
+'follower' speed = 20.506717716213775
+Time 44.4: Gap 'follower'->'leader' = 50.753 (headway=2.475)
+'follower' speed = 20.502289996742324
+Time 44.5: Gap 'follower'->'leader' = 50.663 (headway=2.472)
+'follower' speed = 20.497883898523632
+Time 44.6: Gap 'follower'->'leader' = 50.573 (headway=2.468)
+'follower' speed = 20.493499316007235
+Time 44.7: Gap 'follower'->'leader' = 50.484 (headway=2.464)
+'follower' speed = 20.48913614415552
+Time 44.8: Gap 'follower'->'leader' = 50.395 (headway=2.460)
+'follower' speed = 20.484794278441445
+Time 44.9: Gap 'follower'->'leader' = 50.307 (headway=2.456)
+'follower' speed = 20.480473614846225
+Time 45.0: Gap 'follower'->'leader' = 50.219 (headway=2.453)
+'follower' speed = 20.47617404985704
+Time 45.1: Gap 'follower'->'leader' = 50.132 (headway=2.449)
+'follower' speed = 20.471895480464717
+Time 45.2: Gap 'follower'->'leader' = 50.045 (headway=2.445)
+'follower' speed = 20.467637804161427
+Time 45.3: Gap 'follower'->'leader' = 49.958 (headway=2.441)
+'follower' speed = 20.463400918938373
+Time 45.4: Gap 'follower'->'leader' = 49.872 (headway=2.438)
+'follower' speed = 20.459184723283474
+Time 45.5: Gap 'follower'->'leader' = 49.786 (headway=2.434)
+'follower' speed = 20.454989116179064
+Time 45.6: Gap 'follower'->'leader' = 49.701 (headway=2.430)
+'follower' speed = 20.450813997099573
+Time 45.7: Gap 'follower'->'leader' = 49.616 (headway=2.427)
+'follower' speed = 20.446659266009235
+Time 45.8: Gap 'follower'->'leader' = 49.532 (headway=2.423)
+'follower' speed = 20.442524823359776
+Time 45.9: Gap 'follower'->'leader' = 49.448 (headway=2.419)
+'follower' speed = 20.438410570088113
+Time 46.0: Gap 'follower'->'leader' = 49.364 (headway=2.416)
+'follower' speed = 20.434316407614077
+Time 46.1: Gap 'follower'->'leader' = 49.281 (headway=2.412)
+'follower' speed = 20.4302422378381
+Time 46.2: Gap 'follower'->'leader' = 49.198 (headway=2.409)
+'follower' speed = 20.426187963138954
+Time 46.3: Gap 'follower'->'leader' = 49.116 (headway=2.405)
+'follower' speed = 20.42215348637146
+Time 46.4: Gap 'follower'->'leader' = 49.033 (headway=2.401)
+'follower' speed = 20.418138710864223
+Time 46.5: Gap 'follower'->'leader' = 48.952 (headway=2.398)
+'follower' speed = 20.414143540417363
+Time 46.6: Gap 'follower'->'leader' = 48.871 (headway=2.394)
+'follower' speed = 20.410167879300264
+Time 46.7: Gap 'follower'->'leader' = 48.790 (headway=2.391)
+'follower' speed = 20.406211632249317
+Time 46.8: Gap 'follower'->'leader' = 48.709 (headway=2.387)
+'follower' speed = 20.402274704465682
+Time 46.9: Gap 'follower'->'leader' = 48.629 (headway=2.384)
+'follower' speed = 20.398357001613057
+Time 47.0: Gap 'follower'->'leader' = 48.550 (headway=2.381)
+'follower' speed = 20.394458429815444
+Time 47.1: Gap 'follower'->'leader' = 48.470 (headway=2.377)
+'follower' speed = 20.39057889565493
+Time 47.2: Gap 'follower'->'leader' = 48.392 (headway=2.374)
+'follower' speed = 20.386718306169485
+Time 47.3: Gap 'follower'->'leader' = 48.313 (headway=2.370)
+'follower' speed = 20.382876568850758
+Time 47.4: Gap 'follower'->'leader' = 48.235 (headway=2.367)
+'follower' speed = 20.37905359164188
+Time 47.5: Gap 'follower'->'leader' = 48.157 (headway=2.364)
+'follower' speed = 20.375249282935286
+Time 47.6: Gap 'follower'->'leader' = 48.080 (headway=2.360)
+'follower' speed = 20.371463551570532
+Time 47.7: Gap 'follower'->'leader' = 48.003 (headway=2.357)
+'follower' speed = 20.367696306832137
+Time 47.8: Gap 'follower'->'leader' = 47.926 (headway=2.353)
+'follower' speed = 20.363947458447427
+Time 47.9: Gap 'follower'->'leader' = 47.850 (headway=2.350)
+'follower' speed = 20.360216916584385
+Time 48.0: Gap 'follower'->'leader' = 47.774 (headway=2.347)
+'follower' speed = 20.356504591849507
+Time 48.1: Gap 'follower'->'leader' = 47.699 (headway=2.344)
+'follower' speed = 20.352810395285687
+Time 48.2: Gap 'follower'->'leader' = 47.624 (headway=2.340)
+'follower' speed = 20.34913423837008
+Time 48.3: Gap 'follower'->'leader' = 47.549 (headway=2.337)
+'follower' speed = 20.345476033012005
+Time 48.4: Gap 'follower'->'leader' = 47.475 (headway=2.334)
+'follower' speed = 20.34183569155084
+Time 48.5: Gap 'follower'->'leader' = 47.401 (headway=2.331)
+'follower' speed = 20.33821312675394
+Time 48.6: Gap 'follower'->'leader' = 47.327 (headway=2.327)
+'follower' speed = 20.334608251814526
+Time 48.7: Gap 'follower'->'leader' = 47.254 (headway=2.324)
+'follower' speed = 20.331020980349653
+Time 48.8: Gap 'follower'->'leader' = 47.181 (headway=2.321)
+'follower' speed = 20.327451226398118
+Time 48.9: Gap 'follower'->'leader' = 47.108 (headway=2.318)
+'follower' speed = 20.32389890441842
+Time 49.0: Gap 'follower'->'leader' = 47.036 (headway=2.315)
+'follower' speed = 20.320363929286714
+Time 49.1: Gap 'follower'->'leader' = 46.964 (headway=2.312)
+'follower' speed = 20.316846216294774
+Time 49.2: Gap 'follower'->'leader' = 46.893 (headway=2.308)
+'follower' speed = 20.31334568114797
+Time 49.3: Gap 'follower'->'leader' = 46.822 (headway=2.305)
+'follower' speed = 20.309862239963245
+Time 49.4: Gap 'follower'->'leader' = 46.751 (headway=2.302)
+'follower' speed = 20.306395809267134
+Time 49.5: Gap 'follower'->'leader' = 46.680 (headway=2.299)
+'follower' speed = 20.302946305993736
+Time 49.6: Gap 'follower'->'leader' = 46.610 (headway=2.296)
+'follower' speed = 20.299513647482748
+Time 49.7: Gap 'follower'->'leader' = 46.540 (headway=2.293)
+'follower' speed = 20.296097751477483
+Time 49.8: Gap 'follower'->'leader' = 46.471 (headway=2.290)
+'follower' speed = 20.2926985361229
+Time 49.9: Gap 'follower'->'leader' = 46.402 (headway=2.287)
+'follower' speed = 20.289315919963638
+Time 50.0: Gap 'follower'->'leader' = 46.333 (headway=2.284)
+'follower' speed = 20.28594982194209
+Time 50.1: Gap 'follower'->'leader' = 46.265 (headway=2.281)
+'follower' speed = 20.282600161396434
+## Starting to open gap.
+(followerID, targetTimeHeadway, targetSpaceHeadway, duration, changeRate) = ('follower', -1.0, 250.0, 10.0, 0.01)
+Time 50.2: Gap 'follower'->'leader' = 46.197 (headway=2.278)
+'follower' speed = 20.279266858058723
+Current/target headway: 2.278/-1.0
+Time 50.3: Gap 'follower'->'leader' = 46.129 (headway=2.275)
+'follower' speed = 20.27494983205295
+Current/target headway: 2.275/-1.0
+Time 50.4: Gap 'follower'->'leader' = 46.062 (headway=2.272)
+'follower' speed = 20.26973579989315
+Current/target headway: 2.272/-1.0
+Time 50.5: Gap 'follower'->'leader' = 45.995 (headway=2.270)
+'follower' speed = 20.263704344935874
+Current/target headway: 2.270/-1.0
+Time 50.6: Gap 'follower'->'leader' = 45.929 (headway=2.267)
+'follower' speed = 20.25692850182311
+Current/target headway: 2.267/-1.0
+Time 50.7: Gap 'follower'->'leader' = 45.864 (headway=2.265)
+'follower' speed = 20.24947529305119
+Current/target headway: 2.265/-1.0
+Time 50.8: Gap 'follower'->'leader' = 45.799 (headway=2.263)
+'follower' speed = 20.24140622158711
+Current/target headway: 2.263/-1.0
+Time 50.9: Gap 'follower'->'leader' = 45.735 (headway=2.260)
+'follower' speed = 20.232777723132603
+Current/target headway: 2.260/-1.0
+Time 51.0: Gap 'follower'->'leader' = 45.673 (headway=2.258)
+'follower' speed = 20.22364158134132
+Current/target headway: 2.258/-1.0
+Time 51.1: Gap 'follower'->'leader' = 45.611 (headway=2.256)
+'follower' speed = 20.214045309023696
+Current/target headway: 2.256/-1.0
+Time 51.2: Gap 'follower'->'leader' = 45.550 (headway=2.254)
+'follower' speed = 20.204032498125617
+Current/target headway: 2.254/-1.0
+Time 51.3: Gap 'follower'->'leader' = 45.490 (headway=2.253)
+'follower' speed = 20.19364314103864
+Current/target headway: 2.253/-1.0
+Time 51.4: Gap 'follower'->'leader' = 45.431 (headway=2.251)
+'follower' speed = 20.18291392559013
+Current/target headway: 2.251/-1.0
+Time 51.5: Gap 'follower'->'leader' = 45.373 (headway=2.249)
+'follower' speed = 20.171878505869277
+Current/target headway: 2.249/-1.0
+Time 51.6: Gap 'follower'->'leader' = 45.317 (headway=2.248)
+'follower' speed = 20.160567750868278
+Current/target headway: 2.248/-1.0
+Time 51.7: Gap 'follower'->'leader' = 45.261 (headway=2.246)
+'follower' speed = 20.149009972755998
+Current/target headway: 2.246/-1.0
+Time 51.8: Gap 'follower'->'leader' = 45.207 (headway=2.245)
+'follower' speed = 20.137231136452403
+Current/target headway: 2.245/-1.0
+Time 51.9: Gap 'follower'->'leader' = 45.154 (headway=2.244)
+'follower' speed = 20.125255052035513
+Current/target headway: 2.244/-1.0
+Time 52.0: Gap 'follower'->'leader' = 45.102 (headway=2.242)
+'follower' speed = 20.11310355138709
+Current/target headway: 2.242/-1.0
+Time 52.1: Gap 'follower'->'leader' = 45.051 (headway=2.241)
+'follower' speed = 20.100796650368135
+Current/target headway: 2.241/-1.0
+Time 52.2: Gap 'follower'->'leader' = 45.002 (headway=2.240)
+'follower' speed = 20.088352697709468
+Current/target headway: 2.240/-1.0
+Time 52.3: Gap 'follower'->'leader' = 44.953 (headway=2.239)
+'follower' speed = 20.075788511705614
+Current/target headway: 2.239/-1.0
+Time 52.4: Gap 'follower'->'leader' = 44.907 (headway=2.238)
+'follower' speed = 20.063119505711068
+Current/target headway: 2.238/-1.0
+Time 52.5: Gap 'follower'->'leader' = 44.861 (headway=2.237)
+'follower' speed = 20.05035980335614
+Current/target headway: 2.237/-1.0
+Time 52.6: Gap 'follower'->'leader' = 44.816 (headway=2.237)
+'follower' speed = 20.03752234432453
+Current/target headway: 2.237/-1.0
+Time 52.7: Gap 'follower'->'leader' = 44.773 (headway=2.236)
+'follower' speed = 20.024618981465682
+Current/target headway: 2.236/-1.0
+Time 52.8: Gap 'follower'->'leader' = 44.732 (headway=2.235)
+'follower' speed = 20.0116605699518
+Current/target headway: 2.235/-1.0
+Time 52.9: Gap 'follower'->'leader' = 44.691 (headway=2.235)
+'follower' speed = 19.99865704913109
+Current/target headway: 2.235/-1.0
+Time 53.0: Gap 'follower'->'leader' = 44.652 (headway=2.234)
+'follower' speed = 19.985617517675554
+Current/target headway: 2.234/-1.0
+Time 53.1: Gap 'follower'->'leader' = 44.614 (headway=2.234)
+'follower' speed = 19.972550302572582
+Current/target headway: 2.234/-1.0
+Time 53.2: Gap 'follower'->'leader' = 44.577 (headway=2.233)
+'follower' speed = 19.959463022464615
+Current/target headway: 2.233/-1.0
+Time 53.3: Gap 'follower'->'leader' = 44.542 (headway=2.233)
+'follower' speed = 19.94636264579987
+Current/target headway: 2.233/-1.0
+Time 53.4: Gap 'follower'->'leader' = 44.508 (headway=2.233)
+'follower' speed = 19.933255544219133
+Current/target headway: 2.233/-1.0
+Time 53.5: Gap 'follower'->'leader' = 44.475 (headway=2.233)
+'follower' speed = 19.920147541568877
+Current/target headway: 2.233/-1.0
+Time 53.6: Gap 'follower'->'leader' = 44.444 (headway=2.233)
+'follower' speed = 19.907043958898967
+Current/target headway: 2.233/-1.0
+Time 53.7: Gap 'follower'->'leader' = 44.414 (headway=2.233)
+'follower' speed = 19.893949655773845
+Current/target headway: 2.233/-1.0
+Time 53.8: Gap 'follower'->'leader' = 44.385 (headway=2.233)
+'follower' speed = 19.880869068199214
+Current/target headway: 2.233/-1.0
+Time 53.9: Gap 'follower'->'leader' = 44.358 (headway=2.233)
+'follower' speed = 19.8678062434414
+Current/target headway: 2.233/-1.0
+Time 54.0: Gap 'follower'->'leader' = 44.332 (headway=2.233)
+'follower' speed = 19.854764871993986
+Current/target headway: 2.233/-1.0
+Time 54.1: Gap 'follower'->'leader' = 44.307 (headway=2.233)
+'follower' speed = 19.841748316925344
+Current/target headway: 2.233/-1.0
+Time 54.2: Gap 'follower'->'leader' = 44.283 (headway=2.233)
+'follower' speed = 19.82875964082164
+Current/target headway: 2.233/-1.0
+Time 54.3: Gap 'follower'->'leader' = 44.261 (headway=2.234)
+'follower' speed = 19.815801630522266
+Current/target headway: 2.234/-1.0
+Time 54.4: Gap 'follower'->'leader' = 44.240 (headway=2.234)
+'follower' speed = 19.80287681982851
+Current/target headway: 2.234/-1.0
+Time 54.5: Gap 'follower'->'leader' = 44.221 (headway=2.234)
+'follower' speed = 19.789987510351516
+Current/target headway: 2.234/-1.0
+Time 54.6: Gap 'follower'->'leader' = 44.202 (headway=2.235)
+'follower' speed = 19.777135790651958
+Current/target headway: 2.235/-1.0
+Time 54.7: Gap 'follower'->'leader' = 44.185 (headway=2.236)
+'follower' speed = 19.764323553811302
+Current/target headway: 2.236/-1.0
+Time 54.8: Gap 'follower'->'leader' = 44.169 (headway=2.236)
+'follower' speed = 19.751552513563205
+Current/target headway: 2.236/-1.0
+Time 54.9: Gap 'follower'->'leader' = 44.155 (headway=2.237)
+'follower' speed = 19.73598493824745
+Current/target headway: 2.237/-1.0
+Time 55.0: Gap 'follower'->'leader' = 44.143 (headway=2.241)
+'follower' speed = 19.70167894189237
+Current/target headway: 2.241/-1.0
+Time 55.1: Gap 'follower'->'leader' = 44.135 (headway=2.246)
+'follower' speed = 19.65173697497206
+Current/target headway: 2.246/-1.0
+Time 55.2: Gap 'follower'->'leader' = 44.133 (headway=2.253)
+'follower' speed = 19.588918353899583
+Current/target headway: 2.253/-1.0
+Time 55.3: Gap 'follower'->'leader' = 44.138 (headway=2.262)
+'follower' speed = 19.515668972288168
+Current/target headway: 2.262/-1.0
+Time 55.4: Gap 'follower'->'leader' = 44.151 (headway=2.272)
+'follower' speed = 19.43414903557124
+Current/target headway: 2.272/-1.0
+Time 55.5: Gap 'follower'->'leader' = 44.172 (headway=2.283)
+'follower' speed = 19.346258895419066
+Current/target headway: 2.283/-1.0
+Time 55.6: Gap 'follower'->'leader' = 44.202 (headway=2.296)
+'follower' speed = 19.253663064055303
+Current/target headway: 2.296/-1.0
+Time 55.7: Gap 'follower'->'leader' = 44.241 (headway=2.309)
+'follower' speed = 19.15781249104852
+Current/target headway: 2.309/-1.0
+Time 55.8: Gap 'follower'->'leader' = 44.290 (headway=2.324)
+'follower' speed = 19.059965186591533
+Current/target headway: 2.324/-1.0
+Time 55.9: Gap 'follower'->'leader' = 44.349 (headway=2.339)
+'follower' speed = 18.961205275830462
+Current/target headway: 2.339/-1.0
+Time 56.0: Gap 'follower'->'leader' = 44.418 (headway=2.355)
+'follower' speed = 18.86246056859481
+Current/target headway: 2.355/-1.0
+Time 56.1: Gap 'follower'->'leader' = 44.497 (headway=2.371)
+'follower' speed = 18.764518728026403
+Current/target headway: 2.371/-1.0
+Time 56.2: Gap 'follower'->'leader' = 44.585 (headway=2.388)
+'follower' speed = 18.66804212021237
+Current/target headway: 2.388/-1.0
+Time 56.3: Gap 'follower'->'leader' = 44.683 (headway=2.406)
+'follower' speed = 18.573581425087934
+Current/target headway: 2.406/-1.0
+Time 56.4: Gap 'follower'->'leader' = 44.790 (headway=2.423)
+'follower' speed = 18.481588086670975
+Current/target headway: 2.423/-1.0
+Time 56.5: Gap 'follower'->'leader' = 44.906 (headway=2.442)
+'follower' speed = 18.392425678194535
+Current/target headway: 2.442/-1.0
+Time 56.6: Gap 'follower'->'leader' = 45.031 (headway=2.460)
+'follower' speed = 18.306380254979803
+Current/target headway: 2.460/-1.0
+Time 56.7: Gap 'follower'->'leader' = 45.165 (headway=2.478)
+'follower' speed = 18.223669764996803
+Current/target headway: 2.478/-1.0
+Time 56.8: Gap 'follower'->'leader' = 45.307 (headway=2.497)
+'follower' speed = 18.144452584042064
+Current/target headway: 2.497/-1.0
+Time 56.9: Gap 'follower'->'leader' = 45.456 (headway=2.516)
+'follower' speed = 18.068835239364677
+Current/target headway: 2.516/-1.0
+Time 57.0: Gap 'follower'->'leader' = 45.613 (headway=2.534)
+'follower' speed = 17.996879382431086
+Current/target headway: 2.534/-1.0
+Time 57.1: Gap 'follower'->'leader' = 45.776 (headway=2.553)
+'follower' speed = 17.92860806836646
+Current/target headway: 2.553/-1.0
+Time 57.2: Gap 'follower'->'leader' = 45.947 (headway=2.572)
+'follower' speed = 17.86401139647354
+Current/target headway: 2.572/-1.0
+Time 57.3: Gap 'follower'->'leader' = 46.123 (headway=2.591)
+'follower' speed = 17.80305156313091
+Current/target headway: 2.591/-1.0
+Time 57.4: Gap 'follower'->'leader' = 46.306 (headway=2.609)
+'follower' speed = 17.745667375331305
+Current/target headway: 2.609/-1.0
+Time 57.5: Gap 'follower'->'leader' = 46.494 (headway=2.628)
+'follower' speed = 17.691778270151765
+Current/target headway: 2.628/-1.0
+Time 57.6: Gap 'follower'->'leader' = 46.687 (headway=2.646)
+'follower' speed = 17.641287882564708
+Current/target headway: 2.646/-1.0
+Time 57.7: Gap 'follower'->'leader' = 46.886 (headway=2.665)
+'follower' speed = 17.594087201211774
+Current/target headway: 2.665/-1.0
+Time 57.8: Gap 'follower'->'leader' = 47.088 (headway=2.683)
+'follower' speed = 17.55005734907893
+Current/target headway: 2.683/-1.0
+Time 57.9: Gap 'follower'->'leader' = 47.295 (headway=2.701)
+'follower' speed = 17.509072023437344
+Current/target headway: 2.701/-1.0
+Time 58.0: Gap 'follower'->'leader' = 47.506 (headway=2.719)
+'follower' speed = 17.47099962695409
+Current/target headway: 2.719/-1.0
+Time 58.1: Gap 'follower'->'leader' = 47.721 (headway=2.737)
+'follower' speed = 17.435705119532454
+Current/target headway: 2.737/-1.0
+Time 58.2: Gap 'follower'->'leader' = 47.939 (headway=2.755)
+'follower' speed = 17.403051618214633
+Current/target headway: 2.755/-1.0
+Time 58.3: Gap 'follower'->'leader' = 48.160 (headway=2.772)
+'follower' speed = 17.37290177036998
+Current/target headway: 2.772/-1.0
+Time 58.4: Gap 'follower'->'leader' = 48.384 (headway=2.790)
+'follower' speed = 17.345118923399085
+Current/target headway: 2.790/-1.0
+Time 58.5: Gap 'follower'->'leader' = 48.611 (headway=2.807)
+'follower' speed = 17.319568112305845
+Current/target headway: 2.807/-1.0
+Time 58.6: Gap 'follower'->'leader' = 48.840 (headway=2.824)
+'follower' speed = 17.29611688472435
+Current/target headway: 2.824/-1.0
+Time 58.7: Gap 'follower'->'leader' = 49.072 (headway=2.841)
+'follower' speed = 17.27463598133166
+Current/target headway: 2.841/-1.0
+Time 58.8: Gap 'follower'->'leader' = 49.305 (headway=2.857)
+'follower' speed = 17.254999888028344
+Current/target headway: 2.857/-1.0
+Time 58.9: Gap 'follower'->'leader' = 49.541 (headway=2.874)
+'follower' speed = 17.237087274822137
+Current/target headway: 2.874/-1.0
+Time 59.0: Gap 'follower'->'leader' = 49.778 (headway=2.891)
+'follower' speed = 17.220781335002435
+Current/target headway: 2.891/-1.0
+Time 59.1: Gap 'follower'->'leader' = 50.017 (headway=2.907)
+'follower' speed = 17.205970036940304
+Current/target headway: 2.907/-1.0
+Time 59.2: Gap 'follower'->'leader' = 50.257 (headway=2.923)
+'follower' speed = 17.19254629968619
+Current/target headway: 2.923/-1.0
+Time 59.3: Gap 'follower'->'leader' = 50.498 (headway=2.939)
+'follower' speed = 17.180408102460973
+Current/target headway: 2.939/-1.0
+Time 59.4: Gap 'follower'->'leader' = 50.740 (headway=2.955)
+'follower' speed = 17.1694585371413
+Current/target headway: 2.955/-1.0
+Time 59.5: Gap 'follower'->'leader' = 50.984 (headway=2.971)
+'follower' speed = 17.159605811922543
+Current/target headway: 2.971/-1.0
+Time 59.6: Gap 'follower'->'leader' = 51.229 (headway=2.987)
+'follower' speed = 17.150763213498422
+Current/target headway: 2.987/-1.0
+Time 59.7: Gap 'follower'->'leader' = 51.474 (headway=3.003)
+'follower' speed = 17.142849034320484
+Current/target headway: 3.003/-1.0
+Time 59.8: Gap 'follower'->'leader' = 51.720 (headway=3.018)
+'follower' speed = 17.135786470789515
+Current/target headway: 3.018/-1.0
+Time 59.9: Gap 'follower'->'leader' = 51.967 (headway=3.034)
+'follower' speed = 17.129503497580327
+Current/target headway: 3.034/-1.0
+Time 60.0: Gap 'follower'->'leader' = 52.214 (headway=3.049)
+'follower' speed = 17.123932722707227
+Current/target headway: 3.049/-1.0
+Time 60.1: Gap 'follower'->'leader' = 52.462 (headway=3.065)
+'follower' speed = 17.119011227396317
+Current/target headway: 3.065/-1.0
+Time 60.2: Gap 'follower'->'leader' = 52.710 (headway=3.080)
+'follower' speed = 17.11468039433856
+Current/target headway: 3.080/-1.0
+Time 60.3: Gap 'follower'->'leader' = 52.959 (headway=3.095)
+'follower' speed = 17.110885727451173
+Current/target headway: 3.095/-1.0
+Time 60.4: Gap 'follower'->'leader' = 53.208 (headway=3.110)
+'follower' speed = 17.10757666587082
+Current/target headway: 3.110/-1.0
+Time 60.5: Gap 'follower'->'leader' = 53.457 (headway=3.125)
+'follower' speed = 17.104706394537207
+Current/target headway: 3.125/-1.0
+Time 60.6: Gap 'follower'->'leader' = 53.707 (headway=3.140)
+'follower' speed = 17.102231653396966
+Current/target headway: 3.140/-1.0
+Time 60.7: Gap 'follower'->'leader' = 53.957 (headway=3.155)
+'follower' speed = 17.100112546962436
+Current/target headway: 3.155/-1.0
+Time 60.8: Gap 'follower'->'leader' = 54.207 (headway=3.170)
+'follower' speed = 17.098312355695306
+Current/target headway: 3.170/-1.0
+Time 60.9: Gap 'follower'->'leader' = 54.457 (headway=3.185)
+'follower' speed = 17.09679735044865
+Current/target headway: 3.185/-1.0
+Time 61.0: Gap 'follower'->'leader' = 54.708 (headway=3.200)
+'follower' speed = 17.09553661099023
+Current/target headway: 3.200/-1.0
+Time 61.1: Gap 'follower'->'leader' = 54.958 (headway=3.215)
+'follower' speed = 17.094501849442953
+Current/target headway: 3.215/-1.0
+Time 61.2: Gap 'follower'->'leader' = 55.209 (headway=3.230)
+'follower' speed = 17.093667239312847
+Current/target headway: 3.230/-1.0
+Time 61.3: Gap 'follower'->'leader' = 55.459 (headway=3.245)
+'follower' speed = 17.093009250629077
+Current/target headway: 3.245/-1.0
+Time 61.4: Gap 'follower'->'leader' = 55.710 (headway=3.259)
+'follower' speed = 17.092506491592427
+Current/target headway: 3.259/-1.0
+Time 61.5: Gap 'follower'->'leader' = 55.961 (headway=3.274)
+'follower' speed = 17.092139557016854
+Current/target headway: 3.274/-1.0
+Time 61.6: Gap 'follower'->'leader' = 56.212 (headway=3.289)
+'follower' speed = 17.09189088375129
+Current/target headway: 3.289/-1.0
+Time 61.7: Gap 'follower'->'leader' = 56.462 (headway=3.303)
+'follower' speed = 17.091744613184957
+Current/target headway: 3.303/-1.0
+Time 61.8: Gap 'follower'->'leader' = 56.713 (headway=3.318)
+'follower' speed = 17.091686460867017
+Current/target headway: 3.318/-1.0
+Time 61.9: Gap 'follower'->'leader' = 56.964 (headway=3.333)
+'follower' speed = 17.091703593209964
+Current/target headway: 3.333/-1.0
+Time 62.0: Gap 'follower'->'leader' = 57.215 (headway=3.348)
+'follower' speed = 17.09178451119403
+Current/target headway: 3.348/-1.0
+Time 62.1: Gap 'follower'->'leader' = 57.466 (headway=3.362)
+'follower' speed = 17.09191894094639
+Current/target headway: 3.362/-1.0
+Time 62.2: Gap 'follower'->'leader' = 57.717 (headway=3.377)
+'follower' speed = 17.092097731032947
+Current/target headway: 3.377/-1.0
+Time 62.3: Gap 'follower'->'leader' = 57.967 (headway=3.391)
+'follower' speed = 17.092312756271376
+Current/target headway: 3.391/-1.0
+Time 62.4: Gap 'follower'->'leader' = 58.218 (headway=3.406)
+'follower' speed = 17.09255682785065
+Current/target headway: 3.406/-1.0
+Time 62.5: Gap 'follower'->'leader' = 58.469 (headway=3.421)
+'follower' speed = 17.092823609524373
+Current/target headway: 3.421/-1.0
+Time 62.6: Gap 'follower'->'leader' = 58.720 (headway=3.435)
+'follower' speed = 17.093107539631703
+Current/target headway: 3.435/-1.0
+Time 62.7: Gap 'follower'->'leader' = 58.970 (headway=3.450)
+'follower' speed = 17.09340375869018
+Current/target headway: 3.450/-1.0
+Time 62.8: Gap 'follower'->'leader' = 59.221 (headway=3.464)
+'follower' speed = 17.09370804229883
+Current/target headway: 3.464/-1.0
+Time 62.9: Gap 'follower'->'leader' = 59.471 (headway=3.479)
+'follower' speed = 17.094016739086868
+Current/target headway: 3.479/-1.0
+Time 63.0: Gap 'follower'->'leader' = 59.722 (headway=3.494)
+'follower' speed = 17.094326713442957
+Current/target headway: 3.494/-1.0
+Time 63.1: Gap 'follower'->'leader' = 59.973 (headway=3.508)
+'follower' speed = 17.09463529276168
+Current/target headway: 3.508/-1.0
+Time 63.2: Gap 'follower'->'leader' = 60.223 (headway=3.523)
+'follower' speed = 17.094940218947528
+Current/target headway: 3.523/-1.0
+Time 63.3: Gap 'follower'->'leader' = 60.474 (headway=3.537)
+'follower' speed = 17.095239603921822
+Current/target headway: 3.537/-1.0
+Time 63.4: Gap 'follower'->'leader' = 60.724 (headway=3.552)
+'follower' speed = 17.09553188888442
+Current/target headway: 3.552/-1.0
+Time 63.5: Gap 'follower'->'leader' = 60.974 (headway=3.567)
+'follower' speed = 17.095815807089387
+Current/target headway: 3.567/-1.0
+Time 63.6: Gap 'follower'->'leader' = 61.225 (headway=3.581)
+'follower' speed = 17.09609034990214
+Current/target headway: 3.581/-1.0
+Time 63.7: Gap 'follower'->'leader' = 61.475 (headway=3.596)
+'follower' speed = 17.096354735914375
+Current/target headway: 3.596/-1.0
+Time 63.8: Gap 'follower'->'leader' = 61.726 (headway=3.610)
+'follower' speed = 17.09660838290233
+Current/target headway: 3.610/-1.0
+Time 63.9: Gap 'follower'->'leader' = 61.976 (headway=3.625)
+'follower' speed = 17.096850882423638
+Current/target headway: 3.625/-1.0
+Time 64.0: Gap 'follower'->'leader' = 62.226 (headway=3.640)
+'follower' speed = 17.0970819768578
+Current/target headway: 3.640/-1.0
+Time 64.1: Gap 'follower'->'leader' = 62.477 (headway=3.654)
+'follower' speed = 17.097301538705096
+Current/target headway: 3.654/-1.0
+Time 64.2: Gap 'follower'->'leader' = 62.727 (headway=3.669)
+'follower' speed = 17.097509551968756
+Current/target headway: 3.669/-1.0
+Time 64.3: Gap 'follower'->'leader' = 62.977 (headway=3.683)
+'follower' speed = 17.097706095454914
+Current/target headway: 3.683/-1.0
+Time 64.4: Gap 'follower'->'leader' = 63.227 (headway=3.698)
+'follower' speed = 17.0978913278345
+Current/target headway: 3.698/-1.0
+Time 64.5: Gap 'follower'->'leader' = 63.477 (headway=3.713)
+'follower' speed = 17.09806547432068
+Current/target headway: 3.713/-1.0
+Time 64.6: Gap 'follower'->'leader' = 63.728 (headway=3.727)
+'follower' speed = 17.0982288148246
+Current/target headway: 3.727/-1.0
+Time 64.7: Gap 'follower'->'leader' = 63.978 (headway=3.742)
+'follower' speed = 17.098381673461073
+Current/target headway: 3.742/-1.0
+Time 64.8: Gap 'follower'->'leader' = 64.228 (headway=3.756)
+'follower' speed = 17.098524409284437
+Current/target headway: 3.756/-1.0
+Time 64.9: Gap 'follower'->'leader' = 64.478 (headway=3.771)
+'follower' speed = 17.098657408143062
+Current/target headway: 3.771/-1.0
+Time 65.0: Gap 'follower'->'leader' = 64.728 (headway=3.786)
+'follower' speed = 17.098781075548796
+Current/target headway: 3.786/-1.0
+Time 65.1: Gap 'follower'->'leader' = 64.978 (headway=3.800)
+'follower' speed = 17.098895830465267
+Current/target headway: 3.800/-1.0
+Time 65.2: Gap 'follower'->'leader' = 65.228 (headway=3.815)
+'follower' speed = 17.099002099926018
+Current/target headway: 3.815/-1.0
+Time 65.3: Gap 'follower'->'leader' = 65.479 (headway=3.829)
+'follower' speed = 17.099100314400346
+Current/target headway: 3.829/-1.0
+Time 65.4: Gap 'follower'->'leader' = 65.729 (headway=3.844)
+'follower' speed = 17.099190903831
+Current/target headway: 3.844/-1.0
+Time 65.5: Gap 'follower'->'leader' = 65.979 (headway=3.859)
+'follower' speed = 17.099274294274135
+Current/target headway: 3.859/-1.0
+Time 65.6: Gap 'follower'->'leader' = 66.229 (headway=3.873)
+'follower' speed = 17.099350905077397
+Current/target headway: 3.873/-1.0
+Time 65.7: Gap 'follower'->'leader' = 66.479 (headway=3.888)
+'follower' speed = 17.09942114653761
+Current/target headway: 3.888/-1.0
+Time 65.8: Gap 'follower'->'leader' = 66.729 (headway=3.902)
+'follower' speed = 17.09948541798434
+Current/target headway: 3.902/-1.0
+Time 65.9: Gap 'follower'->'leader' = 66.979 (headway=3.917)
+'follower' speed = 17.099544106240458
+Current/target headway: 3.917/-1.0
+Time 66.0: Gap 'follower'->'leader' = 67.229 (headway=3.932)
+'follower' speed = 17.099597584415037
+Current/target headway: 3.932/-1.0
+Time 66.1: Gap 'follower'->'leader' = 67.479 (headway=3.946)
+'follower' speed = 17.099646210988183
+Current/target headway: 3.946/-1.0
+Time 66.2: Gap 'follower'->'leader' = 67.729 (headway=3.961)
+'follower' speed = 17.099690329151002
+Current/target headway: 3.961/-1.0
+Time 66.3: Gap 'follower'->'leader' = 67.979 (headway=3.975)
+'follower' speed = 17.09973026636748
+Current/target headway: 3.975/-1.0
+Time 66.4: Gap 'follower'->'leader' = 68.229 (headway=3.990)
+'follower' speed = 17.099766334128304
+Current/target headway: 3.990/-1.0
+Time 66.5: Gap 'follower'->'leader' = 68.479 (headway=4.005)
+'follower' speed = 17.099798827869638
+Current/target headway: 4.005/-1.0
+Time 66.6: Gap 'follower'->'leader' = 68.729 (headway=4.019)
+'follower' speed = 17.09982802703257
+Current/target headway: 4.019/-1.0
+Time 66.7: Gap 'follower'->'leader' = 68.979 (headway=4.034)
+'follower' speed = 17.09985419524157
+Current/target headway: 4.034/-1.0
+Time 66.8: Gap 'follower'->'leader' = 69.229 (headway=4.049)
+'follower' speed = 17.09987758058253
+Current/target headway: 4.049/-1.0
+Time 66.9: Gap 'follower'->'leader' = 69.479 (headway=4.063)
+'follower' speed = 17.09989841596317
+Current/target headway: 4.063/-1.0
+Time 67.0: Gap 'follower'->'leader' = 69.729 (headway=4.078)
+'follower' speed = 17.099916919540462
+Current/target headway: 4.078/-1.0
+Time 67.1: Gap 'follower'->'leader' = 69.979 (headway=4.092)
+'follower' speed = 17.09993329520154
+Current/target headway: 4.092/-1.0
+Time 67.2: Gap 'follower'->'leader' = 70.229 (headway=4.107)
+'follower' speed = 17.099947733086236
+Current/target headway: 4.107/-1.0
+Time 67.3: Gap 'follower'->'leader' = 70.479 (headway=4.122)
+'follower' speed = 17.099960410140678
+Current/target headway: 4.122/-1.0
+Time 67.4: Gap 'follower'->'leader' = 70.729 (headway=4.136)
+'follower' speed = 17.09997149069294
+Current/target headway: 4.136/-1.0
+Time 67.5: Gap 'follower'->'leader' = 70.979 (headway=4.151)
+'follower' speed = 17.09998112704271
+Current/target headway: 4.151/-1.0
+Time 67.6: Gap 'follower'->'leader' = 71.229 (headway=4.165)
+'follower' speed = 17.09998946005823
+Current/target headway: 4.165/-1.0
+Time 67.7: Gap 'follower'->'leader' = 71.479 (headway=4.180)
+'follower' speed = 17.099996619774576
+Current/target headway: 4.180/-1.0
+Time 67.8: Gap 'follower'->'leader' = 71.729 (headway=4.195)
+'follower' speed = 17.100002725988332
+Current/target headway: 4.195/-1.0
+Time 67.9: Gap 'follower'->'leader' = 71.979 (headway=4.209)
+'follower' speed = 17.100007888844402
+Current/target headway: 4.209/-1.0
+Time 68.0: Gap 'follower'->'leader' = 72.229 (headway=4.224)
+'follower' speed = 17.100012209411478
+Current/target headway: 4.224/-1.0
+Time 68.1: Gap 'follower'->'leader' = 72.479 (headway=4.239)
+'follower' speed = 17.100015780243275
+Current/target headway: 4.239/-1.0
+Time 68.2: Gap 'follower'->'leader' = 72.729 (headway=4.253)
+'follower' speed = 17.100018685923192
+Current/target headway: 4.253/-1.0
+Time 68.3: Gap 'follower'->'leader' = 72.979 (headway=4.268)
+'follower' speed = 17.10002100359051
+Current/target headway: 4.268/-1.0
+Time 68.4: Gap 'follower'->'leader' = 73.229 (headway=4.282)
+'follower' speed = 17.10002280344675
+Current/target headway: 4.282/-1.0
+Time 68.5: Gap 'follower'->'leader' = 73.479 (headway=4.297)
+'follower' speed = 17.100024149241108
+Current/target headway: 4.297/-1.0
+Time 68.6: Gap 'follower'->'leader' = 73.729 (headway=4.312)
+'follower' speed = 17.100025098734253
+Current/target headway: 4.312/-1.0
+Time 68.7: Gap 'follower'->'leader' = 73.979 (headway=4.326)
+'follower' speed = 17.100025704140016
+Current/target headway: 4.326/-1.0
+Time 68.8: Gap 'follower'->'leader' = 74.229 (headway=4.341)
+'follower' speed = 17.10002601254482
+Current/target headway: 4.341/-1.0
+Time 68.9: Gap 'follower'->'leader' = 74.479 (headway=4.356)
+'follower' speed = 17.10002606630481
+Current/target headway: 4.356/-1.0
+Time 69.0: Gap 'follower'->'leader' = 74.729 (headway=4.370)
+'follower' speed = 17.100025903420903
+Current/target headway: 4.370/-1.0
+Time 69.1: Gap 'follower'->'leader' = 74.979 (headway=4.385)
+'follower' speed = 17.100025557892064
+Current/target headway: 4.385/-1.0
+Time 69.2: Gap 'follower'->'leader' = 75.229 (headway=4.399)
+'follower' speed = 17.1000250600473
+Current/target headway: 4.399/-1.0
+Time 69.3: Gap 'follower'->'leader' = 75.479 (headway=4.414)
+'follower' speed = 17.100024436856888
+Current/target headway: 4.414/-1.0
+Time 69.4: Gap 'follower'->'leader' = 75.729 (headway=4.429)
+'follower' speed = 17.100023712223514
+Current/target headway: 4.429/-1.0
+Time 69.5: Gap 'follower'->'leader' = 75.979 (headway=4.443)
+'follower' speed = 17.10002290725402
+Current/target headway: 4.443/-1.0
+Time 69.6: Gap 'follower'->'leader' = 76.229 (headway=4.458)
+'follower' speed = 17.10002204051249
+Current/target headway: 4.458/-1.0
+Time 69.7: Gap 'follower'->'leader' = 76.479 (headway=4.472)
+'follower' speed = 17.100021128255488
+Current/target headway: 4.472/-1.0
+Time 69.8: Gap 'follower'->'leader' = 76.729 (headway=4.487)
+'follower' speed = 17.10002018465027
+Current/target headway: 4.487/-1.0
+Time 69.9: Gap 'follower'->'leader' = 76.979 (headway=4.502)
+'follower' speed = 17.100019221976744
+Current/target headway: 4.502/-1.0
+Time 70.0: Gap 'follower'->'leader' = 77.229 (headway=4.516)
+'follower' speed = 17.10001825081409
+Current/target headway: 4.516/-1.0
+Time 70.1: Gap 'follower'->'leader' = 77.479 (headway=4.531)
+'follower' speed = 17.100017280212793
+Current/target headway: 4.531/-1.0
+Time 70.2: Gap 'follower'->'leader' = 77.729 (headway=4.546)
+'follower' speed = 17.100016317852937
+Current/target headway: 4.546/-1.0
+Time 70.3: Gap 'follower'->'leader' = 77.979 (headway=4.560)
+'follower' speed = 17.100015370189606
+Current/target headway: 4.560/-1.0
+Time 70.4: Gap 'follower'->'leader' = 78.229 (headway=4.575)
+'follower' speed = 17.100014442586108
+Current/target headway: 4.575/-1.0
+Time 70.5: Gap 'follower'->'leader' = 78.479 (headway=4.589)
+'follower' speed = 17.10001353943584
+Current/target headway: 4.589/-1.0
+Time 70.6: Gap 'follower'->'leader' = 78.729 (headway=4.604)
+'follower' speed = 17.10001266427352
+Current/target headway: 4.604/-1.0
+Time 70.7: Gap 'follower'->'leader' = 78.979 (headway=4.619)
+'follower' speed = 17.10001181987651
+Current/target headway: 4.619/-1.0
+Time 70.8: Gap 'follower'->'leader' = 79.229 (headway=4.633)
+'follower' speed = 17.100011008356883
+Current/target headway: 4.633/-1.0
+Time 70.9: Gap 'follower'->'leader' = 79.479 (headway=4.648)
+'follower' speed = 17.10001023124494
+Current/target headway: 4.648/-1.0
+Time 71.0: Gap 'follower'->'leader' = 79.729 (headway=4.663)
+'follower' speed = 17.100009489564773
+Current/target headway: 4.663/-1.0
+Time 71.1: Gap 'follower'->'leader' = 79.979 (headway=4.677)
+'follower' speed = 17.100008783902453
+Current/target headway: 4.677/-1.0
+Time 71.2: Gap 'follower'->'leader' = 80.229 (headway=4.692)
+'follower' speed = 17.10000811446747
+Current/target headway: 4.692/-1.0
+Time 71.3: Gap 'follower'->'leader' = 80.479 (headway=4.706)
+'follower' speed = 17.100007481147873
+Current/target headway: 4.706/-1.0
+Time 71.4: Gap 'follower'->'leader' = 80.729 (headway=4.721)
+'follower' speed = 17.100006883559683
+Current/target headway: 4.721/-1.0
+Time 71.5: Gap 'follower'->'leader' = 80.979 (headway=4.736)
+'follower' speed = 17.100006321091023
+Current/target headway: 4.736/-1.0
+Time 71.6: Gap 'follower'->'leader' = 81.229 (headway=4.750)
+'follower' speed = 17.100005792941403
+Current/target headway: 4.750/-1.0
+Time 71.7: Gap 'follower'->'leader' = 81.479 (headway=4.765)
+'follower' speed = 17.100005298156592
+Current/target headway: 4.765/-1.0
+Time 71.8: Gap 'follower'->'leader' = 81.729 (headway=4.779)
+'follower' speed = 17.10000483565945
+Current/target headway: 4.779/-1.0
+Time 71.9: Gap 'follower'->'leader' = 81.979 (headway=4.794)
+'follower' speed = 17.1000044042771
+Current/target headway: 4.794/-1.0
+Time 72.0: Gap 'follower'->'leader' = 82.229 (headway=4.809)
+'follower' speed = 17.10000400276476
+Current/target headway: 4.809/-1.0
+Time 72.1: Gap 'follower'->'leader' = 82.479 (headway=4.823)
+'follower' speed = 17.10000362982654
+Current/target headway: 4.823/-1.0
+Time 72.2: Gap 'follower'->'leader' = 82.729 (headway=4.838)
+'follower' speed = 17.10000328413354
+Current/target headway: 4.838/-1.0
+Time 72.3: Gap 'follower'->'leader' = 82.979 (headway=4.853)
+'follower' speed = 17.100002964339456
+Current/target headway: 4.853/-1.0
+Time 72.4: Gap 'follower'->'leader' = 83.229 (headway=4.867)
+'follower' speed = 17.100002669093982
+Current/target headway: 4.867/-1.0
+Time 72.5: Gap 'follower'->'leader' = 83.479 (headway=4.882)
+'follower' speed = 17.1000023970542
+Current/target headway: 4.882/-1.0
+Time 72.6: Gap 'follower'->'leader' = 83.729 (headway=4.896)
+'follower' speed = 17.10000214689423
+Current/target headway: 4.896/-1.0
+Time 72.7: Gap 'follower'->'leader' = 83.979 (headway=4.911)
+'follower' speed = 17.100001917313243
+Current/target headway: 4.911/-1.0
+Time 72.8: Gap 'follower'->'leader' = 84.229 (headway=4.926)
+'follower' speed = 17.10000170704211
+Current/target headway: 4.926/-1.0
+Time 72.9: Gap 'follower'->'leader' = 84.479 (headway=4.940)
+'follower' speed = 17.10000151484876
+Current/target headway: 4.940/-1.0
+Time 73.0: Gap 'follower'->'leader' = 84.729 (headway=4.955)
+'follower' speed = 17.100001339542438
+Current/target headway: 4.955/-1.0
+Time 73.1: Gap 'follower'->'leader' = 84.979 (headway=4.970)
+'follower' speed = 17.100001179977006
+Current/target headway: 4.970/-1.0
+Time 73.2: Gap 'follower'->'leader' = 85.229 (headway=4.984)
+'follower' speed = 17.10000103505337
+Current/target headway: 4.984/-1.0
+Time 73.3: Gap 'follower'->'leader' = 85.479 (headway=4.999)
+'follower' speed = 17.10000090372118
+Current/target headway: 4.999/-1.0
+Time 73.4: Gap 'follower'->'leader' = 85.729 (headway=5.013)
+'follower' speed = 17.100000784979876
+Current/target headway: 5.013/-1.0
+Time 73.5: Gap 'follower'->'leader' = 85.979 (headway=5.028)
+'follower' speed = 17.100000677879166
+Current/target headway: 5.028/-1.0
+Time 73.6: Gap 'follower'->'leader' = 86.229 (headway=5.043)
+'follower' speed = 17.10000058151906
+Current/target headway: 5.043/-1.0
+Time 73.7: Gap 'follower'->'leader' = 86.479 (headway=5.057)
+'follower' speed = 17.100000495049464
+Current/target headway: 5.057/-1.0
+Time 73.8: Gap 'follower'->'leader' = 86.729 (headway=5.072)
+'follower' speed = 17.100000417669463
+Current/target headway: 5.072/-1.0
+Time 73.9: Gap 'follower'->'leader' = 86.979 (headway=5.086)
+'follower' speed = 17.1000003486263
+Current/target headway: 5.086/-1.0
+Time 74.0: Gap 'follower'->'leader' = 87.229 (headway=5.101)
+'follower' speed = 17.10000028721412
+Current/target headway: 5.101/-1.0
+Time 74.1: Gap 'follower'->'leader' = 87.479 (headway=5.116)
+'follower' speed = 17.100000232772548
+Current/target headway: 5.116/-1.0
+Time 74.2: Gap 'follower'->'leader' = 87.729 (headway=5.130)
+'follower' speed = 17.10000018468512
+Current/target headway: 5.130/-1.0
+Time 74.3: Gap 'follower'->'leader' = 87.979 (headway=5.145)
+'follower' speed = 17.10000014237756
+Current/target headway: 5.145/-1.0
+Time 74.4: Gap 'follower'->'leader' = 88.229 (headway=5.160)
+'follower' speed = 17.100000105316035
+Current/target headway: 5.160/-1.0
+Time 74.5: Gap 'follower'->'leader' = 88.479 (headway=5.174)
+'follower' speed = 17.100000073005305
+Current/target headway: 5.174/-1.0
+Time 74.6: Gap 'follower'->'leader' = 88.729 (headway=5.189)
+'follower' speed = 17.100000044986867
+Current/target headway: 5.189/-1.0
+Time 74.7: Gap 'follower'->'leader' = 88.979 (headway=5.203)
+'follower' speed = 17.10000002083708
+Current/target headway: 5.203/-1.0
+Time 74.8: Gap 'follower'->'leader' = 89.229 (headway=5.218)
+'follower' speed = 17.100000000165277
+Current/target headway: 5.218/-1.0
+Time 74.9: Gap 'follower'->'leader' = 89.479 (headway=5.233)
+'follower' speed = 17.09999998261194
+Current/target headway: 5.233/-1.0
+Time 75.0: Gap 'follower'->'leader' = 89.729 (headway=5.247)
+'follower' speed = 17.099999967846855
+Current/target headway: 5.247/-1.0
+Time 75.1: Gap 'follower'->'leader' = 89.979 (headway=5.262)
+'follower' speed = 17.09999995556735
+Current/target headway: 5.262/-1.0
+Time 75.2: Gap 'follower'->'leader' = 90.229 (headway=5.277)
+'follower' speed = 17.099999945496528
+Current/target headway: 5.277/-1.0
+Time 75.3: Gap 'follower'->'leader' = 90.479 (headway=5.291)
+'follower' speed = 17.09999993738163
+Current/target headway: 5.291/-1.0
+Time 75.4: Gap 'follower'->'leader' = 90.729 (headway=5.306)
+'follower' speed = 17.09999993099238
+Current/target headway: 5.306/-1.0
+Time 75.5: Gap 'follower'->'leader' = 90.979 (headway=5.320)
+'follower' speed = 17.09999992611946
+Current/target headway: 5.320/-1.0
+Time 75.6: Gap 'follower'->'leader' = 91.229 (headway=5.335)
+'follower' speed = 17.099999922573005
+Current/target headway: 5.335/-1.0
+Time 75.7: Gap 'follower'->'leader' = 91.479 (headway=5.350)
+'follower' speed = 17.099999920181197
+Current/target headway: 5.350/-1.0
+Time 75.8: Gap 'follower'->'leader' = 91.729 (headway=5.364)
+'follower' speed = 17.099999918788917
+Current/target headway: 5.364/-1.0
+Time 75.9: Gap 'follower'->'leader' = 91.979 (headway=5.379)
+'follower' speed = 17.099999918256454
+Current/target headway: 5.379/-1.0
+Time 76.0: Gap 'follower'->'leader' = 92.229 (headway=5.394)
+'follower' speed = 17.099999918458302
+Current/target headway: 5.394/-1.0
+Time 76.1: Gap 'follower'->'leader' = 92.479 (headway=5.408)
+'follower' speed = 17.099999919282023
+Current/target headway: 5.408/-1.0
+Time 76.2: Gap 'follower'->'leader' = 92.729 (headway=5.423)
+'follower' speed = 17.099999920627177
+Current/target headway: 5.423/-1.0
+Time 76.3: Gap 'follower'->'leader' = 92.979 (headway=5.437)
+'follower' speed = 17.099999922404304
+Current/target headway: 5.437/-1.0
+Time 76.4: Gap 'follower'->'leader' = 93.229 (headway=5.452)
+'follower' speed = 17.099999924533996
+Current/target headway: 5.452/-1.0
+Time 76.5: Gap 'follower'->'leader' = 93.479 (headway=5.467)
+'follower' speed = 17.099999926946005
+Current/target headway: 5.467/-1.0
+Time 76.6: Gap 'follower'->'leader' = 93.729 (headway=5.481)
+'follower' speed = 17.099999929578427
+Current/target headway: 5.481/-1.0
+Time 76.7: Gap 'follower'->'leader' = 93.979 (headway=5.496)
+'follower' speed = 17.099999932376942
+Current/target headway: 5.496/-1.0
+Time 76.8: Gap 'follower'->'leader' = 94.229 (headway=5.510)
+'follower' speed = 17.099999935294093
+Current/target headway: 5.510/-1.0
+Time 76.9: Gap 'follower'->'leader' = 94.479 (headway=5.525)
+'follower' speed = 17.099999938288633
+Current/target headway: 5.525/-1.0
+Time 77.0: Gap 'follower'->'leader' = 94.729 (headway=5.540)
+'follower' speed = 17.09999994132493
+Current/target headway: 5.540/-1.0
+Time 77.1: Gap 'follower'->'leader' = 94.979 (headway=5.554)
+'follower' speed = 17.099999944372396
+Current/target headway: 5.554/-1.0
+Time 77.2: Gap 'follower'->'leader' = 95.229 (headway=5.569)
+'follower' speed = 17.09999994740496
+Current/target headway: 5.569/-1.0
+Time 77.3: Gap 'follower'->'leader' = 95.479 (headway=5.584)
+'follower' speed = 17.09999995040061
+Current/target headway: 5.584/-1.0
+Time 77.4: Gap 'follower'->'leader' = 95.729 (headway=5.598)
+'follower' speed = 17.099999953340955
+Current/target headway: 5.598/-1.0
+Time 77.5: Gap 'follower'->'leader' = 95.979 (headway=5.613)
+'follower' speed = 17.099999956210816
+Current/target headway: 5.613/-1.0
+Time 77.6: Gap 'follower'->'leader' = 96.229 (headway=5.627)
+'follower' speed = 17.099999958997877
+Current/target headway: 5.627/-1.0
+Time 77.7: Gap 'follower'->'leader' = 96.479 (headway=5.642)
+'follower' speed = 17.099999961692333
+Current/target headway: 5.642/-1.0
+Time 77.8: Gap 'follower'->'leader' = 96.729 (headway=5.657)
+'follower' speed = 17.099999964286607
+Current/target headway: 5.657/-1.0
+Time 77.9: Gap 'follower'->'leader' = 96.979 (headway=5.671)
+'follower' speed = 17.099999966775062
+Current/target headway: 5.671/-1.0
+Time 78.0: Gap 'follower'->'leader' = 97.229 (headway=5.686)
+'follower' speed = 17.09999996915376
+Current/target headway: 5.686/-1.0
+Time 78.1: Gap 'follower'->'leader' = 97.479 (headway=5.701)
+'follower' speed = 17.099999971420235
+Current/target headway: 5.701/-1.0
+Time 78.2: Gap 'follower'->'leader' = 97.729 (headway=5.715)
+'follower' speed = 17.099999973573293
+Current/target headway: 5.715/-1.0
+Time 78.3: Gap 'follower'->'leader' = 97.979 (headway=5.730)
+'follower' speed = 17.09999997561283
+Current/target headway: 5.730/-1.0
+Time 78.4: Gap 'follower'->'leader' = 98.229 (headway=5.744)
+'follower' speed = 17.099999977539657
+Current/target headway: 5.744/-1.0
+Time 78.5: Gap 'follower'->'leader' = 98.479 (headway=5.759)
+'follower' speed = 17.099999979355374
+Current/target headway: 5.759/-1.0
+Time 78.6: Gap 'follower'->'leader' = 98.729 (headway=5.774)
+'follower' speed = 17.099999981062222
+Current/target headway: 5.774/-1.0
+Time 78.7: Gap 'follower'->'leader' = 98.979 (headway=5.788)
+'follower' speed = 17.09999998266298
+Current/target headway: 5.788/-1.0
+Time 78.8: Gap 'follower'->'leader' = 99.229 (headway=5.803)
+'follower' speed = 17.09999998416085
+Current/target headway: 5.803/-1.0
+Time 78.9: Gap 'follower'->'leader' = 99.479 (headway=5.817)
+'follower' speed = 17.09999998555938
+Current/target headway: 5.817/-1.0
+Time 79.0: Gap 'follower'->'leader' = 99.729 (headway=5.832)
+'follower' speed = 17.099999986862368
+Current/target headway: 5.832/-1.0
+Time 79.1: Gap 'follower'->'leader' = 99.979 (headway=5.847)
+'follower' speed = 17.099999988073815
+Current/target headway: 5.847/-1.0
+Time 79.2: Gap 'follower'->'leader' = 100.229 (headway=5.861)
+'follower' speed = 17.099999989197844
+Current/target headway: 5.861/-1.0
+Time 79.3: Gap 'follower'->'leader' = 100.479 (headway=5.876)
+'follower' speed = 17.099999990238658
+Current/target headway: 5.876/-1.0
+Time 79.4: Gap 'follower'->'leader' = 100.729 (headway=5.891)
+'follower' speed = 17.09999999120048
+Current/target headway: 5.891/-1.0
+Time 79.5: Gap 'follower'->'leader' = 100.979 (headway=5.905)
+'follower' speed = 17.099999992087547
+Current/target headway: 5.905/-1.0
+Time 79.6: Gap 'follower'->'leader' = 101.229 (headway=5.920)
+'follower' speed = 17.09999999290404
+Current/target headway: 5.920/-1.0
+Time 79.7: Gap 'follower'->'leader' = 101.479 (headway=5.934)
+'follower' speed = 17.099999993654077
+Current/target headway: 5.934/-1.0
+Time 79.8: Gap 'follower'->'leader' = 101.729 (headway=5.949)
+'follower' speed = 17.099999994341687
+Current/target headway: 5.949/-1.0
+Time 79.9: Gap 'follower'->'leader' = 101.979 (headway=5.964)
+'follower' speed = 17.099999994970794
+Current/target headway: 5.964/-1.0
+Time 80.0: Gap 'follower'->'leader' = 102.229 (headway=5.978)
+'follower' speed = 17.099999995545193
+Current/target headway: 5.978/-1.0
+Time 80.1: Gap 'follower'->'leader' = 102.479 (headway=5.993)
+'follower' speed = 17.099999996068544
+Current/target headway: 5.993/-1.0
+Time 80.2: Gap 'follower'->'leader' = 102.729 (headway=6.008)
+'follower' speed = 17.099999996544366
+Current/target headway: 6.008/-1.0
+Time 80.3: Gap 'follower'->'leader' = 102.979 (headway=6.022)
+'follower' speed = 17.09999999697602
+Current/target headway: 6.022/-1.0
+Time 80.4: Gap 'follower'->'leader' = 103.229 (headway=6.037)
+'follower' speed = 17.099999997366726
+Current/target headway: 6.037/-1.0
+Time 80.5: Gap 'follower'->'leader' = 103.479 (headway=6.051)
+'follower' speed = 17.099999997719536
+Current/target headway: 6.051/-1.0
+Time 80.6: Gap 'follower'->'leader' = 103.729 (headway=6.066)
+'follower' speed = 17.099999998037347
+Current/target headway: 6.066/-1.0
+Time 80.7: Gap 'follower'->'leader' = 103.979 (headway=6.081)
+'follower' speed = 17.099999998322893
+Current/target headway: 6.081/-1.0
+Time 80.8: Gap 'follower'->'leader' = 104.229 (headway=6.095)
+'follower' speed = 17.099999998578763
+Current/target headway: 6.095/-1.0
+Time 80.9: Gap 'follower'->'leader' = 104.479 (headway=6.110)
+'follower' speed = 17.09999999880739
+Current/target headway: 6.110/-1.0
+Time 81.0: Gap 'follower'->'leader' = 104.729 (headway=6.125)
+'follower' speed = 17.099999999011057
+Current/target headway: 6.125/-1.0
+Time 81.1: Gap 'follower'->'leader' = 104.979 (headway=6.139)
+'follower' speed = 17.099999999191905
+Current/target headway: 6.139/-1.0
+Time 81.2: Gap 'follower'->'leader' = 105.229 (headway=6.154)
+'follower' speed = 17.09999999935193
+Current/target headway: 6.154/-1.0
+Time 81.3: Gap 'follower'->'leader' = 105.479 (headway=6.168)
+'follower' speed = 17.099999999492994
+Current/target headway: 6.168/-1.0
+Time 81.4: Gap 'follower'->'leader' = 105.729 (headway=6.183)
+'follower' speed = 17.099999999616823
+Current/target headway: 6.183/-1.0
+Time 81.5: Gap 'follower'->'leader' = 105.979 (headway=6.198)
+'follower' speed = 17.099999999725036
+Current/target headway: 6.198/-1.0
+Time 81.6: Gap 'follower'->'leader' = 106.229 (headway=6.212)
+'follower' speed = 17.09999999981912
+Current/target headway: 6.212/-1.0
+Time 81.7: Gap 'follower'->'leader' = 106.479 (headway=6.227)
+'follower' speed = 17.099999999900454
+Current/target headway: 6.227/-1.0
+Time 81.8: Gap 'follower'->'leader' = 106.729 (headway=6.241)
+'follower' speed = 17.09999999997032
+Current/target headway: 6.241/-1.0
+Time 81.9: Gap 'follower'->'leader' = 106.979 (headway=6.256)
+'follower' speed = 17.100000000029876
+Current/target headway: 6.256/-1.0
+Time 82.0: Gap 'follower'->'leader' = 107.229 (headway=6.271)
+'follower' speed = 17.100000000080207
+Current/target headway: 6.271/-1.0
+Time 82.1: Gap 'follower'->'leader' = 107.479 (headway=6.285)
+'follower' speed = 17.100000000122307
+Current/target headway: 6.285/-1.0
+Time 82.2: Gap 'follower'->'leader' = 107.729 (headway=6.300)
+'follower' speed = 17.100000000157074
+Current/target headway: 6.300/-1.0
+Time 82.3: Gap 'follower'->'leader' = 107.979 (headway=6.315)
+'follower' speed = 17.100000000185336
+Current/target headway: 6.315/-1.0
+Time 82.4: Gap 'follower'->'leader' = 108.229 (headway=6.329)
+'follower' speed = 17.100000000207856
+Current/target headway: 6.329/-1.0
+Time 82.5: Gap 'follower'->'leader' = 108.479 (headway=6.344)
+'follower' speed = 17.100000000225315
+Current/target headway: 6.344/-1.0
+Time 82.6: Gap 'follower'->'leader' = 108.729 (headway=6.358)
+'follower' speed = 17.10000000023834
+Current/target headway: 6.358/-1.0
+Time 82.7: Gap 'follower'->'leader' = 108.979 (headway=6.373)
+'follower' speed = 17.10000000024749
+Current/target headway: 6.373/-1.0
+Time 82.8: Gap 'follower'->'leader' = 109.229 (headway=6.388)
+'follower' speed = 17.10000000025329
+Current/target headway: 6.388/-1.0
+Time 82.9: Gap 'follower'->'leader' = 109.479 (headway=6.402)
+'follower' speed = 17.100000000256188
+Current/target headway: 6.402/-1.0
+Time 83.0: Gap 'follower'->'leader' = 109.729 (headway=6.417)
+'follower' speed = 17.1000000002566
+Current/target headway: 6.417/-1.0
+Time 83.1: Gap 'follower'->'leader' = 109.979 (headway=6.432)
+'follower' speed = 17.1000000002549
+Current/target headway: 6.432/-1.0
+Time 83.2: Gap 'follower'->'leader' = 110.229 (headway=6.446)
+'follower' speed = 17.10000000025142
+Current/target headway: 6.446/-1.0
+Time 83.3: Gap 'follower'->'leader' = 110.479 (headway=6.461)
+'follower' speed = 17.100000000246457
+Current/target headway: 6.461/-1.0
+Time 83.4: Gap 'follower'->'leader' = 110.729 (headway=6.475)
+'follower' speed = 17.10000000024027
+Current/target headway: 6.475/-1.0
+Time 83.5: Gap 'follower'->'leader' = 110.979 (headway=6.490)
+'follower' speed = 17.1000000002331
+Current/target headway: 6.490/-1.0
+Time 83.6: Gap 'follower'->'leader' = 111.229 (headway=6.505)
+'follower' speed = 17.100000000225144
+Current/target headway: 6.505/-1.0
+Time 83.7: Gap 'follower'->'leader' = 111.479 (headway=6.519)
+'follower' speed = 17.100000000216596
+Current/target headway: 6.519/-1.0
+Time 83.8: Gap 'follower'->'leader' = 111.729 (headway=6.534)
+'follower' speed = 17.100000000207608
+Current/target headway: 6.534/-1.0
+Time 83.9: Gap 'follower'->'leader' = 111.979 (headway=6.548)
+'follower' speed = 17.100000000198317
+Current/target headway: 6.548/-1.0
+Time 84.0: Gap 'follower'->'leader' = 112.229 (headway=6.563)
+'follower' speed = 17.10000000018885
+Current/target headway: 6.563/-1.0
+Time 84.1: Gap 'follower'->'leader' = 112.479 (headway=6.578)
+'follower' speed = 17.100000000179303
+Current/target headway: 6.578/-1.0
+Time 84.2: Gap 'follower'->'leader' = 112.729 (headway=6.592)
+'follower' speed = 17.10000000016976
+Current/target headway: 6.592/-1.0
+Time 84.3: Gap 'follower'->'leader' = 112.979 (headway=6.607)
+'follower' speed = 17.100000000160307
+Current/target headway: 6.607/-1.0
+Time 84.4: Gap 'follower'->'leader' = 113.229 (headway=6.622)
+'follower' speed = 17.100000000151
+Current/target headway: 6.622/-1.0
+Time 84.5: Gap 'follower'->'leader' = 113.479 (headway=6.636)
+'follower' speed = 17.100000000141886
+Current/target headway: 6.636/-1.0
+Time 84.6: Gap 'follower'->'leader' = 113.729 (headway=6.651)
+'follower' speed = 17.10000000013302
+Current/target headway: 6.651/-1.0
+Time 84.7: Gap 'follower'->'leader' = 113.979 (headway=6.665)
+'follower' speed = 17.100000000124425
+Current/target headway: 6.665/-1.0
+Time 84.8: Gap 'follower'->'leader' = 114.229 (headway=6.680)
+'follower' speed = 17.100000000116136
+Current/target headway: 6.680/-1.0
+Time 84.9: Gap 'follower'->'leader' = 114.479 (headway=6.695)
+'follower' speed = 17.100000000108178
+Current/target headway: 6.695/-1.0
+Time 85.0: Gap 'follower'->'leader' = 114.729 (headway=6.709)
+'follower' speed = 17.10000000010056
+Current/target headway: 6.709/-1.0
+Time 85.1: Gap 'follower'->'leader' = 114.979 (headway=6.724)
+'follower' speed = 17.100000000093296
+Current/target headway: 6.724/-1.0
+Time 85.2: Gap 'follower'->'leader' = 115.229 (headway=6.739)
+'follower' speed = 17.100000000086382
+Current/target headway: 6.739/-1.0
+Time 85.3: Gap 'follower'->'leader' = 115.479 (headway=6.753)
+'follower' speed = 17.10000000007982
+Current/target headway: 6.753/-1.0
+Time 85.4: Gap 'follower'->'leader' = 115.729 (headway=6.768)
+'follower' speed = 17.100000000073614
+Current/target headway: 6.768/-1.0
+Time 85.5: Gap 'follower'->'leader' = 115.979 (headway=6.782)
+'follower' speed = 17.10000000006776
+Current/target headway: 6.782/-1.0
+Time 85.6: Gap 'follower'->'leader' = 116.229 (headway=6.797)
+'follower' speed = 17.100000000062245
+Current/target headway: 6.797/-1.0
+Time 85.7: Gap 'follower'->'leader' = 116.479 (headway=6.812)
+'follower' speed = 17.10000000005707
+Current/target headway: 6.812/-1.0
+Time 85.8: Gap 'follower'->'leader' = 116.729 (headway=6.826)
+'follower' speed = 17.10000000005222
+Current/target headway: 6.826/-1.0
+Time 85.9: Gap 'follower'->'leader' = 116.979 (headway=6.841)
+'follower' speed = 17.100000000047686
+Current/target headway: 6.841/-1.0
+Time 86.0: Gap 'follower'->'leader' = 117.229 (headway=6.856)
+'follower' speed = 17.100000000043455
+Current/target headway: 6.856/-1.0
+Time 86.1: Gap 'follower'->'leader' = 117.479 (headway=6.870)
+'follower' speed = 17.100000000039515
+Current/target headway: 6.870/-1.0
+Time 86.2: Gap 'follower'->'leader' = 117.729 (headway=6.885)
+'follower' speed = 17.10000000003586
+Current/target headway: 6.885/-1.0
+Time 86.3: Gap 'follower'->'leader' = 117.979 (headway=6.899)
+'follower' speed = 17.10000000003247
+Current/target headway: 6.899/-1.0
+Time 86.4: Gap 'follower'->'leader' = 118.229 (headway=6.914)
+'follower' speed = 17.100000000029333
+Current/target headway: 6.914/-1.0
+Time 86.5: Gap 'follower'->'leader' = 118.479 (headway=6.929)
+'follower' speed = 17.100000000026434
+Current/target headway: 6.929/-1.0
+Time 86.6: Gap 'follower'->'leader' = 118.729 (headway=6.943)
+'follower' speed = 17.100000000023766
+Current/target headway: 6.943/-1.0
+Time 86.7: Gap 'follower'->'leader' = 118.979 (headway=6.958)
+'follower' speed = 17.10000000002131
+Current/target headway: 6.958/-1.0
+Time 86.8: Gap 'follower'->'leader' = 119.229 (headway=6.972)
+'follower' speed = 17.100000000019055
+Current/target headway: 6.972/-1.0
+Time 86.9: Gap 'follower'->'leader' = 119.479 (headway=6.987)
+'follower' speed = 17.100000000016994
+Current/target headway: 6.987/-1.0
+Time 87.0: Gap 'follower'->'leader' = 119.729 (headway=7.002)
+'follower' speed = 17.100000000015108
+Current/target headway: 7.002/-1.0
+Time 87.1: Gap 'follower'->'leader' = 119.979 (headway=7.016)
+'follower' speed = 17.100000000013384
+Current/target headway: 7.016/-1.0
+Time 87.2: Gap 'follower'->'leader' = 120.229 (headway=7.031)
+'follower' speed = 17.10000000001182
+Current/target headway: 7.031/-1.0
+Time 87.3: Gap 'follower'->'leader' = 120.479 (headway=7.046)
+'follower' speed = 17.1000000000104
+Current/target headway: 7.046/-1.0
+Time 87.4: Gap 'follower'->'leader' = 120.729 (headway=7.060)
+'follower' speed = 17.100000000009118
+Current/target headway: 7.060/-1.0
+Time 87.5: Gap 'follower'->'leader' = 120.979 (headway=7.075)
+'follower' speed = 17.10000000000796
+Current/target headway: 7.075/-1.0
+Time 87.6: Gap 'follower'->'leader' = 121.229 (headway=7.089)
+'follower' speed = 17.10000000000692
+Current/target headway: 7.089/-1.0
+Time 87.7: Gap 'follower'->'leader' = 121.479 (headway=7.104)
+'follower' speed = 17.100000000005984
+Current/target headway: 7.104/-1.0
+Time 87.8: Gap 'follower'->'leader' = 121.729 (headway=7.119)
+'follower' speed = 17.10000000000515
+Current/target headway: 7.119/-1.0
+Time 87.9: Gap 'follower'->'leader' = 121.979 (headway=7.133)
+'follower' speed = 17.100000000004396
+Current/target headway: 7.133/-1.0
+Time 88.0: Gap 'follower'->'leader' = 122.229 (headway=7.148)
+'follower' speed = 17.100000000003725
+Current/target headway: 7.148/-1.0
+Time 88.1: Gap 'follower'->'leader' = 122.479 (headway=7.163)
+'follower' speed = 17.10000000000313
+Current/target headway: 7.163/-1.0
+Time 88.2: Gap 'follower'->'leader' = 122.729 (headway=7.177)
+'follower' speed = 17.100000000002602
+Current/target headway: 7.177/-1.0
+Time 88.3: Gap 'follower'->'leader' = 122.979 (headway=7.192)
+'follower' speed = 17.100000000002137
+Current/target headway: 7.192/-1.0
+Time 88.4: Gap 'follower'->'leader' = 123.229 (headway=7.206)
+'follower' speed = 17.100000000001724
+Current/target headway: 7.206/-1.0
+Time 88.5: Gap 'follower'->'leader' = 123.479 (headway=7.221)
+'follower' speed = 17.100000000001366
+Current/target headway: 7.221/-1.0
+Time 88.6: Gap 'follower'->'leader' = 123.729 (headway=7.236)
+'follower' speed = 17.100000000001053
+Current/target headway: 7.236/-1.0
+Time 88.7: Gap 'follower'->'leader' = 123.979 (headway=7.250)
+'follower' speed = 17.10000000000078
+Current/target headway: 7.250/-1.0
+Time 88.8: Gap 'follower'->'leader' = 124.229 (headway=7.265)
+'follower' speed = 17.10000000000055
+Current/target headway: 7.265/-1.0
+Time 88.9: Gap 'follower'->'leader' = 124.479 (headway=7.279)
+'follower' speed = 17.100000000000353
+Current/target headway: 7.279/-1.0
+Time 89.0: Gap 'follower'->'leader' = 124.729 (headway=7.294)
+'follower' speed = 17.10000000000019
+Current/target headway: 7.294/-1.0
+Time 89.1: Gap 'follower'->'leader' = 124.979 (headway=7.309)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.309/-1.0
+Time 89.2: Gap 'follower'->'leader' = 125.229 (headway=7.323)
+'follower' speed = 17.099999999999934
+Current/target headway: 7.323/-1.0
+Time 89.3: Gap 'follower'->'leader' = 125.479 (headway=7.338)
+'follower' speed = 17.099999999999834
+Current/target headway: 7.338/-1.0
+Time 89.4: Gap 'follower'->'leader' = 125.729 (headway=7.353)
+'follower' speed = 17.099999999999753
+Current/target headway: 7.353/-1.0
+Time 89.5: Gap 'follower'->'leader' = 125.979 (headway=7.367)
+'follower' speed = 17.09999999999968
+Current/target headway: 7.367/-1.0
+Time 89.6: Gap 'follower'->'leader' = 126.229 (headway=7.382)
+'follower' speed = 17.099999999999632
+Current/target headway: 7.382/-1.0
+Time 89.7: Gap 'follower'->'leader' = 126.479 (headway=7.396)
+'follower' speed = 17.0999999999996
+Current/target headway: 7.396/-1.0
+Time 89.8: Gap 'follower'->'leader' = 126.729 (headway=7.411)
+'follower' speed = 17.099999999999582
+Current/target headway: 7.411/-1.0
+Time 89.9: Gap 'follower'->'leader' = 126.979 (headway=7.426)
+'follower' speed = 17.099999999999575
+Current/target headway: 7.426/-1.0
+Time 90.0: Gap 'follower'->'leader' = 127.229 (headway=7.440)
+'follower' speed = 17.09999999999958
+Current/target headway: 7.440/-1.0
+Time 90.1: Gap 'follower'->'leader' = 127.479 (headway=7.455)
+'follower' speed = 17.09999999999959
+Current/target headway: 7.455/-1.0
+Time 90.2: Gap 'follower'->'leader' = 127.729 (headway=7.470)
+'follower' speed = 17.099999999999607
+Current/target headway: 7.470/-1.0
+Time 90.3: Gap 'follower'->'leader' = 127.979 (headway=7.484)
+'follower' speed = 17.099999999999632
+Current/target headway: 7.484/-1.0
+Time 90.4: Gap 'follower'->'leader' = 128.229 (headway=7.499)
+'follower' speed = 17.09999999999966
+Current/target headway: 7.499/-1.0
+Time 90.5: Gap 'follower'->'leader' = 128.479 (headway=7.513)
+'follower' speed = 17.099999999999696
+Current/target headway: 7.513/-1.0
+Time 90.6: Gap 'follower'->'leader' = 128.729 (headway=7.528)
+'follower' speed = 17.099999999999735
+Current/target headway: 7.528/-1.0
+Time 90.7: Gap 'follower'->'leader' = 128.979 (headway=7.543)
+'follower' speed = 17.099999999999778
+Current/target headway: 7.543/-1.0
+Time 90.8: Gap 'follower'->'leader' = 129.229 (headway=7.557)
+'follower' speed = 17.09999999999982
+Current/target headway: 7.557/-1.0
+Time 90.9: Gap 'follower'->'leader' = 129.479 (headway=7.572)
+'follower' speed = 17.09999999999986
+Current/target headway: 7.572/-1.0
+Time 91.0: Gap 'follower'->'leader' = 129.729 (headway=7.587)
+'follower' speed = 17.09999999999989
+Current/target headway: 7.587/-1.0
+Time 91.1: Gap 'follower'->'leader' = 129.979 (headway=7.601)
+'follower' speed = 17.099999999999916
+Current/target headway: 7.601/-1.0
+Time 91.2: Gap 'follower'->'leader' = 130.229 (headway=7.616)
+'follower' speed = 17.099999999999937
+Current/target headway: 7.616/-1.0
+Time 91.3: Gap 'follower'->'leader' = 130.479 (headway=7.630)
+'follower' speed = 17.099999999999955
+Current/target headway: 7.630/-1.0
+Time 91.4: Gap 'follower'->'leader' = 130.729 (headway=7.645)
+'follower' speed = 17.099999999999973
+Current/target headway: 7.645/-1.0
+Time 91.5: Gap 'follower'->'leader' = 130.979 (headway=7.660)
+'follower' speed = 17.099999999999987
+Current/target headway: 7.660/-1.0
+Time 91.6: Gap 'follower'->'leader' = 131.229 (headway=7.674)
+'follower' speed = 17.099999999999998
+Current/target headway: 7.674/-1.0
+Time 91.7: Gap 'follower'->'leader' = 131.479 (headway=7.689)
+'follower' speed = 17.10000000000001
+Current/target headway: 7.689/-1.0
+Time 91.8: Gap 'follower'->'leader' = 131.729 (headway=7.703)
+'follower' speed = 17.100000000000016
+Current/target headway: 7.703/-1.0
+Time 91.9: Gap 'follower'->'leader' = 131.979 (headway=7.718)
+'follower' speed = 17.100000000000023
+Current/target headway: 7.718/-1.0
+Time 92.0: Gap 'follower'->'leader' = 132.229 (headway=7.733)
+'follower' speed = 17.10000000000003
+Current/target headway: 7.733/-1.0
+Time 92.1: Gap 'follower'->'leader' = 132.479 (headway=7.747)
+'follower' speed = 17.100000000000033
+Current/target headway: 7.747/-1.0
+Time 92.2: Gap 'follower'->'leader' = 132.729 (headway=7.762)
+'follower' speed = 17.100000000000037
+Current/target headway: 7.762/-1.0
+Time 92.3: Gap 'follower'->'leader' = 132.979 (headway=7.777)
+'follower' speed = 17.10000000000004
+Current/target headway: 7.777/-1.0
+Time 92.4: Gap 'follower'->'leader' = 133.229 (headway=7.791)
+'follower' speed = 17.100000000000044
+Current/target headway: 7.791/-1.0
+Time 92.5: Gap 'follower'->'leader' = 133.479 (headway=7.806)
+'follower' speed = 17.100000000000048
+Current/target headway: 7.806/-1.0
+Time 92.6: Gap 'follower'->'leader' = 133.729 (headway=7.820)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.820/-1.0
+Time 92.7: Gap 'follower'->'leader' = 133.979 (headway=7.835)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.835/-1.0
+Time 92.8: Gap 'follower'->'leader' = 134.229 (headway=7.850)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.850/-1.0
+Time 92.9: Gap 'follower'->'leader' = 134.479 (headway=7.864)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.864/-1.0
+Time 93.0: Gap 'follower'->'leader' = 134.729 (headway=7.879)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.879/-1.0
+Time 93.1: Gap 'follower'->'leader' = 134.979 (headway=7.894)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.894/-1.0
+Time 93.2: Gap 'follower'->'leader' = 135.229 (headway=7.908)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.908/-1.0
+Time 93.3: Gap 'follower'->'leader' = 135.479 (headway=7.923)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.923/-1.0
+Time 93.4: Gap 'follower'->'leader' = 135.729 (headway=7.937)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.937/-1.0
+Time 93.5: Gap 'follower'->'leader' = 135.979 (headway=7.952)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.952/-1.0
+Time 93.6: Gap 'follower'->'leader' = 136.229 (headway=7.967)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.967/-1.0
+Time 93.7: Gap 'follower'->'leader' = 136.479 (headway=7.981)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.981/-1.0
+Time 93.8: Gap 'follower'->'leader' = 136.729 (headway=7.996)
+'follower' speed = 17.10000000000005
+Current/target headway: 7.996/-1.0
+Time 93.9: Gap 'follower'->'leader' = 136.979 (headway=8.010)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.010/-1.0
+Time 94.0: Gap 'follower'->'leader' = 137.229 (headway=8.025)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.025/-1.0
+Time 94.1: Gap 'follower'->'leader' = 137.479 (headway=8.040)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.040/-1.0
+Time 94.2: Gap 'follower'->'leader' = 137.729 (headway=8.054)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.054/-1.0
+Time 94.3: Gap 'follower'->'leader' = 137.979 (headway=8.069)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.069/-1.0
+Time 94.4: Gap 'follower'->'leader' = 138.229 (headway=8.084)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.084/-1.0
+Time 94.5: Gap 'follower'->'leader' = 138.479 (headway=8.098)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.098/-1.0
+Time 94.6: Gap 'follower'->'leader' = 138.729 (headway=8.113)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.113/-1.0
+Time 94.7: Gap 'follower'->'leader' = 138.979 (headway=8.127)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.127/-1.0
+Time 94.8: Gap 'follower'->'leader' = 139.229 (headway=8.142)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.142/-1.0
+Time 94.9: Gap 'follower'->'leader' = 139.479 (headway=8.157)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.157/-1.0
+Time 95.0: Gap 'follower'->'leader' = 139.729 (headway=8.171)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.171/-1.0
+Time 95.1: Gap 'follower'->'leader' = 139.979 (headway=8.186)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.186/-1.0
+Time 95.2: Gap 'follower'->'leader' = 140.229 (headway=8.201)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.201/-1.0
+Time 95.3: Gap 'follower'->'leader' = 140.479 (headway=8.215)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.215/-1.0
+Time 95.4: Gap 'follower'->'leader' = 140.729 (headway=8.230)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.230/-1.0
+Time 95.5: Gap 'follower'->'leader' = 140.979 (headway=8.244)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.244/-1.0
+Time 95.6: Gap 'follower'->'leader' = 141.229 (headway=8.259)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.259/-1.0
+Time 95.7: Gap 'follower'->'leader' = 141.479 (headway=8.274)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.274/-1.0
+Time 95.8: Gap 'follower'->'leader' = 141.729 (headway=8.288)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.288/-1.0
+Time 95.9: Gap 'follower'->'leader' = 141.979 (headway=8.303)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.303/-1.0
+Time 96.0: Gap 'follower'->'leader' = 142.229 (headway=8.317)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.317/-1.0
+Time 96.1: Gap 'follower'->'leader' = 142.479 (headway=8.332)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.332/-1.0
+Time 96.2: Gap 'follower'->'leader' = 142.729 (headway=8.347)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.347/-1.0
+Time 96.3: Gap 'follower'->'leader' = 142.979 (headway=8.361)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.361/-1.0
+Time 96.4: Gap 'follower'->'leader' = 143.229 (headway=8.376)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.376/-1.0
+Time 96.5: Gap 'follower'->'leader' = 143.479 (headway=8.391)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.391/-1.0
+Time 96.6: Gap 'follower'->'leader' = 143.729 (headway=8.405)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.405/-1.0
+Time 96.7: Gap 'follower'->'leader' = 143.979 (headway=8.420)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.420/-1.0
+Time 96.8: Gap 'follower'->'leader' = 144.229 (headway=8.434)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.434/-1.0
+Time 96.9: Gap 'follower'->'leader' = 144.479 (headway=8.449)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.449/-1.0
+Time 97.0: Gap 'follower'->'leader' = 144.729 (headway=8.464)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.464/-1.0
+Time 97.1: Gap 'follower'->'leader' = 144.979 (headway=8.478)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.478/-1.0
+Time 97.2: Gap 'follower'->'leader' = 145.229 (headway=8.493)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.493/-1.0
+Time 97.3: Gap 'follower'->'leader' = 145.479 (headway=8.508)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.508/-1.0
+Time 97.4: Gap 'follower'->'leader' = 145.729 (headway=8.522)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.522/-1.0
+Time 97.5: Gap 'follower'->'leader' = 145.979 (headway=8.537)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.537/-1.0
+Time 97.6: Gap 'follower'->'leader' = 146.229 (headway=8.551)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.551/-1.0
+Time 97.7: Gap 'follower'->'leader' = 146.479 (headway=8.566)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.566/-1.0
+Time 97.8: Gap 'follower'->'leader' = 146.729 (headway=8.581)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.581/-1.0
+Time 97.9: Gap 'follower'->'leader' = 146.979 (headway=8.595)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.595/-1.0
+Time 98.0: Gap 'follower'->'leader' = 147.229 (headway=8.610)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.610/-1.0
+Time 98.1: Gap 'follower'->'leader' = 147.479 (headway=8.625)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.625/-1.0
+Time 98.2: Gap 'follower'->'leader' = 147.729 (headway=8.639)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.639/-1.0
+Time 98.3: Gap 'follower'->'leader' = 147.979 (headway=8.654)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.654/-1.0
+Time 98.4: Gap 'follower'->'leader' = 148.229 (headway=8.668)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.668/-1.0
+Time 98.5: Gap 'follower'->'leader' = 148.479 (headway=8.683)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.683/-1.0
+Time 98.6: Gap 'follower'->'leader' = 148.729 (headway=8.698)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.698/-1.0
+Time 98.7: Gap 'follower'->'leader' = 148.979 (headway=8.712)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.712/-1.0
+Time 98.8: Gap 'follower'->'leader' = 149.229 (headway=8.727)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.727/-1.0
+Time 98.9: Gap 'follower'->'leader' = 149.479 (headway=8.741)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.741/-1.0
+Time 99.0: Gap 'follower'->'leader' = 149.729 (headway=8.756)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.756/-1.0
+Time 99.1: Gap 'follower'->'leader' = 149.979 (headway=8.771)
+'follower' speed = 17.10000000000005
+Current/target headway: 8.771/-1.0
+Time 99.2: Gap 'follower'->'leader' = 150.229 (headway=8.785)
+'follower' speed = 17.100000000000044
+Current/target headway: 8.785/-1.0
+Time 99.3: Gap 'follower'->'leader' = 150.479 (headway=8.800)
+'follower' speed = 17.100000000000037
+Current/target headway: 8.800/-1.0
+Time 99.4: Gap 'follower'->'leader' = 150.729 (headway=8.815)
+'follower' speed = 17.10000000000003
+Current/target headway: 8.815/-1.0
+Time 99.5: Gap 'follower'->'leader' = 150.979 (headway=8.829)
+'follower' speed = 17.10000000000002
+Current/target headway: 8.829/-1.0
+Time 99.6: Gap 'follower'->'leader' = 151.229 (headway=8.844)
+'follower' speed = 17.10000000000001
+Current/target headway: 8.844/-1.0
+Time 99.7: Gap 'follower'->'leader' = 151.479 (headway=8.858)
+'follower' speed = 17.099999999999998
+Current/target headway: 8.858/-1.0
+Time 99.8: Gap 'follower'->'leader' = 151.729 (headway=8.873)
+'follower' speed = 17.099999999999984
+Current/target headway: 8.873/-1.0
+Time 99.9: Gap 'follower'->'leader' = 151.979 (headway=8.888)
+'follower' speed = 17.09999999999997
+Current/target headway: 8.888/-1.0
+Time 100.0: Gap 'follower'->'leader' = 152.229 (headway=8.902)
+'follower' speed = 17.099999999999955
+Current/target headway: 8.902/-1.0
+Time 100.1: Gap 'follower'->'leader' = 152.479 (headway=8.917)
+'follower' speed = 17.09999999999994
+Current/target headway: 8.917/-1.0
+Time 100.2: Gap 'follower'->'leader' = 152.729 (headway=8.932)
+'follower' speed = 17.099999999999927
+Current/target headway: 8.932/-1.0
+Time 100.3: Gap 'follower'->'leader' = 152.979 (headway=8.946)
+'follower' speed = 17.09999999999991
+Current/target headway: 8.946/-1.0
+Time 100.4: Gap 'follower'->'leader' = 153.229 (headway=8.961)
+'follower' speed = 17.09999999999989
+Current/target headway: 8.961/-1.0
+Time 100.5: Gap 'follower'->'leader' = 153.479 (headway=8.975)
+'follower' speed = 17.099999999999874
+Current/target headway: 8.975/-1.0
+Time 100.6: Gap 'follower'->'leader' = 153.729 (headway=8.990)
+'follower' speed = 17.099999999999856
+Current/target headway: 8.990/-1.0
+Time 100.7: Gap 'follower'->'leader' = 153.979 (headway=9.005)
+'follower' speed = 17.099999999999838
+Current/target headway: 9.005/-1.0
+Time 100.8: Gap 'follower'->'leader' = 154.229 (headway=9.019)
+'follower' speed = 17.09999999999982
+Current/target headway: 9.019/-1.0
+Time 100.9: Gap 'follower'->'leader' = 154.479 (headway=9.034)
+'follower' speed = 17.099999999999802
+Current/target headway: 9.034/-1.0
+Time 101.0: Gap 'follower'->'leader' = 154.729 (headway=9.048)
+'follower' speed = 17.099999999999785
+Current/target headway: 9.048/-1.0
+Time 101.1: Gap 'follower'->'leader' = 154.979 (headway=9.063)
+'follower' speed = 17.099999999999774
+Current/target headway: 9.063/-1.0
+Time 101.2: Gap 'follower'->'leader' = 155.229 (headway=9.078)
+'follower' speed = 17.099999999999774
+Current/target headway: 9.078/-1.0
+Time 101.3: Gap 'follower'->'leader' = 155.479 (headway=9.092)
+'follower' speed = 17.09999999999978
+Current/target headway: 9.092/-1.0
+Time 101.4: Gap 'follower'->'leader' = 155.729 (headway=9.107)
+'follower' speed = 17.099999999999792
+Current/target headway: 9.107/-1.0
+Time 101.5: Gap 'follower'->'leader' = 155.979 (headway=9.122)
+'follower' speed = 17.099999999999806
+Current/target headway: 9.122/-1.0
+Time 101.6: Gap 'follower'->'leader' = 156.229 (headway=9.136)
+'follower' speed = 17.099999999999817
+Current/target headway: 9.136/-1.0
+Time 101.7: Gap 'follower'->'leader' = 156.479 (headway=9.151)
+'follower' speed = 17.099999999999824
+Current/target headway: 9.151/-1.0
+Time 101.8: Gap 'follower'->'leader' = 156.729 (headway=9.165)
+'follower' speed = 17.099999999999824
+Current/target headway: 9.165/-1.0
+Time 101.9: Gap 'follower'->'leader' = 156.979 (headway=9.180)
+'follower' speed = 17.09999999999982
+Current/target headway: 9.180/-1.0
+Time 102.0: Gap 'follower'->'leader' = 157.229 (headway=9.195)
+'follower' speed = 17.099999999999817
+Current/target headway: 9.195/-1.0
+Time 102.1: Gap 'follower'->'leader' = 157.479 (headway=9.209)
+'follower' speed = 17.09999999999981
+Current/target headway: 9.209/-1.0
+Time 102.2: Gap 'follower'->'leader' = 157.729 (headway=9.224)
+'follower' speed = 17.099999999999802
+Current/target headway: 9.224/-1.0
+Time 102.3: Gap 'follower'->'leader' = 157.979 (headway=9.239)
+'follower' speed = 17.099999999999792
+Current/target headway: 9.239/-1.0
+Time 102.4: Gap 'follower'->'leader' = 158.229 (headway=9.253)
+'follower' speed = 17.09999999999978
+Current/target headway: 9.253/-1.0
+Time 102.5: Gap 'follower'->'leader' = 158.479 (headway=9.268)
+'follower' speed = 17.099999999999778
+Current/target headway: 9.268/-1.0
+Time 102.6: Gap 'follower'->'leader' = 158.729 (headway=9.282)
+'follower' speed = 17.09999999999978
+Current/target headway: 9.282/-1.0
+Time 102.7: Gap 'follower'->'leader' = 158.979 (headway=9.297)
+'follower' speed = 17.09999999999979
+Current/target headway: 9.297/-1.0
+Time 102.8: Gap 'follower'->'leader' = 159.229 (headway=9.312)
+'follower' speed = 17.099999999999802
+Current/target headway: 9.312/-1.0
+Time 102.9: Gap 'follower'->'leader' = 159.479 (headway=9.326)
+'follower' speed = 17.09999999999981
+Current/target headway: 9.326/-1.0
+Time 103.0: Gap 'follower'->'leader' = 159.729 (headway=9.341)
+'follower' speed = 17.099999999999813
+Current/target headway: 9.341/-1.0
+Time 103.1: Gap 'follower'->'leader' = 159.979 (headway=9.356)
+'follower' speed = 17.09999999999981
+Current/target headway: 9.356/-1.0
+Time 103.2: Gap 'follower'->'leader' = 160.229 (headway=9.370)
+'follower' speed = 17.099999999999806
+Current/target headway: 9.370/-1.0
+Time 103.3: Gap 'follower'->'leader' = 160.479 (headway=9.385)
+'follower' speed = 17.0999999999998
+Current/target headway: 9.385/-1.0
+Time 103.4: Gap 'follower'->'leader' = 160.729 (headway=9.399)
+'follower' speed = 17.09999999999979
+Current/target headway: 9.399/-1.0
+Time 103.5: Gap 'follower'->'leader' = 160.979 (headway=9.414)
+'follower' speed = 17.099999999999774
+Current/target headway: 9.414/-1.0
+Time 103.6: Gap 'follower'->'leader' = 161.229 (headway=9.429)
+'follower' speed = 17.09999999999977
+Current/target headway: 9.429/-1.0
+Time 103.7: Gap 'follower'->'leader' = 161.479 (headway=9.443)
+'follower' speed = 17.099999999999774
+Current/target headway: 9.443/-1.0
+Time 103.8: Gap 'follower'->'leader' = 161.729 (headway=9.458)
+'follower' speed = 17.09999999999978
+Current/target headway: 9.458/-1.0
+Time 103.9: Gap 'follower'->'leader' = 161.979 (headway=9.472)
+'follower' speed = 17.099999999999792
+Current/target headway: 9.472/-1.0
+Time 104.0: Gap 'follower'->'leader' = 162.229 (headway=9.487)
+'follower' speed = 17.09999999999981
+Current/target headway: 9.487/-1.0
+Time 104.1: Gap 'follower'->'leader' = 162.479 (headway=9.502)
+'follower' speed = 17.09999999999982
+Current/target headway: 9.502/-1.0
+Time 104.2: Gap 'follower'->'leader' = 162.729 (headway=9.516)
+'follower' speed = 17.099999999999827
+Current/target headway: 9.516/-1.0
+Time 104.3: Gap 'follower'->'leader' = 162.979 (headway=9.531)
+'follower' speed = 17.099999999999827
+Current/target headway: 9.531/-1.0
+Time 104.4: Gap 'follower'->'leader' = 163.229 (headway=9.546)
+'follower' speed = 17.099999999999824
+Current/target headway: 9.546/-1.0
+Time 104.5: Gap 'follower'->'leader' = 163.479 (headway=9.560)
+'follower' speed = 17.09999999999982
+Current/target headway: 9.560/-1.0
+Time 104.6: Gap 'follower'->'leader' = 163.729 (headway=9.575)
+'follower' speed = 17.099999999999813
+Current/target headway: 9.575/-1.0
+Time 104.7: Gap 'follower'->'leader' = 163.979 (headway=9.589)
+'follower' speed = 17.099999999999802
+Current/target headway: 9.589/-1.0
+Time 104.8: Gap 'follower'->'leader' = 164.229 (headway=9.604)
+'follower' speed = 17.099999999999792
+Current/target headway: 9.604/-1.0
+Time 104.9: Gap 'follower'->'leader' = 164.479 (headway=9.619)
+'follower' speed = 17.09999999999979
+Current/target headway: 9.619/-1.0
+Time 105.0: Gap 'follower'->'leader' = 164.729 (headway=9.633)
+'follower' speed = 17.09999999999979
+Current/target headway: 9.633/-1.0
+Time 105.1: Gap 'follower'->'leader' = 164.979 (headway=9.648)
+'follower' speed = 17.099999999999795
+Current/target headway: 9.648/-1.0
+Time 105.2: Gap 'follower'->'leader' = 165.229 (headway=9.663)
+'follower' speed = 17.099999999999806
+Current/target headway: 9.663/-1.0
+Time 105.3: Gap 'follower'->'leader' = 165.479 (headway=9.677)
+'follower' speed = 17.099999999999813
+Current/target headway: 9.677/-1.0
+Time 105.4: Gap 'follower'->'leader' = 165.729 (headway=9.692)
+'follower' speed = 17.099999999999817
+Current/target headway: 9.692/-1.0
+Time 105.5: Gap 'follower'->'leader' = 165.979 (headway=9.706)
+'follower' speed = 17.099999999999817
+Current/target headway: 9.706/-1.0
+Time 105.6: Gap 'follower'->'leader' = 166.229 (headway=9.721)
+'follower' speed = 17.09999999999981
+Current/target headway: 9.721/-1.0
+Time 105.7: Gap 'follower'->'leader' = 166.479 (headway=9.736)
+'follower' speed = 17.099999999999802
+Current/target headway: 9.736/-1.0
+Time 105.8: Gap 'follower'->'leader' = 166.729 (headway=9.750)
+'follower' speed = 17.099999999999795
+Current/target headway: 9.750/-1.0
+Time 105.9: Gap 'follower'->'leader' = 166.979 (headway=9.765)
+'follower' speed = 17.099999999999785
+Current/target headway: 9.765/-1.0
+Time 106.0: Gap 'follower'->'leader' = 167.229 (headway=9.779)
+'follower' speed = 17.099999999999785
+Current/target headway: 9.779/-1.0
+Time 106.1: Gap 'follower'->'leader' = 167.479 (headway=9.794)
+'follower' speed = 17.099999999999792
+Current/target headway: 9.794/-1.0
+Time 106.2: Gap 'follower'->'leader' = 167.729 (headway=9.809)
+'follower' speed = 17.099999999999802
+Current/target headway: 9.809/-1.0
+Time 106.3: Gap 'follower'->'leader' = 167.979 (headway=9.823)
+'follower' speed = 17.09999999999981
+Current/target headway: 9.823/-1.0
+Time 106.4: Gap 'follower'->'leader' = 168.229 (headway=9.838)
+'follower' speed = 17.099999999999813
+Current/target headway: 9.838/-1.0
+Time 106.5: Gap 'follower'->'leader' = 168.479 (headway=9.853)
+'follower' speed = 17.099999999999817
+Current/target headway: 9.853/-1.0
+Time 106.6: Gap 'follower'->'leader' = 168.729 (headway=9.867)
+'follower' speed = 17.099999999999817
+Current/target headway: 9.867/-1.0
+Time 106.7: Gap 'follower'->'leader' = 168.979 (headway=9.882)
+'follower' speed = 17.099999999999813
+Current/target headway: 9.882/-1.0
+Time 106.8: Gap 'follower'->'leader' = 169.229 (headway=9.896)
+'follower' speed = 17.09999999999981
+Current/target headway: 9.896/-1.0
+Time 106.9: Gap 'follower'->'leader' = 169.479 (headway=9.911)
+'follower' speed = 17.099999999999802
+Current/target headway: 9.911/-1.0
+Time 107.0: Gap 'follower'->'leader' = 169.729 (headway=9.926)
+'follower' speed = 17.099999999999795
+Current/target headway: 9.926/-1.0
+Time 107.1: Gap 'follower'->'leader' = 169.979 (headway=9.940)
+'follower' speed = 17.099999999999785
+Current/target headway: 9.940/-1.0
+Time 107.2: Gap 'follower'->'leader' = 170.229 (headway=9.955)
+'follower' speed = 17.099999999999785
+Current/target headway: 9.955/-1.0
+Time 107.3: Gap 'follower'->'leader' = 170.479 (headway=9.970)
+'follower' speed = 17.099999999999792
+Current/target headway: 9.970/-1.0
+Time 107.4: Gap 'follower'->'leader' = 170.729 (headway=9.984)
+'follower' speed = 17.099999999999802
+Current/target headway: 9.984/-1.0
+Time 107.5: Gap 'follower'->'leader' = 170.979 (headway=9.999)
+'follower' speed = 17.09999999999982
+Current/target headway: 9.999/-1.0
+Time 107.6: Gap 'follower'->'leader' = 171.229 (headway=10.013)
+'follower' speed = 17.09999999999983
+Current/target headway: 10.013/-1.0
+Time 107.7: Gap 'follower'->'leader' = 171.479 (headway=10.028)
+'follower' speed = 17.099999999999838
+Current/target headway: 10.028/-1.0
+Time 107.8: Gap 'follower'->'leader' = 171.729 (headway=10.043)
+'follower' speed = 17.09999999999984
+Current/target headway: 10.043/-1.0
+Time 107.9: Gap 'follower'->'leader' = 171.979 (headway=10.057)
+'follower' speed = 17.099999999999845
+Current/target headway: 10.057/-1.0
+Time 108.0: Gap 'follower'->'leader' = 172.229 (headway=10.072)
+'follower' speed = 17.099999999999845
+Current/target headway: 10.072/-1.0
+Time 108.1: Gap 'follower'->'leader' = 172.479 (headway=10.087)
+'follower' speed = 17.09999999999984
+Current/target headway: 10.087/-1.0
+Time 108.2: Gap 'follower'->'leader' = 172.729 (headway=10.101)
+'follower' speed = 17.099999999999838
+Current/target headway: 10.101/-1.0
+Time 108.3: Gap 'follower'->'leader' = 172.979 (headway=10.116)
+'follower' speed = 17.099999999999834
+Current/target headway: 10.116/-1.0
+Time 108.4: Gap 'follower'->'leader' = 173.229 (headway=10.130)
+'follower' speed = 17.099999999999834
+Current/target headway: 10.130/-1.0
+Time 108.5: Gap 'follower'->'leader' = 173.479 (headway=10.145)
+'follower' speed = 17.099999999999838
+Current/target headway: 10.145/-1.0
+Time 108.6: Gap 'follower'->'leader' = 173.729 (headway=10.160)
+'follower' speed = 17.09999999999984
+Current/target headway: 10.160/-1.0
+Time 108.7: Gap 'follower'->'leader' = 173.979 (headway=10.174)
+'follower' speed = 17.099999999999845
+Current/target headway: 10.174/-1.0
+Time 108.8: Gap 'follower'->'leader' = 174.229 (headway=10.189)
+'follower' speed = 17.099999999999852
+Current/target headway: 10.189/-1.0
+Time 108.9: Gap 'follower'->'leader' = 174.479 (headway=10.203)
+'follower' speed = 17.09999999999986
+Current/target headway: 10.203/-1.0
+Time 109.0: Gap 'follower'->'leader' = 174.729 (headway=10.218)
+'follower' speed = 17.099999999999866
+Current/target headway: 10.218/-1.0
+Time 109.1: Gap 'follower'->'leader' = 174.979 (headway=10.233)
+'follower' speed = 17.099999999999877
+Current/target headway: 10.233/-1.0
+Time 109.2: Gap 'follower'->'leader' = 175.229 (headway=10.247)
+'follower' speed = 17.099999999999884
+Current/target headway: 10.247/-1.0
+Time 109.3: Gap 'follower'->'leader' = 175.479 (headway=10.262)
+'follower' speed = 17.099999999999895
+Current/target headway: 10.262/-1.0
+Time 109.4: Gap 'follower'->'leader' = 175.729 (headway=10.277)
+'follower' speed = 17.099999999999905
+Current/target headway: 10.277/-1.0
+Time 109.5: Gap 'follower'->'leader' = 175.979 (headway=10.291)
+'follower' speed = 17.099999999999913
+Current/target headway: 10.291/-1.0
+Time 109.6: Gap 'follower'->'leader' = 176.229 (headway=10.306)
+'follower' speed = 17.099999999999923
+Current/target headway: 10.306/-1.0
+Time 109.7: Gap 'follower'->'leader' = 176.479 (headway=10.320)
+'follower' speed = 17.099999999999934
+Current/target headway: 10.320/-1.0
+Time 109.8: Gap 'follower'->'leader' = 176.729 (headway=10.335)
+'follower' speed = 17.09999999999994
+Current/target headway: 10.335/-1.0
+Time 109.9: Gap 'follower'->'leader' = 176.979 (headway=10.350)
+'follower' speed = 17.09999999999995
+Current/target headway: 10.350/-1.0
+Time 110.0: Gap 'follower'->'leader' = 177.229 (headway=10.364)
+'follower' speed = 17.09999999999996
+Current/target headway: 10.364/-1.0
+Time 110.1: Gap 'follower'->'leader' = 177.479 (headway=10.379)
+'follower' speed = 17.099999999999966
+Current/target headway: 10.379/-1.0
+Time 110.2: Gap 'follower'->'leader' = 177.729 (headway=10.394)
+'follower' speed = 17.099999999999973
+Current/target headway: 10.394/-1.0
+Time 110.3: Gap 'follower'->'leader' = 177.979 (headway=10.408)
+'follower' speed = 17.099999999999984
+Current/target headway: 10.408/-1.0
+Time 110.4: Gap 'follower'->'leader' = 178.229 (headway=10.423)
+'follower' speed = 17.09999999999999
+Current/target headway: 10.423/-1.0
+Time 110.5: Gap 'follower'->'leader' = 178.479 (headway=10.437)
+'follower' speed = 17.099999999999998
+Current/target headway: 10.437/-1.0
+Time 110.6: Gap 'follower'->'leader' = 178.729 (headway=10.452)
+'follower' speed = 17.1
+Current/target headway: 10.452/-1.0
+Time 110.7: Gap 'follower'->'leader' = 178.979 (headway=10.467)
+'follower' speed = 17.100000000000005
+Current/target headway: 10.467/-1.0
+Time 110.8: Gap 'follower'->'leader' = 179.229 (headway=10.481)
+'follower' speed = 17.100000000000012
+Current/target headway: 10.481/-1.0
+Time 110.9: Gap 'follower'->'leader' = 179.479 (headway=10.496)
+'follower' speed = 17.100000000000016
+Current/target headway: 10.496/-1.0
+Time 111.0: Gap 'follower'->'leader' = 179.729 (headway=10.510)
+'follower' speed = 17.10000000000002
+Current/target headway: 10.510/-1.0
+Time 111.1: Gap 'follower'->'leader' = 179.979 (headway=10.525)
+'follower' speed = 17.100000000000026
+Current/target headway: 10.525/-1.0
+Time 111.2: Gap 'follower'->'leader' = 180.229 (headway=10.540)
+'follower' speed = 17.100000000000033
+Current/target headway: 10.540/-1.0
+Time 111.3: Gap 'follower'->'leader' = 180.479 (headway=10.554)
+'follower' speed = 17.100000000000037
+Current/target headway: 10.554/-1.0
+Time 111.4: Gap 'follower'->'leader' = 180.729 (headway=10.569)
+'follower' speed = 17.10000000000004
+Current/target headway: 10.569/-1.0
+Time 111.5: Gap 'follower'->'leader' = 180.979 (headway=10.584)
+'follower' speed = 17.100000000000044
+Current/target headway: 10.584/-1.0
+Time 111.6: Gap 'follower'->'leader' = 181.229 (headway=10.598)
+'follower' speed = 17.100000000000048
+Current/target headway: 10.598/-1.0
+Time 111.7: Gap 'follower'->'leader' = 181.479 (headway=10.613)
+'follower' speed = 17.10000000000005
+Current/target headway: 10.613/-1.0
+Time 111.8: Gap 'follower'->'leader' = 181.729 (headway=10.627)
+'follower' speed = 17.10000000000005
+Current/target headway: 10.627/-1.0
+Time 111.9: Gap 'follower'->'leader' = 181.979 (headway=10.642)
+'follower' speed = 17.10000000000005
+Current/target headway: 10.642/-1.0
+Time 112.0: Gap 'follower'->'leader' = 182.229 (headway=10.657)
+'follower' speed = 17.10000000000005
+Current/target headway: 10.657/-1.0
+Time 112.1: Gap 'follower'->'leader' = 182.479 (headway=10.671)
+'follower' speed = 17.10000000000005
+Current/target headway: 10.671/-1.0
+Time 112.2: Gap 'follower'->'leader' = 182.729 (headway=10.686)
+'follower' speed = 17.10000000000005
+Current/target headway: 10.686/-1.0
+Time 112.3: Gap 'follower'->'leader' = 182.979 (headway=10.701)
+'follower' speed = 17.100000000000048
+Current/target headway: 10.701/-1.0
+Time 112.4: Gap 'follower'->'leader' = 183.229 (headway=10.715)
+'follower' speed = 17.100000000000044
+Current/target headway: 10.715/-1.0
+Time 112.5: Gap 'follower'->'leader' = 183.479 (headway=10.730)
+'follower' speed = 17.100000000000037
+Current/target headway: 10.730/-1.0
+Time 112.6: Gap 'follower'->'leader' = 183.729 (headway=10.744)
+'follower' speed = 17.10000000000003
+Current/target headway: 10.744/-1.0
+Time 112.7: Gap 'follower'->'leader' = 183.979 (headway=10.759)
+'follower' speed = 17.10000000000002
+Current/target headway: 10.759/-1.0
+Time 112.8: Gap 'follower'->'leader' = 184.229 (headway=10.774)
+'follower' speed = 17.100000000000012
+Current/target headway: 10.774/-1.0
+Time 112.9: Gap 'follower'->'leader' = 184.479 (headway=10.788)
+'follower' speed = 17.1
+Current/target headway: 10.788/-1.0
+Time 113.0: Gap 'follower'->'leader' = 184.729 (headway=10.803)
+'follower' speed = 17.09999999999999
+Current/target headway: 10.803/-1.0
+Time 113.1: Gap 'follower'->'leader' = 184.979 (headway=10.817)
+'follower' speed = 17.099999999999984
+Current/target headway: 10.817/-1.0
+Time 113.2: Gap 'follower'->'leader' = 185.229 (headway=10.832)
+'follower' speed = 17.099999999999977
+Current/target headway: 10.832/-1.0
+Time 113.3: Gap 'follower'->'leader' = 185.479 (headway=10.847)
+'follower' speed = 17.099999999999966
+Current/target headway: 10.847/-1.0
+Time 113.4: Gap 'follower'->'leader' = 185.729 (headway=10.861)
+'follower' speed = 17.09999999999996
+Current/target headway: 10.861/-1.0
+Time 113.5: Gap 'follower'->'leader' = 185.979 (headway=10.876)
+'follower' speed = 17.09999999999995
+Current/target headway: 10.876/-1.0
+Time 113.6: Gap 'follower'->'leader' = 186.229 (headway=10.891)
+'follower' speed = 17.099999999999945
+Current/target headway: 10.891/-1.0
+Time 113.7: Gap 'follower'->'leader' = 186.479 (headway=10.905)
+'follower' speed = 17.099999999999934
+Current/target headway: 10.905/-1.0
+Time 113.8: Gap 'follower'->'leader' = 186.729 (headway=10.920)
+'follower' speed = 17.099999999999927
+Current/target headway: 10.920/-1.0
+Time 113.9: Gap 'follower'->'leader' = 186.979 (headway=10.934)
+'follower' speed = 17.09999999999992
+Current/target headway: 10.934/-1.0
+Time 114.0: Gap 'follower'->'leader' = 187.229 (headway=10.949)
+'follower' speed = 17.099999999999913
+Current/target headway: 10.949/-1.0
+Time 114.1: Gap 'follower'->'leader' = 187.479 (headway=10.964)
+'follower' speed = 17.099999999999905
+Current/target headway: 10.964/-1.0
+Time 114.2: Gap 'follower'->'leader' = 187.729 (headway=10.978)
+'follower' speed = 17.0999999999999
+Current/target headway: 10.978/-1.0
+Time 114.3: Gap 'follower'->'leader' = 187.979 (headway=10.993)
+'follower' speed = 17.09999999999989
+Current/target headway: 10.993/-1.0
+Time 114.4: Gap 'follower'->'leader' = 188.229 (headway=11.008)
+'follower' speed = 17.099999999999884
+Current/target headway: 11.008/-1.0
+Time 114.5: Gap 'follower'->'leader' = 188.479 (headway=11.022)
+'follower' speed = 17.099999999999874
+Current/target headway: 11.022/-1.0
+Time 114.6: Gap 'follower'->'leader' = 188.729 (headway=11.037)
+'follower' speed = 17.099999999999866
+Current/target headway: 11.037/-1.0
+Time 114.7: Gap 'follower'->'leader' = 188.979 (headway=11.051)
+'follower' speed = 17.09999999999986
+Current/target headway: 11.051/-1.0
+Time 114.8: Gap 'follower'->'leader' = 189.229 (headway=11.066)
+'follower' speed = 17.099999999999856
+Current/target headway: 11.066/-1.0
+Time 114.9: Gap 'follower'->'leader' = 189.479 (headway=11.081)
+'follower' speed = 17.099999999999852
+Current/target headway: 11.081/-1.0
+Time 115.0: Gap 'follower'->'leader' = 189.729 (headway=11.095)
+'follower' speed = 17.09999999999985
+Current/target headway: 11.095/-1.0
+Time 115.1: Gap 'follower'->'leader' = 189.979 (headway=11.110)
+'follower' speed = 17.099999999999845
+Current/target headway: 11.110/-1.0
+Time 115.2: Gap 'follower'->'leader' = 190.229 (headway=11.125)
+'follower' speed = 17.09999999999984
+Current/target headway: 11.125/-1.0
+Time 115.3: Gap 'follower'->'leader' = 190.479 (headway=11.139)
+'follower' speed = 17.099999999999838
+Current/target headway: 11.139/-1.0
+Time 115.4: Gap 'follower'->'leader' = 190.729 (headway=11.154)
+'follower' speed = 17.099999999999834
+Current/target headway: 11.154/-1.0
+Time 115.5: Gap 'follower'->'leader' = 190.979 (headway=11.168)
+'follower' speed = 17.099999999999834
+Current/target headway: 11.168/-1.0
+Time 115.6: Gap 'follower'->'leader' = 191.229 (headway=11.183)
+'follower' speed = 17.099999999999834
+Current/target headway: 11.183/-1.0
+Time 115.7: Gap 'follower'->'leader' = 191.479 (headway=11.198)
+'follower' speed = 17.099999999999834
+Current/target headway: 11.198/-1.0
+Time 115.8: Gap 'follower'->'leader' = 191.729 (headway=11.212)
+'follower' speed = 17.09999999999983
+Current/target headway: 11.212/-1.0
+Time 115.9: Gap 'follower'->'leader' = 191.979 (headway=11.227)
+'follower' speed = 17.099999999999827
+Current/target headway: 11.227/-1.0
+Time 116.0: Gap 'follower'->'leader' = 192.229 (headway=11.241)
+'follower' speed = 17.099999999999824
+Current/target headway: 11.241/-1.0
+Time 116.1: Gap 'follower'->'leader' = 192.479 (headway=11.256)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.256/-1.0
+Time 116.2: Gap 'follower'->'leader' = 192.729 (headway=11.271)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.271/-1.0
+Time 116.3: Gap 'follower'->'leader' = 192.979 (headway=11.285)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.285/-1.0
+Time 116.4: Gap 'follower'->'leader' = 193.229 (headway=11.300)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.300/-1.0
+Time 116.5: Gap 'follower'->'leader' = 193.479 (headway=11.315)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.315/-1.0
+Time 116.6: Gap 'follower'->'leader' = 193.729 (headway=11.329)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.329/-1.0
+Time 116.7: Gap 'follower'->'leader' = 193.979 (headway=11.344)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.344/-1.0
+Time 116.8: Gap 'follower'->'leader' = 194.229 (headway=11.358)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.358/-1.0
+Time 116.9: Gap 'follower'->'leader' = 194.479 (headway=11.373)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.373/-1.0
+Time 117.0: Gap 'follower'->'leader' = 194.729 (headway=11.388)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.388/-1.0
+Time 117.1: Gap 'follower'->'leader' = 194.979 (headway=11.402)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.402/-1.0
+Time 117.2: Gap 'follower'->'leader' = 195.229 (headway=11.417)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.417/-1.0
+Time 117.3: Gap 'follower'->'leader' = 195.479 (headway=11.432)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.432/-1.0
+Time 117.4: Gap 'follower'->'leader' = 195.729 (headway=11.446)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.446/-1.0
+Time 117.5: Gap 'follower'->'leader' = 195.979 (headway=11.461)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.461/-1.0
+Time 117.6: Gap 'follower'->'leader' = 196.229 (headway=11.475)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.475/-1.0
+Time 117.7: Gap 'follower'->'leader' = 196.479 (headway=11.490)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.490/-1.0
+Time 117.8: Gap 'follower'->'leader' = 196.729 (headway=11.505)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.505/-1.0
+Time 117.9: Gap 'follower'->'leader' = 196.979 (headway=11.519)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.519/-1.0
+Time 118.0: Gap 'follower'->'leader' = 197.229 (headway=11.534)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.534/-1.0
+Time 118.1: Gap 'follower'->'leader' = 197.479 (headway=11.548)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.548/-1.0
+Time 118.2: Gap 'follower'->'leader' = 197.729 (headway=11.563)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.563/-1.0
+Time 118.3: Gap 'follower'->'leader' = 197.979 (headway=11.578)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.578/-1.0
+Time 118.4: Gap 'follower'->'leader' = 198.229 (headway=11.592)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.592/-1.0
+Time 118.5: Gap 'follower'->'leader' = 198.479 (headway=11.607)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.607/-1.0
+Time 118.6: Gap 'follower'->'leader' = 198.729 (headway=11.622)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.622/-1.0
+Time 118.7: Gap 'follower'->'leader' = 198.979 (headway=11.636)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.636/-1.0
+Time 118.8: Gap 'follower'->'leader' = 199.229 (headway=11.651)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.651/-1.0
+Time 118.9: Gap 'follower'->'leader' = 199.479 (headway=11.665)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.665/-1.0
+Time 119.0: Gap 'follower'->'leader' = 199.729 (headway=11.680)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.680/-1.0
+Time 119.1: Gap 'follower'->'leader' = 199.979 (headway=11.695)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.695/-1.0
+Time 119.2: Gap 'follower'->'leader' = 200.229 (headway=11.709)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.709/-1.0
+Time 119.3: Gap 'follower'->'leader' = 200.479 (headway=11.724)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.724/-1.0
+Time 119.4: Gap 'follower'->'leader' = 200.729 (headway=11.739)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.739/-1.0
+Time 119.5: Gap 'follower'->'leader' = 200.979 (headway=11.753)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.753/-1.0
+Time 119.6: Gap 'follower'->'leader' = 201.229 (headway=11.768)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.768/-1.0
+Time 119.7: Gap 'follower'->'leader' = 201.479 (headway=11.782)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.782/-1.0
+Time 119.8: Gap 'follower'->'leader' = 201.729 (headway=11.797)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.797/-1.0
+Time 119.9: Gap 'follower'->'leader' = 201.979 (headway=11.812)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.812/-1.0
+Time 120.0: Gap 'follower'->'leader' = 202.229 (headway=11.826)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.826/-1.0
+Time 120.1: Gap 'follower'->'leader' = 202.479 (headway=11.841)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.841/-1.0
+Time 120.2: Gap 'follower'->'leader' = 202.729 (headway=11.856)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.856/-1.0
+Time 120.3: Gap 'follower'->'leader' = 202.979 (headway=11.870)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.870/-1.0
+Time 120.4: Gap 'follower'->'leader' = 203.229 (headway=11.885)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.885/-1.0
+Time 120.5: Gap 'follower'->'leader' = 203.479 (headway=11.899)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.899/-1.0
+Time 120.6: Gap 'follower'->'leader' = 203.729 (headway=11.914)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.914/-1.0
+Time 120.7: Gap 'follower'->'leader' = 203.979 (headway=11.929)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.929/-1.0
+Time 120.8: Gap 'follower'->'leader' = 204.229 (headway=11.943)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.943/-1.0
+Time 120.9: Gap 'follower'->'leader' = 204.479 (headway=11.958)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.958/-1.0
+Time 121.0: Gap 'follower'->'leader' = 204.729 (headway=11.972)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.972/-1.0
+Time 121.1: Gap 'follower'->'leader' = 204.979 (headway=11.987)
+'follower' speed = 17.09999999999982
+Current/target headway: 11.987/-1.0
+Time 121.2: Gap 'follower'->'leader' = 205.229 (headway=12.002)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.002/-1.0
+Time 121.3: Gap 'follower'->'leader' = 205.479 (headway=12.016)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.016/-1.0
+Time 121.4: Gap 'follower'->'leader' = 205.729 (headway=12.031)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.031/-1.0
+Time 121.5: Gap 'follower'->'leader' = 205.979 (headway=12.046)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.046/-1.0
+Time 121.6: Gap 'follower'->'leader' = 206.229 (headway=12.060)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.060/-1.0
+Time 121.7: Gap 'follower'->'leader' = 206.479 (headway=12.075)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.075/-1.0
+Time 121.8: Gap 'follower'->'leader' = 206.729 (headway=12.089)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.089/-1.0
+Time 121.9: Gap 'follower'->'leader' = 206.979 (headway=12.104)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.104/-1.0
+Time 122.0: Gap 'follower'->'leader' = 207.229 (headway=12.119)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.119/-1.0
+Time 122.1: Gap 'follower'->'leader' = 207.479 (headway=12.133)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.133/-1.0
+Time 122.2: Gap 'follower'->'leader' = 207.729 (headway=12.148)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.148/-1.0
+Time 122.3: Gap 'follower'->'leader' = 207.979 (headway=12.163)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.163/-1.0
+Time 122.4: Gap 'follower'->'leader' = 208.229 (headway=12.177)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.177/-1.0
+Time 122.5: Gap 'follower'->'leader' = 208.479 (headway=12.192)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.192/-1.0
+Time 122.6: Gap 'follower'->'leader' = 208.729 (headway=12.206)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.206/-1.0
+Time 122.7: Gap 'follower'->'leader' = 208.979 (headway=12.221)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.221/-1.0
+Time 122.8: Gap 'follower'->'leader' = 209.229 (headway=12.236)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.236/-1.0
+Time 122.9: Gap 'follower'->'leader' = 209.479 (headway=12.250)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.250/-1.0
+Time 123.0: Gap 'follower'->'leader' = 209.729 (headway=12.265)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.265/-1.0
+Time 123.1: Gap 'follower'->'leader' = 209.979 (headway=12.279)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.279/-1.0
+Time 123.2: Gap 'follower'->'leader' = 210.229 (headway=12.294)
+'follower' speed = 17.09999999999982
+Current/target headway: 12.294/-1.0
+Time 123.3: Gap 'follower'->'leader' = 210.479 (headway=12.309)
+'follower' speed = 17.099999999999817
+Current/target headway: 12.309/-1.0
+Time 123.4: Gap 'follower'->'leader' = 210.729 (headway=12.323)
+'follower' speed = 17.099999999999813
+Current/target headway: 12.323/-1.0
+Time 123.5: Gap 'follower'->'leader' = 210.979 (headway=12.338)
+'follower' speed = 17.09999999999981
+Current/target headway: 12.338/-1.0
+Time 123.6: Gap 'follower'->'leader' = 211.229 (headway=12.353)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.353/-1.0
+Time 123.7: Gap 'follower'->'leader' = 211.479 (headway=12.367)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.367/-1.0
+Time 123.8: Gap 'follower'->'leader' = 211.729 (headway=12.382)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.382/-1.0
+Time 123.9: Gap 'follower'->'leader' = 211.979 (headway=12.396)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.396/-1.0
+Time 124.0: Gap 'follower'->'leader' = 212.229 (headway=12.411)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.411/-1.0
+Time 124.1: Gap 'follower'->'leader' = 212.479 (headway=12.426)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.426/-1.0
+Time 124.2: Gap 'follower'->'leader' = 212.729 (headway=12.440)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.440/-1.0
+Time 124.3: Gap 'follower'->'leader' = 212.979 (headway=12.455)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.455/-1.0
+Time 124.4: Gap 'follower'->'leader' = 213.229 (headway=12.470)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.470/-1.0
+Time 124.5: Gap 'follower'->'leader' = 213.479 (headway=12.484)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.484/-1.0
+Time 124.6: Gap 'follower'->'leader' = 213.729 (headway=12.499)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.499/-1.0
+Time 124.7: Gap 'follower'->'leader' = 213.979 (headway=12.513)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.513/-1.0
+Time 124.8: Gap 'follower'->'leader' = 214.229 (headway=12.528)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.528/-1.0
+Time 124.9: Gap 'follower'->'leader' = 214.479 (headway=12.543)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.543/-1.0
+Time 125.0: Gap 'follower'->'leader' = 214.729 (headway=12.557)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.557/-1.0
+Time 125.1: Gap 'follower'->'leader' = 214.979 (headway=12.572)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.572/-1.0
+Time 125.2: Gap 'follower'->'leader' = 215.229 (headway=12.587)
+'follower' speed = 17.099999999999806
+Current/target headway: 12.587/-1.0
+Time 125.3: Gap 'follower'->'leader' = 215.479 (headway=12.601)
+'follower' speed = 17.09999999999981
+Current/target headway: 12.601/-1.0
+Time 125.4: Gap 'follower'->'leader' = 215.729 (headway=12.616)
+'follower' speed = 17.099999999999817
+Current/target headway: 12.616/-1.0
+Time 125.5: Gap 'follower'->'leader' = 215.979 (headway=12.630)
+'follower' speed = 17.099999999999827
+Current/target headway: 12.630/-1.0
+Time 125.6: Gap 'follower'->'leader' = 216.229 (headway=12.645)
+'follower' speed = 17.09999999999984
+Current/target headway: 12.645/-1.0
+Time 125.7: Gap 'follower'->'leader' = 216.479 (headway=12.660)
+'follower' speed = 17.099999999999856
+Current/target headway: 12.660/-1.0
+Time 125.8: Gap 'follower'->'leader' = 216.729 (headway=12.674)
+'follower' speed = 17.099999999999874
+Current/target headway: 12.674/-1.0
+Time 125.9: Gap 'follower'->'leader' = 216.979 (headway=12.689)
+'follower' speed = 17.099999999999895
+Current/target headway: 12.689/-1.0
+Time 126.0: Gap 'follower'->'leader' = 217.229 (headway=12.703)
+'follower' speed = 17.099999999999916
+Current/target headway: 12.703/-1.0
+Time 126.1: Gap 'follower'->'leader' = 217.479 (headway=12.718)
+'follower' speed = 17.099999999999937
+Current/target headway: 12.718/-1.0
+Time 126.2: Gap 'follower'->'leader' = 217.729 (headway=12.733)
+'follower' speed = 17.099999999999962
+Current/target headway: 12.733/-1.0
+Time 126.3: Gap 'follower'->'leader' = 217.979 (headway=12.747)
+'follower' speed = 17.099999999999987
+Current/target headway: 12.747/-1.0
+Time 126.4: Gap 'follower'->'leader' = 218.229 (headway=12.762)
+'follower' speed = 17.100000000000012
+Current/target headway: 12.762/-1.0
+Time 126.5: Gap 'follower'->'leader' = 218.479 (headway=12.777)
+'follower' speed = 17.100000000000037
+Current/target headway: 12.777/-1.0
+Time 126.6: Gap 'follower'->'leader' = 218.729 (headway=12.791)
+'follower' speed = 17.100000000000062
+Current/target headway: 12.791/-1.0
+Time 126.7: Gap 'follower'->'leader' = 218.979 (headway=12.806)
+'follower' speed = 17.10000000000009
+Current/target headway: 12.806/-1.0
+Time 126.8: Gap 'follower'->'leader' = 219.229 (headway=12.820)
+'follower' speed = 17.10000000000012
+Current/target headway: 12.820/-1.0
+Time 126.9: Gap 'follower'->'leader' = 219.479 (headway=12.835)
+'follower' speed = 17.10000000000014
+Current/target headway: 12.835/-1.0
+Time 127.0: Gap 'follower'->'leader' = 219.729 (headway=12.850)
+'follower' speed = 17.10000000000016
+Current/target headway: 12.850/-1.0
+Time 127.1: Gap 'follower'->'leader' = 219.979 (headway=12.864)
+'follower' speed = 17.10000000000018
+Current/target headway: 12.864/-1.0
+Time 127.2: Gap 'follower'->'leader' = 220.229 (headway=12.879)
+'follower' speed = 17.100000000000193
+Current/target headway: 12.879/-1.0
+Time 127.3: Gap 'follower'->'leader' = 220.479 (headway=12.894)
+'follower' speed = 17.100000000000204
+Current/target headway: 12.894/-1.0
+Time 127.4: Gap 'follower'->'leader' = 220.729 (headway=12.908)
+'follower' speed = 17.100000000000215
+Current/target headway: 12.908/-1.0
+Time 127.5: Gap 'follower'->'leader' = 220.979 (headway=12.923)
+'follower' speed = 17.10000000000022
+Current/target headway: 12.923/-1.0
+Time 127.6: Gap 'follower'->'leader' = 221.229 (headway=12.937)
+'follower' speed = 17.10000000000023
+Current/target headway: 12.937/-1.0
+Time 127.7: Gap 'follower'->'leader' = 221.479 (headway=12.952)
+'follower' speed = 17.100000000000236
+Current/target headway: 12.952/-1.0
+Time 127.8: Gap 'follower'->'leader' = 221.729 (headway=12.967)
+'follower' speed = 17.10000000000024
+Current/target headway: 12.967/-1.0
+Time 127.9: Gap 'follower'->'leader' = 221.979 (headway=12.981)
+'follower' speed = 17.100000000000243
+Current/target headway: 12.981/-1.0
+Time 128.0: Gap 'follower'->'leader' = 222.229 (headway=12.996)
+'follower' speed = 17.100000000000247
+Current/target headway: 12.996/-1.0
+Time 128.1: Gap 'follower'->'leader' = 222.479 (headway=13.010)
+'follower' speed = 17.10000000000025
+Current/target headway: 13.010/-1.0
+Time 128.2: Gap 'follower'->'leader' = 222.729 (headway=13.025)
+'follower' speed = 17.100000000000254
+Current/target headway: 13.025/-1.0
+Time 128.3: Gap 'follower'->'leader' = 222.979 (headway=13.040)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.040/-1.0
+Time 128.4: Gap 'follower'->'leader' = 223.229 (headway=13.054)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.054/-1.0
+Time 128.5: Gap 'follower'->'leader' = 223.479 (headway=13.069)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.069/-1.0
+Time 128.6: Gap 'follower'->'leader' = 223.729 (headway=13.084)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.084/-1.0
+Time 128.7: Gap 'follower'->'leader' = 223.979 (headway=13.098)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.098/-1.0
+Time 128.8: Gap 'follower'->'leader' = 224.229 (headway=13.113)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.113/-1.0
+Time 128.9: Gap 'follower'->'leader' = 224.479 (headway=13.127)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.127/-1.0
+Time 129.0: Gap 'follower'->'leader' = 224.729 (headway=13.142)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.142/-1.0
+Time 129.1: Gap 'follower'->'leader' = 224.979 (headway=13.157)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.157/-1.0
+Time 129.2: Gap 'follower'->'leader' = 225.229 (headway=13.171)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.171/-1.0
+Time 129.3: Gap 'follower'->'leader' = 225.479 (headway=13.186)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.186/-1.0
+Time 129.4: Gap 'follower'->'leader' = 225.729 (headway=13.201)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.201/-1.0
+Time 129.5: Gap 'follower'->'leader' = 225.979 (headway=13.215)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.215/-1.0
+Time 129.6: Gap 'follower'->'leader' = 226.229 (headway=13.230)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.230/-1.0
+Time 129.7: Gap 'follower'->'leader' = 226.479 (headway=13.244)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.244/-1.0
+Time 129.8: Gap 'follower'->'leader' = 226.729 (headway=13.259)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.259/-1.0
+Time 129.9: Gap 'follower'->'leader' = 226.979 (headway=13.274)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.274/-1.0
+Time 130.0: Gap 'follower'->'leader' = 227.229 (headway=13.288)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.288/-1.0
+Time 130.1: Gap 'follower'->'leader' = 227.479 (headway=13.303)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.303/-1.0
+Time 130.2: Gap 'follower'->'leader' = 227.729 (headway=13.317)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.317/-1.0
+Time 130.3: Gap 'follower'->'leader' = 227.979 (headway=13.332)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.332/-1.0
+Time 130.4: Gap 'follower'->'leader' = 228.229 (headway=13.347)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.347/-1.0
+Time 130.5: Gap 'follower'->'leader' = 228.479 (headway=13.361)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.361/-1.0
+Time 130.6: Gap 'follower'->'leader' = 228.729 (headway=13.376)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.376/-1.0
+Time 130.7: Gap 'follower'->'leader' = 228.979 (headway=13.391)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.391/-1.0
+Time 130.8: Gap 'follower'->'leader' = 229.229 (headway=13.405)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.405/-1.0
+Time 130.9: Gap 'follower'->'leader' = 229.479 (headway=13.420)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.420/-1.0
+Time 131.0: Gap 'follower'->'leader' = 229.729 (headway=13.434)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.434/-1.0
+Time 131.1: Gap 'follower'->'leader' = 229.979 (headway=13.449)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.449/-1.0
+Time 131.2: Gap 'follower'->'leader' = 230.229 (headway=13.464)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.464/-1.0
+Time 131.3: Gap 'follower'->'leader' = 230.479 (headway=13.478)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.478/-1.0
+Time 131.4: Gap 'follower'->'leader' = 230.729 (headway=13.493)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.493/-1.0
+Time 131.5: Gap 'follower'->'leader' = 230.979 (headway=13.508)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.508/-1.0
+Time 131.6: Gap 'follower'->'leader' = 231.229 (headway=13.522)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.522/-1.0
+Time 131.7: Gap 'follower'->'leader' = 231.479 (headway=13.537)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.537/-1.0
+Time 131.8: Gap 'follower'->'leader' = 231.729 (headway=13.551)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.551/-1.0
+Time 131.9: Gap 'follower'->'leader' = 231.979 (headway=13.566)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.566/-1.0
+Time 132.0: Gap 'follower'->'leader' = 232.229 (headway=13.581)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.581/-1.0
+Time 132.1: Gap 'follower'->'leader' = 232.479 (headway=13.595)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.595/-1.0
+Time 132.2: Gap 'follower'->'leader' = 232.729 (headway=13.610)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.610/-1.0
+Time 132.3: Gap 'follower'->'leader' = 232.979 (headway=13.625)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.625/-1.0
+Time 132.4: Gap 'follower'->'leader' = 233.229 (headway=13.639)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.639/-1.0
+Time 132.5: Gap 'follower'->'leader' = 233.479 (headway=13.654)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.654/-1.0
+Time 132.6: Gap 'follower'->'leader' = 233.729 (headway=13.668)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.668/-1.0
+Time 132.7: Gap 'follower'->'leader' = 233.979 (headway=13.683)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.683/-1.0
+Time 132.8: Gap 'follower'->'leader' = 234.229 (headway=13.698)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.698/-1.0
+Time 132.9: Gap 'follower'->'leader' = 234.479 (headway=13.712)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.712/-1.0
+Time 133.0: Gap 'follower'->'leader' = 234.729 (headway=13.727)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.727/-1.0
+Time 133.1: Gap 'follower'->'leader' = 234.979 (headway=13.741)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.741/-1.0
+Time 133.2: Gap 'follower'->'leader' = 235.229 (headway=13.756)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.756/-1.0
+Time 133.3: Gap 'follower'->'leader' = 235.479 (headway=13.771)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.771/-1.0
+Time 133.4: Gap 'follower'->'leader' = 235.729 (headway=13.785)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.785/-1.0
+Time 133.5: Gap 'follower'->'leader' = 235.979 (headway=13.800)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.800/-1.0
+Time 133.6: Gap 'follower'->'leader' = 236.229 (headway=13.815)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.815/-1.0
+Time 133.7: Gap 'follower'->'leader' = 236.479 (headway=13.829)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.829/-1.0
+Time 133.8: Gap 'follower'->'leader' = 236.729 (headway=13.844)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.844/-1.0
+Time 133.9: Gap 'follower'->'leader' = 236.979 (headway=13.858)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.858/-1.0
+Time 134.0: Gap 'follower'->'leader' = 237.229 (headway=13.873)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.873/-1.0
+Time 134.1: Gap 'follower'->'leader' = 237.479 (headway=13.888)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.888/-1.0
+Time 134.2: Gap 'follower'->'leader' = 237.729 (headway=13.902)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.902/-1.0
+Time 134.3: Gap 'follower'->'leader' = 237.979 (headway=13.917)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.917/-1.0
+Time 134.4: Gap 'follower'->'leader' = 238.229 (headway=13.932)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.932/-1.0
+Time 134.5: Gap 'follower'->'leader' = 238.479 (headway=13.946)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.946/-1.0
+Time 134.6: Gap 'follower'->'leader' = 238.729 (headway=13.961)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.961/-1.0
+Time 134.7: Gap 'follower'->'leader' = 238.979 (headway=13.975)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.975/-1.0
+Time 134.8: Gap 'follower'->'leader' = 239.229 (headway=13.990)
+'follower' speed = 17.100000000000257
+Current/target headway: 13.990/-1.0
+Time 134.9: Gap 'follower'->'leader' = 239.479 (headway=14.005)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.005/-1.0
+Time 135.0: Gap 'follower'->'leader' = 239.729 (headway=14.019)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.019/-1.0
+Time 135.1: Gap 'follower'->'leader' = 239.979 (headway=14.034)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.034/-1.0
+Time 135.2: Gap 'follower'->'leader' = 240.229 (headway=14.048)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.048/-1.0
+Time 135.3: Gap 'follower'->'leader' = 240.479 (headway=14.063)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.063/-1.0
+Time 135.4: Gap 'follower'->'leader' = 240.729 (headway=14.078)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.078/-1.0
+Time 135.5: Gap 'follower'->'leader' = 240.979 (headway=14.092)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.092/-1.0
+Time 135.6: Gap 'follower'->'leader' = 241.229 (headway=14.107)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.107/-1.0
+Time 135.7: Gap 'follower'->'leader' = 241.479 (headway=14.122)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.122/-1.0
+Time 135.8: Gap 'follower'->'leader' = 241.729 (headway=14.136)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.136/-1.0
+Time 135.9: Gap 'follower'->'leader' = 241.979 (headway=14.151)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.151/-1.0
+Time 136.0: Gap 'follower'->'leader' = 242.229 (headway=14.165)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.165/-1.0
+Time 136.1: Gap 'follower'->'leader' = 242.479 (headway=14.180)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.180/-1.0
+Time 136.2: Gap 'follower'->'leader' = 242.729 (headway=14.195)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.195/-1.0
+Time 136.3: Gap 'follower'->'leader' = 242.979 (headway=14.209)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.209/-1.0
+Time 136.4: Gap 'follower'->'leader' = 243.229 (headway=14.224)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.224/-1.0
+Time 136.5: Gap 'follower'->'leader' = 243.479 (headway=14.239)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.239/-1.0
+Time 136.6: Gap 'follower'->'leader' = 243.729 (headway=14.253)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.253/-1.0
+Time 136.7: Gap 'follower'->'leader' = 243.979 (headway=14.268)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.268/-1.0
+Time 136.8: Gap 'follower'->'leader' = 244.229 (headway=14.282)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.282/-1.0
+Time 136.9: Gap 'follower'->'leader' = 244.479 (headway=14.297)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.297/-1.0
+Time 137.0: Gap 'follower'->'leader' = 244.729 (headway=14.312)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.312/-1.0
+Time 137.1: Gap 'follower'->'leader' = 244.979 (headway=14.326)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.326/-1.0
+Time 137.2: Gap 'follower'->'leader' = 245.229 (headway=14.341)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.341/-1.0
+Time 137.3: Gap 'follower'->'leader' = 245.479 (headway=14.356)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.356/-1.0
+Time 137.4: Gap 'follower'->'leader' = 245.729 (headway=14.370)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.370/-1.0
+Time 137.5: Gap 'follower'->'leader' = 245.979 (headway=14.385)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.385/-1.0
+Time 137.6: Gap 'follower'->'leader' = 246.229 (headway=14.399)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.399/-1.0
+Time 137.7: Gap 'follower'->'leader' = 246.479 (headway=14.414)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.414/-1.0
+Time 137.8: Gap 'follower'->'leader' = 246.729 (headway=14.429)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.429/-1.0
+Time 137.9: Gap 'follower'->'leader' = 246.979 (headway=14.443)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.443/-1.0
+Time 138.0: Gap 'follower'->'leader' = 247.229 (headway=14.458)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.458/-1.0
+Time 138.1: Gap 'follower'->'leader' = 247.479 (headway=14.472)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.472/-1.0
+Time 138.2: Gap 'follower'->'leader' = 247.729 (headway=14.487)
+'follower' speed = 17.100000000000257
+Current/target headway: 14.487/-1.0
+Time 138.3: Gap 'follower'->'leader' = 247.979 (headway=14.502)
+'follower' speed = 17.100000000000264
+Current/target headway: 14.502/-1.0
+Time 138.4: Gap 'follower'->'leader' = 248.229 (headway=14.516)
+'follower' speed = 17.100000000000268
+Current/target headway: 14.516/-1.0
+Time 138.5: Gap 'follower'->'leader' = 248.479 (headway=14.531)
+'follower' speed = 17.10000000000027
+Current/target headway: 14.531/-1.0
+Time 138.6: Gap 'follower'->'leader' = 248.729 (headway=14.546)
+'follower' speed = 17.100000000000275
+Current/target headway: 14.546/-1.0
+Time 138.7: Gap 'follower'->'leader' = 248.979 (headway=14.560)
+'follower' speed = 17.10000000000028
+Current/target headway: 14.560/-1.0
+Time 138.8: Gap 'follower'->'leader' = 249.229 (headway=14.575)
+'follower' speed = 17.100000000000282
+Current/target headway: 14.575/-1.0
+Time 138.9: Gap 'follower'->'leader' = 249.479 (headway=14.589)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.589/-1.0
+Time 139.0: Gap 'follower'->'leader' = 249.729 (headway=14.604)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.604/-1.0
+Time 139.1: Gap 'follower'->'leader' = 249.979 (headway=14.619)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.619/-1.0
+## Target Headway attained.
+Remaining: 9.9
+Time 139.2: Gap 'follower'->'leader' = 250.229 (headway=14.633)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.633/-1.0
+Remaining: 9.8
+Time 139.3: Gap 'follower'->'leader' = 250.479 (headway=14.648)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.648/-1.0
+Remaining: 9.700000000000001
+Time 139.4: Gap 'follower'->'leader' = 250.729 (headway=14.663)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.663/-1.0
+Remaining: 9.600000000000001
+Time 139.5: Gap 'follower'->'leader' = 250.979 (headway=14.677)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.677/-1.0
+Remaining: 9.500000000000002
+Time 139.6: Gap 'follower'->'leader' = 251.229 (headway=14.692)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.692/-1.0
+Remaining: 9.400000000000002
+Time 139.7: Gap 'follower'->'leader' = 251.479 (headway=14.706)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.706/-1.0
+Remaining: 9.300000000000002
+Time 139.8: Gap 'follower'->'leader' = 251.729 (headway=14.721)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.721/-1.0
+Remaining: 9.200000000000003
+Time 139.9: Gap 'follower'->'leader' = 251.979 (headway=14.736)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.736/-1.0
+Remaining: 9.100000000000003
+Time 140.0: Gap 'follower'->'leader' = 252.229 (headway=14.750)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.750/-1.0
+Remaining: 9.000000000000004
+Time 140.1: Gap 'follower'->'leader' = 252.479 (headway=14.765)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.765/-1.0
+Remaining: 8.900000000000004
+Time 140.2: Gap 'follower'->'leader' = 252.729 (headway=14.779)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.779/-1.0
+Remaining: 8.800000000000004
+Time 140.3: Gap 'follower'->'leader' = 252.979 (headway=14.794)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.794/-1.0
+Remaining: 8.700000000000005
+Time 140.4: Gap 'follower'->'leader' = 253.229 (headway=14.809)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.809/-1.0
+Remaining: 8.600000000000005
+Time 140.5: Gap 'follower'->'leader' = 253.479 (headway=14.823)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.823/-1.0
+Remaining: 8.500000000000005
+Time 140.6: Gap 'follower'->'leader' = 253.729 (headway=14.838)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.838/-1.0
+Remaining: 8.400000000000006
+Time 140.7: Gap 'follower'->'leader' = 253.979 (headway=14.853)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.853/-1.0
+Remaining: 8.300000000000006
+Time 140.8: Gap 'follower'->'leader' = 254.229 (headway=14.867)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.867/-1.0
+Remaining: 8.200000000000006
+Time 140.9: Gap 'follower'->'leader' = 254.479 (headway=14.882)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.882/-1.0
+Remaining: 8.100000000000007
+Time 141.0: Gap 'follower'->'leader' = 254.729 (headway=14.896)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.896/-1.0
+Remaining: 8.000000000000007
+Time 141.1: Gap 'follower'->'leader' = 254.979 (headway=14.911)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.911/-1.0
+Remaining: 7.9000000000000075
+Time 141.2: Gap 'follower'->'leader' = 255.229 (headway=14.926)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.926/-1.0
+Remaining: 7.800000000000008
+Time 141.3: Gap 'follower'->'leader' = 255.479 (headway=14.940)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.940/-1.0
+Remaining: 7.700000000000008
+Time 141.4: Gap 'follower'->'leader' = 255.729 (headway=14.955)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.955/-1.0
+Remaining: 7.6000000000000085
+Time 141.5: Gap 'follower'->'leader' = 255.979 (headway=14.970)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.970/-1.0
+Remaining: 7.500000000000009
+Time 141.6: Gap 'follower'->'leader' = 256.229 (headway=14.984)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.984/-1.0
+Remaining: 7.400000000000009
+Time 141.7: Gap 'follower'->'leader' = 256.479 (headway=14.999)
+'follower' speed = 17.100000000000286
+Current/target headway: 14.999/-1.0
+Remaining: 7.30000000000001
+Time 141.8: Gap 'follower'->'leader' = 256.729 (headway=15.013)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.013/-1.0
+Remaining: 7.20000000000001
+Time 141.9: Gap 'follower'->'leader' = 256.979 (headway=15.028)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.028/-1.0
+Remaining: 7.10000000000001
+Time 142.0: Gap 'follower'->'leader' = 257.229 (headway=15.043)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.043/-1.0
+Remaining: 7.000000000000011
+Time 142.1: Gap 'follower'->'leader' = 257.479 (headway=15.057)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.057/-1.0
+Remaining: 6.900000000000011
+Time 142.2: Gap 'follower'->'leader' = 257.729 (headway=15.072)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.072/-1.0
+Remaining: 6.800000000000011
+Time 142.3: Gap 'follower'->'leader' = 257.979 (headway=15.086)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.086/-1.0
+Remaining: 6.700000000000012
+Time 142.4: Gap 'follower'->'leader' = 258.229 (headway=15.101)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.101/-1.0
+Remaining: 6.600000000000012
+Time 142.5: Gap 'follower'->'leader' = 258.479 (headway=15.116)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.116/-1.0
+Remaining: 6.500000000000012
+Time 142.6: Gap 'follower'->'leader' = 258.729 (headway=15.130)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.130/-1.0
+Remaining: 6.400000000000013
+Time 142.7: Gap 'follower'->'leader' = 258.979 (headway=15.145)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.145/-1.0
+Remaining: 6.300000000000013
+Time 142.8: Gap 'follower'->'leader' = 259.229 (headway=15.160)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.160/-1.0
+Remaining: 6.2000000000000135
+Time 142.9: Gap 'follower'->'leader' = 259.479 (headway=15.174)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.174/-1.0
+Remaining: 6.100000000000014
+Time 143.0: Gap 'follower'->'leader' = 259.729 (headway=15.189)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.189/-1.0
+Remaining: 6.000000000000014
+Time 143.1: Gap 'follower'->'leader' = 259.979 (headway=15.203)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.203/-1.0
+Remaining: 5.900000000000015
+Time 143.2: Gap 'follower'->'leader' = 260.229 (headway=15.218)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.218/-1.0
+Remaining: 5.800000000000015
+Time 143.3: Gap 'follower'->'leader' = 260.479 (headway=15.233)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.233/-1.0
+Remaining: 5.700000000000015
+Time 143.4: Gap 'follower'->'leader' = 260.729 (headway=15.247)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.247/-1.0
+Remaining: 5.600000000000016
+Time 143.5: Gap 'follower'->'leader' = 260.979 (headway=15.262)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.262/-1.0
+Remaining: 5.500000000000016
+Time 143.6: Gap 'follower'->'leader' = 261.229 (headway=15.277)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.277/-1.0
+Remaining: 5.400000000000016
+Time 143.7: Gap 'follower'->'leader' = 261.479 (headway=15.291)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.291/-1.0
+Remaining: 5.300000000000017
+Time 143.8: Gap 'follower'->'leader' = 261.729 (headway=15.306)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.306/-1.0
+Remaining: 5.200000000000017
+Time 143.9: Gap 'follower'->'leader' = 261.979 (headway=15.320)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.320/-1.0
+Remaining: 5.100000000000017
+Time 144.0: Gap 'follower'->'leader' = 262.229 (headway=15.335)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.335/-1.0
+Remaining: 5.000000000000018
+Time 144.1: Gap 'follower'->'leader' = 262.479 (headway=15.350)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.350/-1.0
+Remaining: 4.900000000000018
+Time 144.2: Gap 'follower'->'leader' = 262.729 (headway=15.364)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.364/-1.0
+Remaining: 4.8000000000000185
+Time 144.3: Gap 'follower'->'leader' = 262.979 (headway=15.379)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.379/-1.0
+Remaining: 4.700000000000019
+Time 144.4: Gap 'follower'->'leader' = 263.229 (headway=15.394)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.394/-1.0
+Remaining: 4.600000000000019
+Time 144.5: Gap 'follower'->'leader' = 263.479 (headway=15.408)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.408/-1.0
+Remaining: 4.5000000000000195
+Time 144.6: Gap 'follower'->'leader' = 263.729 (headway=15.423)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.423/-1.0
+Remaining: 4.40000000000002
+Time 144.7: Gap 'follower'->'leader' = 263.979 (headway=15.437)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.437/-1.0
+Remaining: 4.30000000000002
+Time 144.8: Gap 'follower'->'leader' = 264.229 (headway=15.452)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.452/-1.0
+Remaining: 4.200000000000021
+Time 144.9: Gap 'follower'->'leader' = 264.479 (headway=15.467)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.467/-1.0
+Remaining: 4.100000000000021
+Time 145.0: Gap 'follower'->'leader' = 264.729 (headway=15.481)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.481/-1.0
+Remaining: 4.000000000000021
+Time 145.1: Gap 'follower'->'leader' = 264.979 (headway=15.496)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.496/-1.0
+Remaining: 3.9000000000000212
+Time 145.2: Gap 'follower'->'leader' = 265.229 (headway=15.510)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.510/-1.0
+Remaining: 3.800000000000021
+Time 145.3: Gap 'follower'->'leader' = 265.479 (headway=15.525)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.525/-1.0
+Remaining: 3.700000000000021
+Time 145.4: Gap 'follower'->'leader' = 265.729 (headway=15.540)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.540/-1.0
+Remaining: 3.600000000000021
+Time 145.5: Gap 'follower'->'leader' = 265.979 (headway=15.554)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.554/-1.0
+Remaining: 3.500000000000021
+Time 145.6: Gap 'follower'->'leader' = 266.229 (headway=15.569)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.569/-1.0
+Remaining: 3.400000000000021
+Time 145.7: Gap 'follower'->'leader' = 266.479 (headway=15.584)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.584/-1.0
+Remaining: 3.3000000000000207
+Time 145.8: Gap 'follower'->'leader' = 266.729 (headway=15.598)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.598/-1.0
+Remaining: 3.2000000000000206
+Time 145.9: Gap 'follower'->'leader' = 266.979 (headway=15.613)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.613/-1.0
+Remaining: 3.1000000000000205
+Time 146.0: Gap 'follower'->'leader' = 267.229 (headway=15.627)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.627/-1.0
+Remaining: 3.0000000000000204
+Time 146.1: Gap 'follower'->'leader' = 267.479 (headway=15.642)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.642/-1.0
+Remaining: 2.9000000000000203
+Time 146.2: Gap 'follower'->'leader' = 267.729 (headway=15.657)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.657/-1.0
+Remaining: 2.8000000000000203
+Time 146.3: Gap 'follower'->'leader' = 267.979 (headway=15.671)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.671/-1.0
+Remaining: 2.70000000000002
+Time 146.4: Gap 'follower'->'leader' = 268.229 (headway=15.686)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.686/-1.0
+Remaining: 2.60000000000002
+Time 146.5: Gap 'follower'->'leader' = 268.479 (headway=15.701)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.701/-1.0
+Remaining: 2.50000000000002
+Time 146.6: Gap 'follower'->'leader' = 268.729 (headway=15.715)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.715/-1.0
+Remaining: 2.40000000000002
+Time 146.7: Gap 'follower'->'leader' = 268.979 (headway=15.730)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.730/-1.0
+Remaining: 2.30000000000002
+Time 146.8: Gap 'follower'->'leader' = 269.229 (headway=15.744)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.744/-1.0
+Remaining: 2.2000000000000197
+Time 146.9: Gap 'follower'->'leader' = 269.479 (headway=15.759)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.759/-1.0
+Remaining: 2.1000000000000196
+Time 147.0: Gap 'follower'->'leader' = 269.729 (headway=15.774)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.774/-1.0
+Remaining: 2.0000000000000195
+Time 147.1: Gap 'follower'->'leader' = 269.979 (headway=15.788)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.788/-1.0
+Remaining: 1.9000000000000195
+Time 147.2: Gap 'follower'->'leader' = 270.229 (headway=15.803)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.803/-1.0
+Remaining: 1.8000000000000194
+Time 147.3: Gap 'follower'->'leader' = 270.479 (headway=15.817)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.817/-1.0
+Remaining: 1.7000000000000193
+Time 147.4: Gap 'follower'->'leader' = 270.729 (headway=15.832)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.832/-1.0
+Remaining: 1.6000000000000192
+Time 147.5: Gap 'follower'->'leader' = 270.979 (headway=15.847)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.847/-1.0
+Remaining: 1.500000000000019
+Time 147.6: Gap 'follower'->'leader' = 271.229 (headway=15.861)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.861/-1.0
+Remaining: 1.400000000000019
+Time 147.7: Gap 'follower'->'leader' = 271.479 (headway=15.876)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.876/-1.0
+Remaining: 1.300000000000019
+Time 147.8: Gap 'follower'->'leader' = 271.729 (headway=15.891)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.891/-1.0
+Remaining: 1.2000000000000188
+Time 147.9: Gap 'follower'->'leader' = 271.979 (headway=15.905)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.905/-1.0
+Remaining: 1.1000000000000187
+Time 148.0: Gap 'follower'->'leader' = 272.229 (headway=15.920)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.920/-1.0
+Remaining: 1.0000000000000187
+Time 148.1: Gap 'follower'->'leader' = 272.479 (headway=15.934)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.934/-1.0
+Remaining: 0.9000000000000187
+Time 148.2: Gap 'follower'->'leader' = 272.729 (headway=15.949)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.949/-1.0
+Remaining: 0.8000000000000187
+Time 148.3: Gap 'follower'->'leader' = 272.979 (headway=15.964)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.964/-1.0
+Remaining: 0.7000000000000187
+Time 148.4: Gap 'follower'->'leader' = 273.229 (headway=15.978)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.978/-1.0
+Remaining: 0.6000000000000187
+Time 148.5: Gap 'follower'->'leader' = 273.479 (headway=15.993)
+'follower' speed = 17.100000000000286
+Current/target headway: 15.993/-1.0
+Remaining: 0.5000000000000188
+Time 148.6: Gap 'follower'->'leader' = 273.729 (headway=16.008)
+'follower' speed = 17.100000000000286
+Current/target headway: 16.008/-1.0
+Remaining: 0.4000000000000188
+Time 148.7: Gap 'follower'->'leader' = 273.979 (headway=16.022)
+'follower' speed = 17.100000000000286
+Current/target headway: 16.022/-1.0
+Remaining: 0.3000000000000188
+Time 148.8: Gap 'follower'->'leader' = 274.229 (headway=16.037)
+'follower' speed = 17.100000000000286
+Current/target headway: 16.037/-1.0
+Remaining: 0.2000000000000188
+Time 148.9: Gap 'follower'->'leader' = 274.479 (headway=16.051)
+'follower' speed = 17.100000000000286
+Current/target headway: 16.051/-1.0
+Remaining: 0.1000000000000188
+Time 149.0: Gap 'follower'->'leader' = 274.729 (headway=16.066)
+'follower' speed = 17.100000000000286
+Current/target headway: 16.066/-1.0
+Remaining: 1.8790524691780774e-14
+Time 149.1: Gap 'follower'->'leader' = 274.979 (headway=16.081)
+'follower' speed = 17.100000000000286
+Current/target headway: 16.081/-1.0
+Remaining: 0.0
+## Gap control expired.
+Time 149.2: Gap 'follower'->'leader' = 275.229 (headway=16.095)
+'follower' speed = 17.100000000000286
+Remaining: 0.0
+Time 149.3: Gap 'follower'->'leader' = 275.479 (headway=16.110)
+'follower' speed = 17.100000000000286
+Remaining: 0.0
+Time 149.4: Gap 'follower'->'leader' = 275.729 (headway=16.125)
+'follower' speed = 17.100000000000286
+Remaining: 0.0
+Time 149.5: Gap 'follower'->'leader' = 275.979 (headway=16.139)
+'follower' speed = 17.100000000000282
+Remaining: 0.0
+Time 149.6: Gap 'follower'->'leader' = 276.229 (headway=16.154)
+'follower' speed = 17.100000000000275
+Remaining: 0.0
+Time 149.7: Gap 'follower'->'leader' = 276.479 (headway=16.168)
+'follower' speed = 17.100000000000264
+Remaining: 0.0
+Time 149.8: Gap 'follower'->'leader' = 276.729 (headway=16.183)
+'follower' speed = 17.100000000000254
+Remaining: 0.0
+Time 149.9: Gap 'follower'->'leader' = 276.979 (headway=16.198)
+'follower' speed = 17.100000000000243
+Remaining: 0.0
+Time 150.0: Gap 'follower'->'leader' = 277.229 (headway=16.212)
+'follower' speed = 17.10000000000023
+Remaining: 0.0
+Time 150.1: Gap 'follower'->'leader' = 277.479 (headway=16.227)
+'follower' speed = 17.100000000000218
+Remaining: 0.0
+Time 150.2: Gap 'follower'->'leader' = 277.729 (headway=16.241)
+'follower' speed = 17.100000000000204
+Remaining: 0.0
+Time 150.3: Gap 'follower'->'leader' = 277.978 (headway=16.237)
+'follower' speed = 17.12000000000019
+Remaining: 0.0
+Time 150.4: Gap 'follower'->'leader' = 278.224 (headway=16.217)
+'follower' speed = 17.156821600000175
+Remaining: 0.0
+Time 150.5: Gap 'follower'->'leader' = 278.466 (headway=16.183)
+'follower' speed = 17.207631511328156
+Remaining: 0.0
+Time 150.6: Gap 'follower'->'leader' = 278.701 (headway=16.107)
+'follower' speed = 17.30332625087503
+Remaining: 0.0
+Time 150.7: Gap 'follower'->'leader' = 278.926 (headway=16.035)
+'follower' speed = 17.39519320084003
+Remaining: 0.0
+Time 150.8: Gap 'follower'->'leader' = 279.142 (headway=15.966)
+'follower' speed = 17.48338547280643
+Remaining: 0.0
+Time 150.9: Gap 'follower'->'leader' = 279.349 (headway=15.901)
+'follower' speed = 17.568050053894172
+Remaining: 0.0
+Time 151.0: Gap 'follower'->'leader' = 279.548 (headway=15.839)
+'follower' speed = 17.649328051738404
+Remaining: 0.0
+Time 151.1: Gap 'follower'->'leader' = 279.739 (headway=15.780)
+'follower' speed = 17.72735492966887
+Remaining: 0.0
+Time 151.2: Gap 'follower'->'leader' = 279.923 (headway=15.724)
+'follower' speed = 17.802260732482114
+Remaining: 0.0
+Time 151.3: Gap 'follower'->'leader' = 280.099 (headway=15.671)
+'follower' speed = 17.87417030318283
+Remaining: 0.0
+Time 151.4: Gap 'follower'->'leader' = 280.268 (headway=15.620)
+'follower' speed = 17.943203491055517
+Remaining: 0.0
+Time 151.5: Gap 'follower'->'leader' = 280.431 (headway=15.571)
+'follower' speed = 18.009475351413297
+Remaining: 0.0
+Time 151.6: Gap 'follower'->'leader' = 280.586 (headway=15.525)
+'follower' speed = 18.073096337356766
+Remaining: 0.0
+Time 151.7: Gap 'follower'->'leader' = 280.736 (headway=15.481)
+'follower' speed = 18.134172483862496
+Remaining: 0.0
+Time 151.8: Gap 'follower'->'leader' = 280.880 (headway=15.439)
+'follower' speed = 18.192805584507997
+Remaining: 0.0
+Time 151.9: Gap 'follower'->'leader' = 281.018 (headway=15.399)
+'follower' speed = 18.249093361127677
+Remaining: 0.0
+Time 152.0: Gap 'follower'->'leader' = 281.150 (headway=15.361)
+'follower' speed = 18.30312962668257
+Remaining: 0.0
+Time 152.1: Gap 'follower'->'leader' = 281.277 (headway=15.324)
+'follower' speed = 18.355004441615268
+Remaining: 0.0
+Time 152.2: Gap 'follower'->'leader' = 281.399 (headway=15.289)
+'follower' speed = 18.40480426395066
+Remaining: 0.0
+Time 152.3: Gap 'follower'->'leader' = 281.516 (headway=15.256)
+'follower' speed = 18.452612093392634
+Remaining: 0.0
+Time 152.4: Gap 'follower'->'leader' = 281.629 (headway=15.224)
+'follower' speed = 18.49850760965693
+Remaining: 0.0
+Time 152.5: Gap 'follower'->'leader' = 281.737 (headway=15.194)
+'follower' speed = 18.54256730527065
+Remaining: 0.0
+Time 152.6: Gap 'follower'->'leader' = 281.840 (headway=15.165)
+'follower' speed = 18.584864613059825
+Remaining: 0.0
+Time 152.7: Gap 'follower'->'leader' = 281.940 (headway=15.137)
+'follower' speed = 18.625470028537432
+Remaining: 0.0
+Time 152.8: Gap 'follower'->'leader' = 282.035 (headway=15.111)
+'follower' speed = 18.664451227395936
+Remaining: 0.0
+Time 152.9: Gap 'follower'->'leader' = 282.127 (headway=15.085)
+'follower' speed = 18.701873178300097
+Remaining: 0.0
+Time 153.0: Gap 'follower'->'leader' = 282.215 (headway=15.061)
+'follower' speed = 18.737798251168094
+Remaining: 0.0
+Time 153.1: Gap 'follower'->'leader' = 282.299 (headway=15.038)
+'follower' speed = 18.77228632112137
+Remaining: 0.0
+Time 153.2: Gap 'follower'->'leader' = 282.381 (headway=15.016)
+'follower' speed = 18.805394868276515
+Remaining: 0.0
+Time 153.3: Gap 'follower'->'leader' = 282.458 (headway=14.995)
+'follower' speed = 18.837179073545453
+Remaining: 0.0
+Time 153.4: Gap 'follower'->'leader' = 282.533 (headway=14.974)
+'follower' speed = 18.867691910603636
+Remaining: 0.0
+Time 153.5: Gap 'follower'->'leader' = 282.605 (headway=14.955)
+'follower' speed = 18.89698423417949
+Remaining: 0.0
+Time 153.6: Gap 'follower'->'leader' = 282.674 (headway=14.936)
+'follower' speed = 18.92510486481231
+Remaining: 0.0
+Time 153.7: Gap 'follower'->'leader' = 282.740 (headway=14.919)
+'follower' speed = 18.95210067021982
+Remaining: 0.0
+Time 153.8: Gap 'follower'->'leader' = 282.804 (headway=14.902)
+'follower' speed = 18.978016643411028
+Remaining: 0.0
+Time 153.9: Gap 'follower'->'leader' = 282.864 (headway=14.885)
+'follower' speed = 19.002895977674587
+Remaining: 0.0
+Time 154.0: Gap 'follower'->'leader' = 282.923 (headway=14.870)
+'follower' speed = 19.026780138567602
+Remaining: 0.0
+Time 154.1: Gap 'follower'->'leader' = 282.979 (headway=14.855)
+'follower' speed = 19.0497089330249
+Remaining: 0.0
+Time 154.2: Gap 'follower'->'leader' = 283.033 (headway=14.840)
+'follower' speed = 19.071720575703903
+Remaining: 0.0
+Time 154.3: Gap 'follower'->'leader' = 283.085 (headway=14.827)
+'follower' speed = 19.09285175267575
+Remaining: 0.0
+Time 154.4: Gap 'follower'->'leader' = 283.135 (headway=14.814)
+'follower' speed = 19.11313768256872
+Remaining: 0.0
+Time 154.5: Gap 'follower'->'leader' = 283.182 (headway=14.801)
+'follower' speed = 19.132612175265972
+Remaining: 0.0
+Time 154.6: Gap 'follower'->'leader' = 283.228 (headway=14.789)
+'follower' speed = 19.151307688255333
+Remaining: 0.0
+Time 154.7: Gap 'follower'->'leader' = 283.272 (headway=14.777)
+'follower' speed = 19.16925538072512
+Remaining: 0.0
+Time 154.8: Gap 'follower'->'leader' = 283.314 (headway=14.766)
+'follower' speed = 19.186485165496116
+Remaining: 0.0
+Time 154.9: Gap 'follower'->'leader' = 283.355 (headway=14.756)
+'follower' speed = 19.203025758876272
+Remaining: 0.0
+Time 155.0: Gap 'follower'->'leader' = 283.394 (headway=14.746)
+'follower' speed = 19.21890472852122
+Remaining: 0.0
+Time 155.1: Gap 'follower'->'leader' = 283.431 (headway=14.736)
+'follower' speed = 19.23414853938037
+Remaining: 0.0
+Time 155.2: Gap 'follower'->'leader' = 283.467 (headway=14.726)
+'follower' speed = 19.248782597805157
+Remaining: 0.0
+Time 155.3: Gap 'follower'->'leader' = 283.501 (headway=14.718)
+'follower' speed = 19.26283129389295
+Remaining: 0.0
+Time 155.4: Gap 'follower'->'leader' = 283.534 (headway=14.709)
+'follower' speed = 19.276318042137234
+Remaining: 0.0
+Time 155.5: Gap 'follower'->'leader' = 283.566 (headway=14.701)
+'follower' speed = 19.289265320451744
+Remaining: 0.0
+Time 155.6: Gap 'follower'->'leader' = 283.597 (headway=14.693)
+'follower' speed = 19.301694707633676
+Remaining: 0.0
+Time 155.7: Gap 'follower'->'leader' = 283.626 (headway=14.685)
+'follower' speed = 19.31362691932833
+Remaining: 0.0
+Time 155.8: Gap 'follower'->'leader' = 283.654 (headway=14.678)
+'follower' speed = 19.325081842555196
+Remaining: 0.0
+Time 155.9: Gap 'follower'->'leader' = 283.681 (headway=14.671)
+'follower' speed = 19.33607856885299
+Remaining: 0.0
+Time 156.0: Gap 'follower'->'leader' = 283.707 (headway=14.664)
+'follower' speed = 19.34663542609887
+Remaining: 0.0
+Time 156.1: Gap 'follower'->'leader' = 283.731 (headway=14.658)
+'follower' speed = 19.356770009054916
+Remaining: 0.0
+Time 156.2: Gap 'follower'->'leader' = 283.755 (headway=14.652)
+'follower' speed = 19.36649920869272
+Remaining: 0.0
+Time 156.3: Gap 'follower'->'leader' = 283.778 (headway=14.646)
+'follower' speed = 19.37583924034501
+Remaining: 0.0
+Time 156.4: Gap 'follower'->'leader' = 283.800 (headway=14.640)
+'follower' speed = 19.384805670731208
+Remaining: 0.0
+Time 156.5: Gap 'follower'->'leader' = 283.821 (headway=14.635)
+'follower' speed = 19.39341344390196
+Remaining: 0.0
+Time 156.6: Gap 'follower'->'leader' = 283.841 (headway=14.630)
+'follower' speed = 19.40167690614588
+Remaining: 0.0
+Time 156.7: Gap 'follower'->'leader' = 283.861 (headway=14.625)
+'follower' speed = 19.409609829900045
+Remaining: 0.0
+Time 156.8: Gap 'follower'->'leader' = 283.880 (headway=14.620)
+'follower' speed = 19.417225436704044
+Remaining: 0.0
+Time 156.9: Gap 'follower'->'leader' = 283.898 (headway=14.615)
+'follower' speed = 19.42453641923588
+Remaining: 0.0
+Time 157.0: Gap 'follower'->'leader' = 283.915 (headway=14.611)
+'follower' speed = 19.431554962466446
+Remaining: 0.0
+Time 157.1: Gap 'follower'->'leader' = 283.931 (headway=14.607)
+'follower' speed = 19.438292763967787
+Remaining: 0.0
+Time 157.2: Gap 'follower'->'leader' = 283.947 (headway=14.603)
+'follower' speed = 19.444761053409074
+Remaining: 0.0
+Time 157.3: Gap 'follower'->'leader' = 283.962 (headway=14.599)
+'follower' speed = 19.450970611272712
+Remaining: 0.0
+Time 157.4: Gap 'follower'->'leader' = 283.977 (headway=14.595)
+'follower' speed = 19.456931786821805
+Remaining: 0.0
+Time 157.5: Gap 'follower'->'leader' = 283.991 (headway=14.592)
+'follower' speed = 19.462654515348934
+Remaining: 0.0
+Time 157.6: Gap 'follower'->'leader' = 284.004 (headway=14.588)
+'follower' speed = 19.468148334734977
+Remaining: 0.0
+Time 157.7: Gap 'follower'->'leader' = 284.017 (headway=14.585)
+'follower' speed = 19.473422401345577
+Remaining: 0.0
+Time 157.8: Gap 'follower'->'leader' = 284.030 (headway=14.582)
+'follower' speed = 19.478485505291754
+Remaining: 0.0
+Time 157.9: Gap 'follower'->'leader' = 284.042 (headway=14.579)
+'follower' speed = 19.483346085080083
+Remaining: 0.0
+Time 158.0: Gap 'follower'->'leader' = 284.053 (headway=14.576)
+'follower' speed = 19.48801224167688
+Remaining: 0.0
+Time 158.1: Gap 'follower'->'leader' = 284.064 (headway=14.573)
+'follower' speed = 19.492491752009805
+Remaining: 0.0
+Time 158.2: Gap 'follower'->'leader' = 284.075 (headway=14.570)
+'follower' speed = 19.496792081929414
+Remaining: 0.0
+Time 158.3: Gap 'follower'->'leader' = 284.085 (headway=14.568)
+'follower' speed = 19.500920398652237
+Remaining: 0.0
+Time 158.4: Gap 'follower'->'leader' = 284.094 (headway=14.565)
+'follower' speed = 19.50488358270615
+Remaining: 0.0
+Time 158.5: Gap 'follower'->'leader' = 284.104 (headway=14.563)
+'follower' speed = 19.508688239397905
+Remaining: 0.0
+Time 158.6: Gap 'follower'->'leader' = 284.113 (headway=14.561)
+'follower' speed = 19.512340709821988
+Remaining: 0.0
+Time 158.7: Gap 'follower'->'leader' = 284.121 (headway=14.558)
+'follower' speed = 19.515847081429108
+Remaining: 0.0
+Time 158.8: Gap 'follower'->'leader' = 284.129 (headway=14.556)
+'follower' speed = 19.519213198171943
+Remaining: 0.0
+Time 158.9: Gap 'follower'->'leader' = 284.137 (headway=14.554)
+'follower' speed = 19.522444670245065
+Remaining: 0.0
+Time 159.0: Gap 'follower'->'leader' = 284.145 (headway=14.552)
+'follower' speed = 19.52554688343526
+Remaining: 0.0
+Time 159.1: Gap 'follower'->'leader' = 284.152 (headway=14.551)
+'follower' speed = 19.52852500809785
+Remaining: 0.0
+Time 159.2: Gap 'follower'->'leader' = 284.159 (headway=14.549)
+'follower' speed = 19.531384007773937
+Remaining: 0.0
+Time 159.3: Gap 'follower'->'leader' = 284.166 (headway=14.547)
+'follower' speed = 19.53412864746298
+Remaining: 0.0
+Time 159.4: Gap 'follower'->'leader' = 284.172 (headway=14.546)
+'follower' speed = 19.536763501564458
+Remaining: 0.0
+Time 159.5: Gap 'follower'->'leader' = 284.179 (headway=14.544)
+'follower' speed = 19.53929296150188
+Remaining: 0.0
+Time 159.6: Gap 'follower'->'leader' = 284.185 (headway=14.542)
+'follower' speed = 19.541721243041803
+Remaining: 0.0
+Time 159.7: Gap 'follower'->'leader' = 284.190 (headway=14.541)
+'follower' speed = 19.54405239332013
+Remaining: 0.0
+Time 159.8: Gap 'follower'->'leader' = 284.196 (headway=14.540)
+'follower' speed = 19.546290297587323
+Remaining: 0.0
+Time 159.9: Gap 'follower'->'leader' = 284.201 (headway=14.538)
+'follower' speed = 19.54843868568383
+Remaining: 0.0
+Time 160.0: Gap 'follower'->'leader' = 284.206 (headway=14.537)
+'follower' speed = 19.55050113825648
+Remaining: 0.0
+Time 160.1: Gap 'follower'->'leader' = 284.211 (headway=14.536)
+'follower' speed = 19.552481092726218
+Remaining: 0.0
+Time 160.2: Gap 'follower'->'leader' = 284.216 (headway=14.535)
+'follower' speed = 19.55438184901717
+Remaining: 0.0
+Time 160.3: Gap 'follower'->'leader' = 284.220 (headway=14.533)
+'follower' speed = 19.556206575056482
+Remaining: 0.0
+Time 160.4: Gap 'follower'->'leader' = 284.224 (headway=14.532)
+'follower' speed = 19.55795831205422
+Remaining: 0.0
+Time 160.5: Gap 'follower'->'leader' = 284.229 (headway=14.531)
+'follower' speed = 19.559639979572054
+Remaining: 0.0
+Time 160.6: Gap 'follower'->'leader' = 284.232 (headway=14.530)
+'follower' speed = 19.561254380389173
+Remaining: 0.0
+Time 160.7: Gap 'follower'->'leader' = 284.236 (headway=14.529)
+'follower' speed = 19.562804205173606
+Remaining: 0.0
+Time 160.8: Gap 'follower'->'leader' = 284.240 (headway=14.529)
+'follower' speed = 19.564292036966663
+Remaining: 0.0
+Time 160.9: Gap 'follower'->'leader' = 284.243 (headway=14.528)
+'follower' speed = 19.565720355487997
+Remaining: 0.0
+Time 161.0: Gap 'follower'->'leader' = 284.247 (headway=14.527)
+'follower' speed = 19.56709154126848
+Remaining: 0.0
+Time 161.1: Gap 'follower'->'leader' = 284.250 (headway=14.526)
+'follower' speed = 19.56840787961774
+Remaining: 0.0
+Time 161.2: Gap 'follower'->'leader' = 284.253 (headway=14.525)
+'follower' speed = 19.56967156443303
+Remaining: 0.0
+Time 161.3: Gap 'follower'->'leader' = 284.256 (headway=14.524)
+'follower' speed = 19.570884701855707
+Remaining: 0.0
+Time 161.4: Gap 'follower'->'leader' = 284.259 (headway=14.524)
+'follower' speed = 19.57204931378148
+Remaining: 0.0
+Time 161.5: Gap 'follower'->'leader' = 284.262 (headway=14.523)
+'follower' speed = 19.57316734123022
+Remaining: 0.0
+Time 161.6: Gap 'follower'->'leader' = 284.264 (headway=14.522)
+'follower' speed = 19.57424064758101
+Remaining: 0.0
+Time 161.7: Gap 'follower'->'leader' = 284.267 (headway=14.522)
+'follower' speed = 19.57527102167777
+Remaining: 0.0
+Time 161.8: Gap 'follower'->'leader' = 284.269 (headway=14.521)
+'follower' speed = 19.57626018081066
+Remaining: 0.0
+Time 161.9: Gap 'follower'->'leader' = 284.272 (headway=14.521)
+'follower' speed = 19.577209773578232
+Remaining: 0.0
+Time 162.0: Gap 'follower'->'leader' = 284.274 (headway=14.520)
+'follower' speed = 19.578121382635103
+Remaining: 0.0
+Time 162.1: Gap 'follower'->'leader' = 284.276 (headway=14.519)
+'follower' speed = 19.5789965273297
+Remaining: 0.0
+Time 162.2: Gap 'follower'->'leader' = 284.278 (headway=14.519)
+'follower' speed = 19.579836666236513
+Remaining: 0.0
+Time 162.3: Gap 'follower'->'leader' = 284.280 (headway=14.518)
+'follower' speed = 19.58064319958705
+Remaining: 0.0
+Time 162.4: Gap 'follower'->'leader' = 284.282 (headway=14.518)
+'follower' speed = 19.58141747160357
+Remaining: 0.0
+Time 162.5: Gap 'follower'->'leader' = 284.284 (headway=14.517)
+'follower' speed = 19.582160772739424
+Remaining: 0.0
+Time 162.6: Gap 'follower'->'leader' = 284.285 (headway=14.517)
+'follower' speed = 19.582874341829847
+Remaining: 0.0
+Time 162.7: Gap 'follower'->'leader' = 284.287 (headway=14.517)
+'follower' speed = 19.583559368156653
+Remaining: 0.0
+Time 162.8: Gap 'follower'->'leader' = 284.289 (headway=14.516)
+'follower' speed = 19.58421699343039
+Remaining: 0.0
+Time 162.9: Gap 'follower'->'leader' = 284.290 (headway=14.516)
+'follower' speed = 19.584848313693172
+Remaining: 0.0
+Time 163.0: Gap 'follower'->'leader' = 284.292 (headway=14.515)
+'follower' speed = 19.585454381145446
+Remaining: 0.0
+Time 163.1: Gap 'follower'->'leader' = 284.293 (headway=14.515)
+'follower' speed = 19.586036205899628
+Remaining: 0.0
+Time 163.2: Gap 'follower'->'leader' = 284.295 (headway=14.515)
+'follower' speed = 19.586594757663644
+Remaining: 0.0
+Time 163.3: Gap 'follower'->'leader' = 284.296 (headway=14.514)
+'follower' speed = 19.587130967357098
+Remaining: 0.0
+Time 163.4: Gap 'follower'->'leader' = 284.297 (headway=14.514)
+'follower' speed = 19.587645728662814
+Remaining: 0.0
+Time 163.5: Gap 'follower'->'leader' = 284.298 (headway=14.514)
+'follower' speed = 19.5881398995163
+Remaining: 0.0
+Time 163.6: Gap 'follower'->'leader' = 284.299 (headway=14.514)
+'follower' speed = 19.588614303535646
+Remaining: 0.0
+Time 163.7: Gap 'follower'->'leader' = 284.301 (headway=14.513)
+'follower' speed = 19.589069731394222
+Remaining: 0.0
+Time 163.8: Gap 'follower'->'leader' = 284.302 (headway=14.513)
+'follower' speed = 19.589506942138453
+Remaining: 0.0
+Time 163.9: Gap 'follower'->'leader' = 284.303 (headway=14.513)
+'follower' speed = 19.589926664452914
+Remaining: 0.0
+Time 164.0: Gap 'follower'->'leader' = 284.304 (headway=14.512)
+'follower' speed = 19.5903295978748
+Remaining: 0.0
+Time 164.1: Gap 'follower'->'leader' = 284.305 (headway=14.512)
+'follower' speed = 19.590716413959807
+Remaining: 0.0
+Time 164.2: Gap 'follower'->'leader' = 284.306 (headway=14.512)
+'follower' speed = 19.591087757401414
+Remaining: 0.0
+Time 164.3: Gap 'follower'->'leader' = 284.306 (headway=14.512)
+'follower' speed = 19.591444247105358
+Remaining: 0.0
+Time 164.4: Gap 'follower'->'leader' = 284.307 (headway=14.512)
+'follower' speed = 19.59178647722114
+Remaining: 0.0
+Time 164.5: Gap 'follower'->'leader' = 284.308 (headway=14.511)
+'follower' speed = 19.592115018132297
+Remaining: 0.0
+Time 164.6: Gap 'follower'->'leader' = 284.309 (headway=14.511)
+'follower' speed = 19.592430417407005
+Remaining: 0.0
+Time 164.7: Gap 'follower'->'leader' = 284.310 (headway=14.511)
+'follower' speed = 19.592733200710725
+Remaining: 0.0
+Time 164.8: Gap 'follower'->'leader' = 284.310 (headway=14.511)
+'follower' speed = 19.593023872682295
+Remaining: 0.0
+Time 164.9: Gap 'follower'->'leader' = 284.311 (headway=14.511)
+'follower' speed = 19.593302917775002
+Remaining: 0.0
+Time 165.0: Gap 'follower'->'leader' = 284.312 (headway=14.510)
+'follower' speed = 19.593570801064
+Remaining: 0.0
+Time 165.1: Gap 'follower'->'leader' = 284.312 (headway=14.510)
+'follower' speed = 19.59382796902144
+Remaining: 0.0
+Time 165.2: Gap 'follower'->'leader' = 284.313 (headway=14.510)
+'follower' speed = 19.594074850260583
+Remaining: 0.0
+Time 165.3: Gap 'follower'->'leader' = 284.313 (headway=14.510)
+'follower' speed = 19.594311856250158
+Remaining: 0.0
+Time 165.4: Gap 'follower'->'leader' = 284.314 (headway=14.510)
+'follower' speed = 19.594539382000153
+Remaining: 0.0
+Time 165.5: Gap 'follower'->'leader' = 284.315 (headway=14.510)
+'follower' speed = 19.594757806720146
+Remaining: 0.0
+Time 165.6: Gap 'follower'->'leader' = 284.315 (headway=14.510)
+'follower' speed = 19.59496749445134
+Remaining: 0.0
+Time 165.7: Gap 'follower'->'leader' = 284.316 (headway=14.509)
+'follower' speed = 19.595168794673285
+Remaining: 0.0
+Time 165.8: Gap 'follower'->'leader' = 284.316 (headway=14.509)
+'follower' speed = 19.595362042886354
+Remaining: 0.0
+Time 165.9: Gap 'follower'->'leader' = 284.316 (headway=14.509)
+'follower' speed = 19.5955475611709
+Remaining: 0.0
+Time 166.0: Gap 'follower'->'leader' = 284.317 (headway=14.509)
+'follower' speed = 19.595725658724064
+Remaining: 0.0
+Time 166.1: Gap 'follower'->'leader' = 284.317 (headway=14.509)
+'follower' speed = 19.5958966323751
+Remaining: 0.0
+Time 166.2: Gap 'follower'->'leader' = 284.318 (headway=14.509)
+'follower' speed = 19.596060767080097
+Remaining: 0.0
+Time 166.3: Gap 'follower'->'leader' = 284.318 (headway=14.509)
+'follower' speed = 19.596218336396895
+Remaining: 0.0
+Time 166.4: Gap 'follower'->'leader' = 284.318 (headway=14.509)
+'follower' speed = 19.596369602941017
+Remaining: 0.0
+Time 166.5: Gap 'follower'->'leader' = 284.319 (headway=14.509)
+'follower' speed = 19.596514818823376
+Remaining: 0.0
+Time 166.6: Gap 'follower'->'leader' = 284.319 (headway=14.509)
+'follower' speed = 19.59665422607044
+Remaining: 0.0
+Time 166.7: Gap 'follower'->'leader' = 284.320 (headway=14.508)
+'follower' speed = 19.596788057027624
+Remaining: 0.0
+Time 166.8: Gap 'follower'->'leader' = 284.320 (headway=14.508)
+'follower' speed = 19.59691653474652
+Remaining: 0.0
+Time 166.9: Gap 'follower'->'leader' = 284.320 (headway=14.508)
+'follower' speed = 19.597039873356657
+Remaining: 0.0
+Time 167.0: Gap 'follower'->'leader' = 284.320 (headway=14.508)
+'follower' speed = 19.59715827842239
+Remaining: 0.0
+Time 167.1: Gap 'follower'->'leader' = 284.321 (headway=14.508)
+'follower' speed = 19.597271947285495
+Remaining: 0.0
+Time 167.2: Gap 'follower'->'leader' = 284.321 (headway=14.508)
+'follower' speed = 19.597381069394075
+Remaining: 0.0
+Time 167.3: Gap 'follower'->'leader' = 284.321 (headway=14.508)
+'follower' speed = 19.59748582661831
+Remaining: 0.0
+Time 167.4: Gap 'follower'->'leader' = 284.321 (headway=14.508)
+'follower' speed = 19.597586393553577
+Remaining: 0.0
+Time 167.5: Gap 'follower'->'leader' = 284.322 (headway=14.508)
+'follower' speed = 19.597682937811435
+Remaining: 0.0
+Time 167.6: Gap 'follower'->'leader' = 284.322 (headway=14.508)
+'follower' speed = 19.59777562029898
+Remaining: 0.0
+Time 167.7: Gap 'follower'->'leader' = 284.322 (headway=14.508)
+'follower' speed = 19.59786459548702
+Remaining: 0.0
+Time 167.8: Gap 'follower'->'leader' = 284.322 (headway=14.508)
+'follower' speed = 19.59795001166754
+Remaining: 0.0
+Time 167.9: Gap 'follower'->'leader' = 284.323 (headway=14.508)
+'follower' speed = 19.598032011200836
+Remaining: 0.0
+Time 168.0: Gap 'follower'->'leader' = 284.323 (headway=14.508)
+'follower' speed = 19.5981107307528
+Remaining: 0.0
+Time 168.1: Gap 'follower'->'leader' = 284.323 (headway=14.508)
+'follower' speed = 19.598186301522688
+Remaining: 0.0
+Time 168.2: Gap 'follower'->'leader' = 284.323 (headway=14.508)
+'follower' speed = 19.59825884946178
+Remaining: 0.0
+Time 168.3: Gap 'follower'->'leader' = 284.323 (headway=14.508)
+'follower' speed = 19.598328495483308
+Remaining: 0.0
+Time 168.4: Gap 'follower'->'leader' = 284.323 (headway=14.507)
+'follower' speed = 19.598395355663975
+Remaining: 0.0
+Time 168.5: Gap 'follower'->'leader' = 284.324 (headway=14.507)
+'follower' speed = 19.598459541437414
+Remaining: 0.0
+Time 168.6: Gap 'follower'->'leader' = 284.324 (headway=14.507)
+'follower' speed = 19.598521159779917
+Remaining: 0.0
+Time 168.7: Gap 'follower'->'leader' = 284.324 (headway=14.507)
+'follower' speed = 19.59858031338872
+Remaining: 0.0
+Time 168.8: Gap 'follower'->'leader' = 284.324 (headway=14.507)
+'follower' speed = 19.59863710085317
+Remaining: 0.0
+Time 168.9: Gap 'follower'->'leader' = 284.324 (headway=14.507)
+'follower' speed = 19.598691616819046
+Remaining: 0.0
+Time 169.0: Gap 'follower'->'leader' = 284.324 (headway=14.507)
+'follower' speed = 19.598743952146286
+Remaining: 0.0
+Time 169.1: Gap 'follower'->'leader' = 284.324 (headway=14.507)
+'follower' speed = 19.598794194060435
+Remaining: 0.0
+Time 169.2: Gap 'follower'->'leader' = 284.325 (headway=14.507)
+'follower' speed = 19.598842426298017
+Remaining: 0.0
+Time 169.3: Gap 'follower'->'leader' = 284.325 (headway=14.507)
+'follower' speed = 19.598888729246095
+Remaining: 0.0
+Time 169.4: Gap 'follower'->'leader' = 284.325 (headway=14.507)
+'follower' speed = 19.59893318007625
+Remaining: 0.0
+Time 169.5: Gap 'follower'->'leader' = 284.325 (headway=14.507)
+'follower' speed = 19.598975852873203
+Remaining: 0.0
+Time 169.6: Gap 'follower'->'leader' = 284.325 (headway=14.507)
+'follower' speed = 19.599016818758276
+Remaining: 0.0
+Time 169.7: Gap 'follower'->'leader' = 284.325 (headway=14.507)
+'follower' speed = 19.599056146007946
+Remaining: 0.0
+Time 169.8: Gap 'follower'->'leader' = 284.325 (headway=14.507)
+'follower' speed = 19.599093900167627
+Remaining: 0.0
+Time 169.9: Gap 'follower'->'leader' = 284.325 (headway=14.507)
+'follower' speed = 19.599130144160924
+Remaining: 0.0
+Time 170.0: Gap 'follower'->'leader' = 284.325 (headway=14.507)
+'follower' speed = 19.599164938394487
+Remaining: 0.0
+Time 170.1: Gap 'follower'->'leader' = 284.325 (headway=14.507)
+'follower' speed = 19.59919834085871
+Remaining: 0.0
+Time 170.2: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.59923040722436
+Remaining: 0.0
+Time 170.3: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.599261190935387
+Remaining: 0.0
+Time 170.4: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.59929074329797
+Remaining: 0.0
+Time 170.5: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.59931911356605
+Remaining: 0.0
+Time 170.6: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.59934634902341
+Remaining: 0.0
+Time 170.7: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.599372495062475
+Remaining: 0.0
+Time 170.8: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.599397595259976
+Remaining: 0.0
+Time 170.9: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.599421691449578
+Remaining: 0.0
+Time 171.0: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.599444823791593
+Remaining: 0.0
+Time 171.1: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.59946703083993
+Remaining: 0.0
+Time 171.2: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.599488349606332
+Remaining: 0.0
+Time 171.3: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.59950881562208
+Remaining: 0.0
+Time 171.4: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.599528462997196
+Remaining: 0.0
+Time 171.5: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.599547324477307
+Remaining: 0.0
+Time 171.6: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.599565431498213
+Remaining: 0.0
+Time 171.7: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.599582814238286
+Remaining: 0.0
+Time 171.8: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.599599501668756
+Remaining: 0.0
+Time 171.9: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.599615521602004
+Remaining: 0.0
+Time 172.0: Gap 'follower'->'leader' = 284.326 (headway=14.507)
+'follower' speed = 19.599630900737925
+Remaining: 0.0
+Time 172.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599645664708408
+Remaining: 0.0
+Time 172.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599659838120072
+Remaining: 0.0
+Time 172.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59967344459527
+Remaining: 0.0
+Time 172.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59968650681146
+Remaining: 0.0
+Time 172.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599699046539
+Remaining: 0.0
+Time 172.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59971108467744
+Remaining: 0.0
+Time 172.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599722641290345
+Remaining: 0.0
+Time 172.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599733735638733
+Remaining: 0.0
+Time 172.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59974438621318
+Remaining: 0.0
+Time 173.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599754610764656
+Remaining: 0.0
+Time 173.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59976442633407
+Remaining: 0.0
+Time 173.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599773849280705
+Remaining: 0.0
+Time 173.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599782895309477
+Remaining: 0.0
+Time 173.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599791579497097
+Remaining: 0.0
+Time 173.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599799916317213
+Remaining: 0.0
+Time 173.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599807919664524
+Remaining: 0.0
+Time 173.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599815602877943
+Remaining: 0.0
+Time 173.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599822978762823
+Remaining: 0.0
+Time 173.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59983005961231
+Remaining: 0.0
+Time 174.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599836857227817
+Remaining: 0.0
+Time 174.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599843382938705
+Remaining: 0.0
+Time 174.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599849647621156
+Remaining: 0.0
+Time 174.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599855661716308
+Remaining: 0.0
+Time 174.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599861435247657
+Remaining: 0.0
+Time 174.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599866977837753
+Remaining: 0.0
+Time 174.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599872298724243
+Remaining: 0.0
+Time 174.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599877406775274
+Remaining: 0.0
+Time 174.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599882310504263
+Remaining: 0.0
+Time 174.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599887018084093
+Remaining: 0.0
+Time 175.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59989153736073
+Remaining: 0.0
+Time 175.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599895875866302
+Remaining: 0.0
+Time 175.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59990004083165
+Remaining: 0.0
+Time 175.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599904039198382
+Remaining: 0.0
+Time 175.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599907877630447
+Remaining: 0.0
+Time 175.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59991156252523
+Remaining: 0.0
+Time 175.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59991510002422
+Remaining: 0.0
+Time 175.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59991849602325
+Remaining: 0.0
+Time 175.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59992175618232
+Remaining: 0.0
+Time 175.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599924885935025
+Remaining: 0.0
+Time 176.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599927890497625
+Remaining: 0.0
+Time 176.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59993077487772
+Remaining: 0.0
+Time 176.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59993354388261
+Remaining: 0.0
+Time 176.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599936202127306
+Remaining: 0.0
+Time 176.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599938754042213
+Remaining: 0.0
+Time 176.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599941203880526
+Remaining: 0.0
+Time 176.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599943555725304
+Remaining: 0.0
+Time 176.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59994581349629
+Remaining: 0.0
+Time 176.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59994798095644
+Remaining: 0.0
+Time 176.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599950061718182
+Remaining: 0.0
+Time 177.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599952059249453
+Remaining: 0.0
+Time 177.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599953976879476
+Remaining: 0.0
+Time 177.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599955817804297
+Remaining: 0.0
+Time 177.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599957585092124
+Remaining: 0.0
+Time 177.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599959281688438
+Remaining: 0.0
+Time 177.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.5999609104209
+Remaining: 0.0
+Time 177.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599962474004066
+Remaining: 0.0
+Time 177.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599963975043902
+Remaining: 0.0
+Time 177.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599965416042146
+Remaining: 0.0
+Time 177.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59996679940046
+Remaining: 0.0
+Time 178.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59996812742444
+Remaining: 0.0
+Time 178.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599969402327464
+Remaining: 0.0
+Time 178.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599970626234366
+Remaining: 0.0
+Time 178.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599971801184992
+Remaining: 0.0
+Time 178.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599972929137593
+Remaining: 0.0
+Time 178.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59997401197209
+Remaining: 0.0
+Time 178.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599975051493207
+Remaining: 0.0
+Time 178.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59997604943348
+Remaining: 0.0
+Time 178.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59997700745614
+Remaining: 0.0
+Time 178.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599977927157894
+Remaining: 0.0
+Time 179.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59997881007158
+Remaining: 0.0
+Time 179.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599979657668715
+Remaining: 0.0
+Time 179.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599980471361967
+Remaining: 0.0
+Time 179.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599981252507487
+Remaining: 0.0
+Time 179.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599982002407188
+Remaining: 0.0
+Time 179.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.5999827223109
+Remaining: 0.0
+Time 179.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599983413418464
+Remaining: 0.0
+Time 179.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599984076881725
+Remaining: 0.0
+Time 179.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599984713806457
+Remaining: 0.0
+Time 179.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.5999853252542
+Remaining: 0.0
+Time 180.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59998591224403
+Remaining: 0.0
+Time 180.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599986475754267
+Remaining: 0.0
+Time 180.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599987016724096
+Remaining: 0.0
+Time 180.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59998753605513
+Remaining: 0.0
+Time 180.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599988034612927
+Remaining: 0.0
+Time 180.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59998851322841
+Remaining: 0.0
+Time 180.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599988972699276
+Remaining: 0.0
+Time 180.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599989413791306
+Remaining: 0.0
+Time 180.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599989837239654
+Remaining: 0.0
+Time 180.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599990243750067
+Remaining: 0.0
+Time 181.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599990634000065
+Remaining: 0.0
+Time 181.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599991008640064
+Remaining: 0.0
+Time 181.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999136829446
+Remaining: 0.0
+Time 181.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599991713562684
+Remaining: 0.0
+Time 181.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599992045020176
+Remaining: 0.0
+Time 181.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599992363219368
+Remaining: 0.0
+Time 181.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599992668690593
+Remaining: 0.0
+Time 181.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999296194297
+Remaining: 0.0
+Time 181.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599993243465253
+Remaining: 0.0
+Time 181.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999351372664
+Remaining: 0.0
+Time 182.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599993773177577
+Remaining: 0.0
+Time 182.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599994022250474
+Remaining: 0.0
+Time 182.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599994261360454
+Remaining: 0.0
+Time 182.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599994490906035
+Remaining: 0.0
+Time 182.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599994711269794
+Remaining: 0.0
+Time 182.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599994922819
+Remaining: 0.0
+Time 182.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999512590624
+Remaining: 0.0
+Time 182.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999532086999
+Remaining: 0.0
+Time 182.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999550803519
+Remaining: 0.0
+Time 182.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599995687713783
+Remaining: 0.0
+Time 183.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599995860205233
+Remaining: 0.0
+Time 183.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599996025797022
+Remaining: 0.0
+Time 183.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599996184765143
+Remaining: 0.0
+Time 183.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599996337374538
+Remaining: 0.0
+Time 183.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599996483879558
+Remaining: 0.0
+Time 183.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599996624524376
+Remaining: 0.0
+Time 183.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.5999967595434
+Remaining: 0.0
+Time 183.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599996889161666
+Remaining: 0.0
+Time 183.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.5999970135952
+Remaining: 0.0
+Time 183.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599997133051392
+Remaining: 0.0
+Time 184.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599997247729338
+Remaining: 0.0
+Time 184.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599997357820165
+Remaining: 0.0
+Time 184.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599997463507357
+Remaining: 0.0
+Time 184.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999756496706
+Remaining: 0.0
+Time 184.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999766236838
+Remaining: 0.0
+Time 184.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599997755873645
+Remaining: 0.0
+Time 184.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.5999978456387
+Remaining: 0.0
+Time 184.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599997931813153
+Remaining: 0.0
+Time 184.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599998014540628
+Remaining: 0.0
+Time 184.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599998093959
+Remaining: 0.0
+Time 185.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599998170200642
+Remaining: 0.0
+Time 185.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599998243392616
+Remaining: 0.0
+Time 185.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999831365691
+Remaining: 0.0
+Time 185.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599998381110634
+Remaining: 0.0
+Time 185.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999844586621
+Remaining: 0.0
+Time 185.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999850803156
+Remaining: 0.0
+Time 185.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599998567710298
+Remaining: 0.0
+Time 185.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599998625001884
+Remaining: 0.0
+Time 185.8: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999868000181
+Remaining: 0.0
+Time 185.9: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599998732801737
+Remaining: 0.0
+Time 186.0: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599998783489667
+Remaining: 0.0
+Time 186.1: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999883215008
+Remaining: 0.0
+Time 186.2: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599998878864078
+Remaining: 0.0
+Time 186.3: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599998923709514
+Remaining: 0.0
+Time 186.4: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599998966761135
+Remaining: 0.0
+Time 186.5: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.599999008090688
+Remaining: 0.0
+Time 186.6: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999904776706
+Remaining: 0.0
+Time 186.7: Gap 'follower'->'leader' = 284.327 (headway=14.507)
+'follower' speed = 19.59999908585638
+Remaining: 0.0
+Time 186.8: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999122422123
+Remaining: 0.0
+Time 186.9: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999915752524
+Remaining: 0.0
+Time 187.0: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999919122423
+Remaining: 0.0
+Time 187.1: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999223575264
+Remaining: 0.0
+Time 187.2: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999925463225
+Remaining: 0.0
+Time 187.3: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999284446962
+Remaining: 0.0
+Time 187.4: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999313069084
+Remaining: 0.0
+Time 187.5: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999340546322
+Remaining: 0.0
+Time 187.6: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999366924468
+Remaining: 0.0
+Time 187.7: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999939224749
+Remaining: 0.0
+Time 187.8: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999941655759
+Remaining: 0.0
+Time 187.9: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999943989529
+Remaining: 0.0
+Time 188.0: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999462299476
+Remaining: 0.0
+Time 188.1: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999483807498
+Remaining: 0.0
+Time 188.2: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999504455198
+Remaining: 0.0
+Time 188.3: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999952427699
+Remaining: 0.0
+Time 188.4: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999954330591
+Remaining: 0.0
+Time 188.5: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999956157367
+Remaining: 0.0
+Time 188.6: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999579110726
+Remaining: 0.0
+Time 188.7: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999595946297
+Remaining: 0.0
+Time 188.8: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999612108444
+Remaining: 0.0
+Time 188.9: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999627624108
+Remaining: 0.0
+Time 189.0: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999642519144
+Remaining: 0.0
+Time 189.1: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999965681838
+Remaining: 0.0
+Time 189.2: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999670545646
+Remaining: 0.0
+Time 189.3: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999968372382
+Remaining: 0.0
+Time 189.4: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999696374866
+Remaining: 0.0
+Time 189.5: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999970851987
+Remaining: 0.0
+Time 189.6: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999720179078
+Remaining: 0.0
+Time 189.7: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999731371916
+Remaining: 0.0
+Time 189.8: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999974211704
+Remaining: 0.0
+Time 189.9: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999752432357
+Remaining: 0.0
+Time 190.0: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999762335063
+Remaining: 0.0
+Time 190.1: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999977184166
+Remaining: 0.0
+Time 190.2: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999780967995
+Remaining: 0.0
+Time 190.3: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999789729274
+Remaining: 0.0
+Time 190.4: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999798140104
+Remaining: 0.0
+Time 190.5: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999806214498
+Remaining: 0.0
+Time 190.6: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999981396592
+Remaining: 0.0
+Time 190.7: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999821407284
+Remaining: 0.0
+Time 190.8: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999982855099
+Remaining: 0.0
+Time 190.9: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999983540895
+Remaining: 0.0
+Time 191.0: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999984199259
+Remaining: 0.0
+Time 191.1: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999848312887
+Remaining: 0.0
+Time 191.2: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999985438037
+Remaining: 0.0
+Time 191.3: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999860205155
+Remaining: 0.0
+Time 191.4: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999986579695
+Remaining: 0.0
+Time 191.5: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999987116507
+Remaining: 0.0
+Time 191.6: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999876318467
+Remaining: 0.0
+Time 191.7: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999881265727
+Remaining: 0.0
+Time 191.8: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999886015098
+Remaining: 0.0
+Time 191.9: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999890574495
+Remaining: 0.0
+Time 192.0: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999894951516
+Remaining: 0.0
+Time 192.1: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999899153456
+Remaining: 0.0
+Time 192.2: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999903187317
+Remaining: 0.0
+Time 192.3: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999907059825
+Remaining: 0.0
+Time 192.4: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999991077743
+Remaining: 0.0
+Time 192.5: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999914346334
+Remaining: 0.0
+Time 192.6: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999917772482
+Remaining: 0.0
+Time 192.7: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999921061585
+Remaining: 0.0
+Time 192.8: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999924219123
+Remaining: 0.0
+Time 192.9: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999992725036
+Remaining: 0.0
+Time 193.0: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999930160344
+Remaining: 0.0
+Time 193.1: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999993295393
+Remaining: 0.0
+Time 193.2: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999935635775
+Remaining: 0.0
+Time 193.3: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999938210345
+Remaining: 0.0
+Time 193.4: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999940681933
+Remaining: 0.0
+Time 193.5: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999943054655
+Remaining: 0.0
+Time 193.6: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999994533247
+Remaining: 0.0
+Time 193.7: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999947519173
+Remaining: 0.0
+Time 193.8: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999949618407
+Remaining: 0.0
+Time 193.9: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999995163367
+Remaining: 0.0
+Time 194.0: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999995356832
+Remaining: 0.0
+Time 194.1: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999955425588
+Remaining: 0.0
+Time 194.2: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999957208563
+Remaining: 0.0
+Time 194.3: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999958920222
+Remaining: 0.0
+Time 194.4: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999960563412
+Remaining: 0.0
+Time 194.5: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999962140878
+Remaining: 0.0
+Time 194.6: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999963655243
+Remaining: 0.0
+Time 194.7: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999965109035
+Remaining: 0.0
+Time 194.8: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999966504672
+Remaining: 0.0
+Time 194.9: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999967844486
+Remaining: 0.0
+Time 195.0: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999969130707
+Remaining: 0.0
+Time 195.1: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999970365477
+Remaining: 0.0
+Time 195.2: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999971550858
+Remaining: 0.0
+Time 195.3: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999972688824
+Remaining: 0.0
+Time 195.4: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999973781273
+Remaining: 0.0
+Time 195.5: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999974830023
+Remaining: 0.0
+Time 195.6: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999975836823
+Remaining: 0.0
+Time 195.7: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999997680335
+Remaining: 0.0
+Time 195.8: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999977731215
+Remaining: 0.0
+Time 195.9: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999978621966
+Remaining: 0.0
+Time 196.0: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999979477086
+Remaining: 0.0
+Time 196.1: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999980298
+Remaining: 0.0
+Time 196.2: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999981086082
+Remaining: 0.0
+Time 196.3: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999998184264
+Remaining: 0.0
+Time 196.4: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999982568935
+Remaining: 0.0
+Time 196.5: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999983266176
+Remaining: 0.0
+Time 196.6: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999998393553
+Remaining: 0.0
+Time 196.7: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999998457811
+Remaining: 0.0
+Time 196.8: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999985194984
+Remaining: 0.0
+Time 196.9: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999985787186
+Remaining: 0.0
+Time 197.0: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999986355698
+Remaining: 0.0
+Time 197.1: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999998690147
+Remaining: 0.0
+Time 197.2: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999998742541
+Remaining: 0.0
+Time 197.3: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999987928392
+Remaining: 0.0
+Time 197.4: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999988411255
+Remaining: 0.0
+Time 197.5: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999988874806
+Remaining: 0.0
+Time 197.6: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999989319816
+Remaining: 0.0
+Time 197.7: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999989747023
+Remaining: 0.0
+Time 197.8: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999999015714
+Remaining: 0.0
+Time 197.9: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999990550856
+Remaining: 0.0
+Time 198.0: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999990928822
+Remaining: 0.0
+Time 198.1: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999991291668
+Remaining: 0.0
+Time 198.2: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999999164
+Remaining: 0.0
+Time 198.3: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.5999999919744
+Remaining: 0.0
+Time 198.4: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999992295423
+Remaining: 0.0
+Time 198.5: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999992603607
+Remaining: 0.0
+Time 198.6: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999992899463
+Remaining: 0.0
+Time 198.7: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999993183484
+Remaining: 0.0
+Time 198.8: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999993456144
+Remaining: 0.0
+Time 198.9: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.599999993717898
+Remaining: 0.0
+Time 199.0: Gap 'follower'->'leader' = 284.327 (headway=14.506)
+'follower' speed = 19.59999999396918
+Remaining: 0.0

--- a/tests/complex/traci/vehicle/openGap/without_maxDecel_slow_spacegap_ACC/sumo.sumocfg
+++ b/tests/complex/traci/vehicle/openGap/without_maxDecel_slow_spacegap_ACC/sumo.sumocfg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on Tue Oct 30 16:12:43 2018 by Eclipse SUMO Version v1_0_1+0370-a7f1300
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+SPDX-License-Identifier: EPL-2.0
+-->
+
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
+
+    <input>
+        <net-file value="input_net.net.xml"/>
+        <route-files value="input_routes.rou.xml"/>
+        <additional-files value="input_additional.add.xml"/>
+    </input>
+
+    <output>
+        <write-license value="true"/>
+    </output>
+
+    <time>
+        <begin value="0"/>
+        <end value="3000"/>
+    </time>
+
+    <processing>
+        <default.speeddev value="0"/>
+        <step-method.ballistic value="true" />
+	    <step-length value="0.1" />
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+        <no-step-log value="true"/>
+    </report>
+
+</configuration>


### PR DESCRIPTION
The gap controller that is used by the ToC device (and simpla) with the openGap functionality has a relatively short lookahead distance. Getting the leader across different edges (as in the circle tests) is problematic when other cf models than Krauss, as the ACC model, keep larger distances. Therefore, as discussed with @namdre , I added the brakeGap to the lookahead. 

The newly added test would show undesirable spikes in the ACC's acceleration without this fix due to a missing leader when passing edges.