### PR TITLE
Platoon-aware lane change logic

### DIFF
--- a/data/xsd/routeTypes.xsd
+++ b/data/xsd/routeTypes.xsd
@@ -174,6 +174,7 @@
                     <xsd:enumeration value="default"/>
                     <xsd:enumeration value="DK2008"/>
                     <xsd:enumeration value="LC2013"/>
+                    <xsd:enumeration value="LC2013_CC"/>
                     <xsd:enumeration value="SL2015"/>
                 </xsd:restriction>
             </xsd:simpleType>

--- a/src/microsim/MSLaneChanger.cpp
+++ b/src/microsim/MSLaneChanger.cpp
@@ -1060,6 +1060,11 @@ MSLaneChanger::checkChange(
                   << "\n";
     }
 #endif
+
+    if (state & LCA_WANTS_LANECHANGE && blocked == 0) {
+        blocked = vehicle->getLaneChangeModel().checkChangeBeforeCommitting(vehicle, state);
+        state |= blocked;
+    }
     vehicle->getLaneChangeModel().saveLCState(laneOffset, oldstate, state);
     if (blocked == 0 && (state & LCA_WANTS_LANECHANGE)) {
         // this lane change will be executed, save gaps

--- a/src/microsim/cfmodels/CC_VehicleVariables.cpp
+++ b/src/microsim/cfmodels/CC_VehicleVariables.cpp
@@ -45,7 +45,7 @@ const double CC_VehicleVariables::defaultH[MAX_N_CARS] = {0.8, 0.8, 0.8, 0.8, 0.
 CC_VehicleVariables::CC_VehicleVariables() :
     controllerAcceleration(0), frontSpeed(0), frontAcceleration(0),
     frontControllerAcceleration(0), frontDataReadTime(0), frontAngle(0), frontInitialized(false),
-    autoFeed(false), leaderVehicle(0), frontVehicle(0),
+    autoFeed(false), leaderVehicle(nullptr), leaderVehicleId(""), frontVehicle(nullptr), frontVehicleId(""),
     isLeader(true),
     accHeadwayTime(1.5), accLambda(0.1),
     useControllerAcceleration(true), leaderSpeed(0),

--- a/src/microsim/cfmodels/CC_VehicleVariables.cpp
+++ b/src/microsim/cfmodels/CC_VehicleVariables.cpp
@@ -46,6 +46,7 @@ CC_VehicleVariables::CC_VehicleVariables() :
     controllerAcceleration(0), frontSpeed(0), frontAcceleration(0),
     frontControllerAcceleration(0), frontDataReadTime(0), frontAngle(0), frontInitialized(false),
     autoFeed(false), leaderVehicle(0), frontVehicle(0),
+    isLeader(true),
     accHeadwayTime(1.5), accLambda(0.1),
     useControllerAcceleration(true), leaderSpeed(0),
     leaderAcceleration(0), leaderControllerAcceleration(0), leaderDataReadTime(0), leaderAngle(0),

--- a/src/microsim/cfmodels/CC_VehicleVariables.cpp
+++ b/src/microsim/cfmodels/CC_VehicleVariables.cpp
@@ -63,7 +63,8 @@ CC_VehicleVariables::CC_VehicleVariables() :
     engine(0), engineModel(CC_ENGINE_MODEL_FOLM),
     usePrediction(false),
     autoLaneChange(false),
-    platoonFixedLane(-1) {
+    platoonFixedLane(-1),
+    commitToLaneChange(true), noCommitReason(0), laneChangeCommitTime(-1) {
     fakeData.frontAcceleration = 0;
     fakeData.frontControllerAcceleration = 0;
     fakeData.frontDistance = 0;

--- a/src/microsim/cfmodels/CC_VehicleVariables.h
+++ b/src/microsim/cfmodels/CC_VehicleVariables.h
@@ -106,8 +106,12 @@ public:
     bool autoFeed;
     /// @brief leader vehicle, used for auto feeding
     MSVehicle* leaderVehicle;
+    /// @brief sumo id of the leader vehicle
+    std::string leaderVehicleId;
     /// @brief front sumo id, used for auto feeding
     MSVehicle* frontVehicle;
+    /// @brief sumo id of the front vehicle
+    std::string frontVehicleId;
     /// @brief whether this vehicle is leader of a platoon or not. This is mainly used by the lane change logic.
     /// By default this is true as a single vehicle is treated as a 1-vehicle platoon
     bool isLeader;

--- a/src/microsim/cfmodels/CC_VehicleVariables.h
+++ b/src/microsim/cfmodels/CC_VehicleVariables.h
@@ -206,4 +206,14 @@ public:
 
     /// @brief whole platoon lane change (not automatic). -1 indicates no need to change lane (mechanism disabled)
     int platoonFixedLane;
+
+    /// @brief when followers asks whether to actually change lane or not, what should the leader tell them?¬
+    bool commitToLaneChange;
+
+    /// @brief if a follower asks and we don't commit, what should be the blocked state to return?
+    int noCommitReason;
+
+    /// @brief timestep for which the above commit is valid¬
+    SUMOTime laneChangeCommitTime;
+
 };

--- a/src/microsim/cfmodels/CC_VehicleVariables.h
+++ b/src/microsim/cfmodels/CC_VehicleVariables.h
@@ -108,6 +108,9 @@ public:
     MSVehicle* leaderVehicle;
     /// @brief front sumo id, used for auto feeding
     MSVehicle* frontVehicle;
+    /// @brief whether this vehicle is leader of a platoon or not. This is mainly used by the lane change logic.
+    /// By default this is true as a single vehicle is treated as a 1-vehicle platoon
+    bool isLeader;
 
     /// @brief headway time for ACC
     double accHeadwayTime;

--- a/src/microsim/cfmodels/MSCFModel_CC.cpp
+++ b/src/microsim/cfmodels/MSCFModel_CC.cpp
@@ -284,7 +284,7 @@ MSCFModel_CC::finalizeSpeed(MSVehicle* const veh, double vPos) const {
         }
     }
 
-    if (vars->activeController != Plexe::DRIVER) {
+    if (vars->activeController != Plexe::DRIVER && !vars->useFixedAcceleration) {
         veh->setChosenSpeedFactor(vars->ccDesiredSpeed / veh->getLane()->getSpeedLimit());
     }
 

--- a/src/microsim/cfmodels/MSCFModel_CC.cpp
+++ b/src/microsim/cfmodels/MSCFModel_CC.cpp
@@ -1119,3 +1119,10 @@ MSCFModel*
 MSCFModel_CC::duplicate(const MSVehicleType* vtype) const {
     return new MSCFModel_CC(vtype);
 }
+
+bool
+MSCFModel_CC::isLeader(const MSVehicle *veh) const {
+    auto vars = (CC_VehicleVariables*)veh->getCarFollowVariables();
+    // TODO: this condition might not be enough
+    return vars->activeController == Plexe::ACC;
+}

--- a/src/microsim/cfmodels/MSCFModel_CC.cpp
+++ b/src/microsim/cfmodels/MSCFModel_CC.cpp
@@ -182,6 +182,29 @@ MSCFModel_CC::performPlatoonLaneChange(MSVehicle* const veh) const {
 }
 
 double
+MSCFModel_CC::getSecureGap(const MSVehicle* const veh, const MSVehicle* const pred, const double speed, const double leaderSpeed, const double leaderMaxDecel) const
+{
+    CC_VehicleVariables* vars = (CC_VehicleVariables*)veh->getCarFollowVariables();
+
+    const double tolerance = 0.8;
+    switch (vars->activeController) {
+        case Plexe::CACC:
+        case Plexe::FAKED_CACC:
+            return vars->caccSpacing * tolerance;
+        case Plexe::ACC:
+            return (vars->accHeadwayTime * speed + 2) * tolerance;
+        case Plexe::PLOEG:
+            return (vars->ploegH * speed + 2) * tolerance;
+        case Plexe::CONSENSUS:
+            return d_i_j(vars->vehicles, vars->h, 1, 0) * tolerance;
+        case Plexe::FLATBED:
+            return (vars->flatbedD - vars->flatbedH * (speed - leaderSpeed)) * tolerance;
+        case Plexe::DRIVER:
+            return myHumanDriver->getSecureGap(veh, pred, speed, leaderSpeed, leaderMaxDecel);
+    }
+}
+
+double
 MSCFModel_CC::finalizeSpeed(MSVehicle* const veh, double vPos) const {
     double vNext;
     //acceleration computed by the controller

--- a/src/microsim/cfmodels/MSCFModel_CC.cpp
+++ b/src/microsim/cfmodels/MSCFModel_CC.cpp
@@ -112,6 +112,11 @@ void
 MSCFModel_CC::setLeader(MSVehicle* veh, MSVehicle* const leader) const {
     auto* vars = (CC_VehicleVariables*) veh->getCarFollowVariables();
     vars->leaderVehicle = leader;
+    if (leader != nullptr)
+        vars->isLeader = false;
+    else
+        // if we are removing our leader, then this vehicle must become a leader of itself until being member of another platoon
+        vars->isLeader = true;
 }
 
 int
@@ -818,6 +823,7 @@ void MSCFModel_CC::setParameter(MSVehicle* veh, const std::string& key, const st
                 throw libsumo::TraCIException("Adding " + id + " as member but " + id + " is not using MSCFModel_CC");
             }
             cfm->setLeader(vehicle, veh);
+            vars->isLeader = true;
             return;
         }
         if (key.compare(PAR_REMOVE_MEMBER) == 0) {
@@ -1170,6 +1176,5 @@ MSCFModel_CC::duplicate(const MSVehicleType* vtype) const {
 bool
 MSCFModel_CC::isLeader(const MSVehicle *veh) const {
     auto vars = (CC_VehicleVariables*)veh->getCarFollowVariables();
-    // TODO: this condition might not be enough
-    return vars->activeController == Plexe::ACC;
+    return vars->isLeader;
 }

--- a/src/microsim/cfmodels/MSCFModel_CC.h
+++ b/src/microsim/cfmodels/MSCFModel_CC.h
@@ -76,6 +76,7 @@ public:
     /// @brief Destructor
     ~MSCFModel_CC();
 
+    virtual double getSecureGap(const MSVehicle* const veh, const MSVehicle* const /*pred*/, const double speed, const double leaderSpeed, const double leaderMaxDecel) const;
 
     /// @name Implementations of the MSCFModel interface
     /// @{

--- a/src/microsim/cfmodels/MSCFModel_CC.h
+++ b/src/microsim/cfmodels/MSCFModel_CC.h
@@ -249,6 +249,8 @@ public:
      */
     double getACCAcceleration(const MSVehicle* veh) const;
 
+    bool isPlatoonLaneChangeSafe(MSVehicle* const veh, bool left) const;
+
     /**
      * @brief returns the number of lanes set in the configuration file
      */
@@ -269,7 +271,6 @@ private:
     void resetConsensus(const MSVehicle* veh) const;
 
 private:
-    bool isPlatoonLaneChangeSafe(MSVehicle* const veh, bool left) const;
     void changeWholePlatoonLane(MSVehicle* const veh, int direction) const;
     void performAutoLaneChange(MSVehicle* const veh) const;
     void performPlatoonLaneChange(MSVehicle* const veh) const;

--- a/src/microsim/cfmodels/MSCFModel_CC.h
+++ b/src/microsim/cfmodels/MSCFModel_CC.h
@@ -34,6 +34,7 @@
 #include <microsim/engine/RealisticEngineModel.h>
 
 #include "CC_VehicleVariables.h"
+#include <libsumo/Helper.h>
 
 
 // ===========================================================================
@@ -250,6 +251,8 @@ public:
     double getACCAcceleration(const MSVehicle* veh) const;
 
     bool isPlatoonLaneChangeSafe(MSVehicle* const veh, bool left) const;
+
+    void setLeader(MSVehicle* veh, MSVehicle* const leader) const;
 
     /**
      * @brief returns the number of lanes set in the configuration file

--- a/src/microsim/cfmodels/MSCFModel_CC.h
+++ b/src/microsim/cfmodels/MSCFModel_CC.h
@@ -250,7 +250,7 @@ public:
      */
     double getACCAcceleration(const MSVehicle* veh) const;
 
-    bool isPlatoonLaneChangeSafe(MSVehicle* const veh, bool left) const;
+    int isPlatoonLaneChangeSafe(const MSVehicle* veh, bool left) const;
 
     void setLeader(MSVehicle* veh, MSVehicle* const leader) const;
 

--- a/src/microsim/cfmodels/MSCFModel_CC.h
+++ b/src/microsim/cfmodels/MSCFModel_CC.h
@@ -266,8 +266,9 @@ public:
      * @brief Sets the leader for a member of the platoon
      * @param veh platoon member
      * @param leader platoon leader
+     * @param leaderId platoon leader id
      */
-    void setLeader(MSVehicle* veh, MSVehicle* const leader) const;
+    void setLeader(MSVehicle* veh, MSVehicle* const leader, std::string leaderId) const;
 
     /**
      * @brief Returns whether a vehicle is a leader of a platoon or not. By default, a vehicle on its own using an ACC
@@ -291,6 +292,14 @@ public:
      * @return 0 if it is safe to change lane, the blocking reason otherwise
      */
     int commitToLaneChange(const MSVehicle* veh, bool left) const;
+
+    /**
+     * Searches for a vehicle given its sumo id. Differently from libsumo's getVehicle, this call does not throw an
+     * exception if the vehicle does not exist, so we can check for its existance
+     * @param id sumo vehicle id
+     * @return a pointer to the vehicle if found, nullptr otherwise
+     */
+    MSVehicle* findVehicle(std::string id) const;
 
     /**
      * @brief returns the number of lanes set in the configuration file

--- a/src/microsim/cfmodels/MSCFModel_CC.h
+++ b/src/microsim/cfmodels/MSCFModel_CC.h
@@ -254,6 +254,8 @@ public:
 
     void setLeader(MSVehicle* veh, MSVehicle* const leader) const;
 
+    bool isLeader(const MSVehicle* veh) const;
+
     /**
      * @brief returns the number of lanes set in the configuration file
      */

--- a/src/microsim/cfmodels/MSCFModel_CC.h
+++ b/src/microsim/cfmodels/MSCFModel_CC.h
@@ -256,6 +256,8 @@ public:
 
     bool isLeader(const MSVehicle* veh) const;
 
+    int commitToLaneChange(const MSVehicle* veh, bool left) const;
+
     /**
      * @brief returns the number of lanes set in the configuration file
      */

--- a/src/microsim/lcmodels/CMakeLists.txt
+++ b/src/microsim/lcmodels/CMakeLists.txt
@@ -7,6 +7,8 @@ set(microsim_lcmodels_STAT_SRCS
    MSLCM_DK2008.h
    MSLCM_LC2013.cpp
    MSLCM_LC2013.h
+   MSLCM_LC2013_CC.cpp
+   MSLCM_LC2013_CC.h
    MSLCM_SL2015.cpp
    MSLCM_SL2015.h
 )

--- a/src/microsim/lcmodels/MSAbstractLaneChangeModel.cpp
+++ b/src/microsim/lcmodels/MSAbstractLaneChangeModel.cpp
@@ -47,6 +47,7 @@
 #include <microsim/devices/MSDevice_Bluelight.h>
 #include "MSLCM_DK2008.h"
 #include "MSLCM_LC2013.h"
+#include "MSLCM_LC2013_CC.h"
 #include "MSLCM_SL2015.h"
 #include "MSAbstractLaneChangeModel.h"
 
@@ -86,6 +87,8 @@ MSAbstractLaneChangeModel::build(LaneChangeModel lcm, MSVehicle& v) {
             return new MSLCM_DK2008(v);
         case LaneChangeModel::LC2013:
             return new MSLCM_LC2013(v);
+        case LaneChangeModel::LC2013_CC:
+            return new MSLCM_LC2013_CC(v);
         case LaneChangeModel::SL2015:
             return new MSLCM_SL2015(v);
         case LaneChangeModel::DEFAULT:

--- a/src/microsim/lcmodels/MSAbstractLaneChangeModel.h
+++ b/src/microsim/lcmodels/MSAbstractLaneChangeModel.h
@@ -144,6 +144,20 @@ public:
      */
     virtual LaneChangeModel getModelID() const = 0;
 
+    /** @brief Informs the vehicle that it is about to be moved on an adjacent lane.
+     * The method can be used to re-evaluate the state of the vehicle and potentially abort the lane change.
+     * By default, if the method is not overridden by the lane change model implementation, nothing is altered and the vehicle will perform the lane change.
+     * @param veh the lane changing vehicle
+     * @param state current lane change state
+     * @return the blocked status of the vehicle. If the vehicle should perform the lane change, the method should return 0, corresponding to non-blocked.
+     * Otherwise the method should return a non-zero state, corresponding to the type of blockage.
+     */
+    virtual int checkChangeBeforeCommitting(const MSVehicle* veh, int state) const {
+        UNUSED_PARAMETER(veh);
+        UNUSED_PARAMETER(state);
+        return 0;
+    }
+
     /** @brief Save the state of the laneChangeModel
      * @param[in] out The OutputDevice to write the information into
      */

--- a/src/microsim/lcmodels/MSLCM_LC2013_CC.cpp
+++ b/src/microsim/lcmodels/MSLCM_LC2013_CC.cpp
@@ -1,0 +1,50 @@
+/****************************************************************************/
+// Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.dev/sumo
+// Copyright (C) 2001-2023 German Aerospace Center (DLR) and others.
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0/
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License 2.0 are satisfied: GNU General Public License, version 2
+// or later which is available at
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+/****************************************************************************/
+/// @file    MSLCM_LC2013.cpp
+/// @author  Daniel Krajzewicz
+/// @author  Jakob Erdmann
+/// @author  Friedemann Wesner
+/// @author  Sascha Krieg
+/// @author  Michael Behrisch
+/// @author  Laura Bieker
+/// @author  Leonhard Luecken
+/// @date    Fri, 08.10.2013
+///
+// A lane change model developed by J. Erdmann
+// based on the model of D. Krajzewicz developed between 2004 and 2011 (MSLCM_DK2004)
+/****************************************************************************/
+#include "MSLCM_LC2013_CC.h"
+#include <microsim/cfmodels/MSCFModel_CC.h>
+
+// ===========================================================================
+// member method definitions
+// ===========================================================================
+MSLCM_LC2013_CC::MSLCM_LC2013_CC(MSVehicle& v) : MSLCM_LC2013(v) {}
+
+MSLCM_LC2013_CC::~MSLCM_LC2013_CC() {}
+
+int MSLCM_LC2013_CC::checkChangeBeforeCommitting(const MSVehicle *veh, int state) const {
+
+    if (state & LCA_WANTS_LANECHANGE) {
+        auto *cfm = dynamic_cast<const MSCFModel_CC *>(&veh->getCarFollowModel());
+
+        if (cfm) {
+            bool left = (state & LCA_LEFT) != 0;
+            return cfm->commitToLaneChange(veh, left);
+        }
+    }
+    return 0;
+}
+
+/****************************************************************************/

--- a/src/microsim/lcmodels/MSLCM_LC2013_CC.h
+++ b/src/microsim/lcmodels/MSLCM_LC2013_CC.h
@@ -1,0 +1,50 @@
+/****************************************************************************/
+// Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.dev/sumo
+// Copyright (C) 2001-2023 German Aerospace Center (DLR) and others.
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0/
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License 2.0 are satisfied: GNU General Public License, version 2
+// or later which is available at
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+/****************************************************************************/
+/// @file    MSLCM_LC2013.h
+/// @author  Daniel Krajzewicz
+/// @author  Jakob Erdmann
+/// @author  Friedemann Wesner
+/// @author  Sascha Krieg
+/// @author  Michael Behrisch
+/// @date    Fri, 08.10.2013
+///
+// A lane change model developed by D. Krajzewicz, J. Erdmann et al. between 2004 and 2013
+/****************************************************************************/
+#pragma once
+
+#include "MSLCM_LC2013.h"
+
+// ===========================================================================
+// class definitions
+// ===========================================================================
+/**
+ * @class MSLCM_LC2013_CC
+ * @brief A lane change model developed by D. Krajzewicz, J. Erdmann
+ * et al. between 2004 and 2013, extended for atomic lane change for platoons
+ */
+class MSLCM_LC2013_CC : public MSLCM_LC2013 {
+public:
+
+    MSLCM_LC2013_CC(MSVehicle& v);
+
+    virtual ~MSLCM_LC2013_CC();
+
+    /// @brief Returns the model's id
+    LaneChangeModel getModelID() const override {
+        return LaneChangeModel::LC2013_CC;
+    }
+
+    int checkChangeBeforeCommitting(const MSVehicle* veh, int state) const override;
+
+};

--- a/src/utils/xml/SUMOXMLDefinitions.cpp
+++ b/src/utils/xml/SUMOXMLDefinitions.cpp
@@ -1270,6 +1270,7 @@ StringBijection<InsertionCheck>::Entry SUMOXMLDefinitions::insertionCheckValues[
 StringBijection<LaneChangeModel>::Entry SUMOXMLDefinitions::laneChangeModelValues[] = {
     { "DK2008",     LaneChangeModel::DK2008 },
     { "LC2013",     LaneChangeModel::LC2013 },
+    { "LC2013_CC",  LaneChangeModel::LC2013_CC },
     { "SL2015",     LaneChangeModel::SL2015 },
     { "default",    LaneChangeModel::DEFAULT } //< must be the last one
 };

--- a/src/utils/xml/SUMOXMLDefinitions.h
+++ b/src/utils/xml/SUMOXMLDefinitions.h
@@ -1882,6 +1882,7 @@ enum LaneChangeAction {
 enum class LaneChangeModel {
     DK2008,
     LC2013,
+    LC2013_CC,
     SL2015,
     DEFAULT
 };


### PR DESCRIPTION
This PR solves the long-lasting problem of making Plexe-controlled platoons change lane atomically (#14623). It does so by slightly changing `MSLaneChanger` enabling to have a custom lane change model. The changes to core files are backward compatible and do not affect "standard" SUMO simulations. A summary of the changes is listed below:

- [This commit](https://github.com/eclipse-sumo/sumo/commit/ec8e4c2d2dd755731f9fa71fe76348dc2d8c9b79) is the one making changes to the core files (MSLaneChanger and MSAbstractLaneChangeModel). As you can see the change is minimal and totally backward compatible. The idea is, when a vehicle wants to change lane and it is not blocked, call the `checkChangeBeforeCommitting` method to re-evaluate the blocking state. If not implemented, this method simply returns 0 (so not blocked) and thus have no effect.
- [This commit](https://github.com/michele-segata/plexe-sumo/commit/11d3009d42f3a79c3d4400a136c4796c41582122) instead adds a custom lane change model that extends LC2013 and which is platoon-aware. For vehicles not using `MSCFModel_CC` the lane change model has no effect, but in any case people not using platooning features would not even instantiate that.

We tested the changes running several simulations with hundreds of vehicles and platoons that can autonomously change lane and verified that no collisions occur. In fact, the test campaign revealed another bug, that is, an invalid reference to a pointer when the leader vehicle leaves the simulation. We fixed this in [this commit](https://github.com/michele-segata/plexe-sumo/commit/4c21b91114ef2e8f8f0e30ec8addc19f555b8901).
The [last commit](https://github.com/michele-segata/plexe-sumo/commit/5816341612d46a600881cdd649db5e6c3ea535f9) is another issue related to the realistic engine model which caused platooning vehicles not to converge to the desired distance due to friction forces. The commit now uses friction forces only to compute the physical limits of the vehicle.