### PR TITLE
Fix for wrong brutto occupancy calculation when minGap of vehicles is changed 

### DIFF
--- a/src/libsumo/Vehicle.cpp
+++ b/src/libsumo/Vehicle.cpp
@@ -1927,6 +1927,7 @@ Vehicle::setType(const std::string& vehID, const std::string& typeID) {
     MSVehicle* microVeh = dynamic_cast<MSVehicle*>(veh);
     if (microVeh != nullptr && microVeh->isOnRoad()) {
         microVeh->updateBestLanes(true);
+        microVeh->updateLaneBruttoSum();
     }
 }
 
@@ -2351,7 +2352,12 @@ Vehicle::setHeight(const std::string& vehID, double height) {
 
 void
 Vehicle::setMinGap(const std::string& vehID, double minGap) {
-    Helper::getVehicle(vehID)->getSingularType().setMinGap(minGap);
+    MSBaseVehicle* veh = Helper::getVehicle(vehID);
+    veh->getSingularType().setMinGap(minGap);
+    MSVehicle* microVeh = dynamic_cast<MSVehicle*>(veh);
+    if (microVeh != nullptr && microVeh->isOnRoad()) {
+        microVeh->updateLaneBruttoSum();
+    }
 }
 
 

--- a/src/microsim/MSLane.cpp
+++ b/src/microsim/MSLane.cpp
@@ -264,6 +264,7 @@ MSLane::MSLane(const std::string& id, double maxSpeed, double friction, double l
     myCanonicalSuccessorLane(nullptr),
     myBruttoVehicleLengthSum(0), myNettoVehicleLengthSum(0),
     myBruttoVehicleLengthSumToRemove(0), myNettoVehicleLengthSumToRemove(0),
+    myRecalculateBruttoSum(false),
     myLeaderInfo(width, nullptr, 0.),
     myFollowerInfo(width, nullptr, 0.),
     myLeaderInfoTime(SUMOTime_MIN),
@@ -2308,6 +2309,12 @@ MSLane::executeMovements(const SUMOTime t) {
 
 
 void
+MSLane::markRecalculateBruttoSum() {
+    myRecalculateBruttoSum = true;
+}
+
+
+void
 MSLane::updateLengthSum() {
     myBruttoVehicleLengthSum -= myBruttoVehicleLengthSumToRemove;
     myNettoVehicleLengthSum -= myNettoVehicleLengthSumToRemove;
@@ -2317,6 +2324,12 @@ MSLane::updateLengthSum() {
         // avoid numerical instability
         myBruttoVehicleLengthSum = 0;
         myNettoVehicleLengthSum = 0;
+    } else if (myRecalculateBruttoSum){
+        myBruttoVehicleLengthSum = 0;
+        for (VehCont::const_iterator i = myVehicles.begin(); i != myVehicles.end(); ++i) {
+            myBruttoVehicleLengthSum += (*i)->getVehicleType().getLengthWithGap();
+        }
+        myRecalculateBruttoSum = false;
     }
 }
 

--- a/src/microsim/MSLane.h
+++ b/src/microsim/MSLane.h
@@ -684,6 +684,10 @@ public:
     /// Insert buffered vehicle into the real lane.
     virtual void integrateNewVehicles();
 
+    /** @brief Set a flag to recalculate the brutto (including minGaps) occupancy of this lane (used if mingap is changed)
+     */
+    void markRecalculateBruttoSum();
+
     /// @brief updated current vehicle length sum (delayed to avoid lane-order-dependency)
     void updateLengthSum();
     ///@}
@@ -1539,6 +1543,9 @@ protected:
 
     /// @brief The length of all vehicles that have left this lane in the current step (this lane, excluding their minGaps)
     double myNettoVehicleLengthSumToRemove;
+
+    /// @brief Flag to recalculate the occupancy (including minGaps) after a change in minGap
+    bool myRecalculateBruttoSum;
 
     /** The lane's Links to its succeeding lanes and the default
         right-of-way rule, i.e. blocked or not blocked. */

--- a/src/microsim/MSVehicle.cpp
+++ b/src/microsim/MSVehicle.cpp
@@ -6170,6 +6170,12 @@ MSVehicle::updateBestLanes(bool forceRebuild, const MSLane* startLane) {
 #endif
 }
 
+void
+MSVehicle::updateLaneBruttoSum() {
+    if (myLane != nullptr) {
+        myLane->markRecalculateBruttoSum();
+    }
+}
 
 bool
 MSVehicle::betterContinuation(const LaneQ* bestConnectedNext, const LaneQ& m) {

--- a/src/microsim/MSVehicle.h
+++ b/src/microsim/MSVehicle.h
@@ -909,6 +909,9 @@ public:
      */
     void updateBestLanes(bool forceRebuild = false, const MSLane* startLane = 0);
 
+    /** @brief Update the lane brutto occupancy after a change in minGap
+     * */
+    void updateLaneBruttoSum();
 
     /** @brief Returns the best sequence of lanes to continue the route starting at myLane
      * @return The bestContinuations of the LaneQ for myLane (see LaneQ)

--- a/src/traci-server/TraCIServerAPI_Vehicle.cpp
+++ b/src/traci-server/TraCIServerAPI_Vehicle.cpp
@@ -1388,6 +1388,17 @@ TraCIServerAPI_Vehicle::processSet(TraCIServer& server, tcpip::Storage& inputSto
                 libsumo::Vehicle::updateBestLanes(id);
             }
             break;
+            case libsumo::VAR_MINGAP: {
+                double value = 0;
+                if (!server.readTypeCheckingDouble(inputStorage, value)) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "Setting minimum gap requires a double.", outputStorage);
+                }
+                if (value < 0.0 || fabs(value) == std::numeric_limits<double>::infinity()) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "Invalid minimum gap.", outputStorage);
+                }
+                libsumo::Vehicle::setMinGap(id, value);
+            }
+            break;
             case libsumo::VAR_MINGAP_LAT: {
                 double value = 0;
                 if (!server.readTypeCheckingDouble(inputStorage, value)) {


### PR DESCRIPTION
This PR solves the problem with variable minGaps (e.g. for platoons) causing a wrong brutto occupancy calculation (see #13024) and affecting vehicle insertion.

minGap can be changed in the following ways (possibly not an exhaustive list):

1. Changing minGap for a single vehicle, which creates a singular VType
2. Changing minGap for a VType
3. Changing the VType for a vehicle (happens in simpla)

Case 1 and Case 3 can lead to the problem, especially if used in a loop for multiple vehicles, as the exiting minGap is different than the entering minGap
Case 2 is less serious as the minGap is changed to the same value for both the inserting and exiting vehicles and any accumulated minGap difference (vehicles already moving when the change is happening) is static

The proposed solution solves the problem for the severe cases 1 and 3 by setting a flag to the vehicle's current lane object that triggers a brutto occupancy recalculation in the next step. 

Despite the existence of a setMinGap function in the libsumo Vehicle C++ API, it was not set in the TraCI Server API and was redirected to the VehicleType C++ API setMinGap function  (https://github.com/eclipse-sumo/sumo/blob/main/src/traci-server/TraCIServerAPI_Vehicle.cpp#L1404). With the proposed solution, the already existing Vehicle setMinGap function is added to the TraCI Server API, so that the MSVehicle object can access the lane object and set the recalculation flag.

Before fix:
![image](https://github.com/eclipse-sumo/sumo/assets/18355854/f68a0486-e450-4073-8541-eb523f8844f6)

After fix:
![image](https://github.com/eclipse-sumo/sumo/assets/18355854/6a0c74e0-4819-4290-bb15-96199dbc9d7b)