### PR TITLE
Change the GLOSA adaptSpeed calculation

### DIFF
--- a/tests/sumo/devices/glosa/slowDown/fcd.sumo
+++ b/tests/sumo/devices/glosa/slowDown/fcd.sumo
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on Wed Apr 21 17:17:11 2021 by Eclipse SUMO sumo Version v1_9_0+0147-f1bb915
+<!-- generated on 2024-06-21 00:52:01 by Eclipse SUMO sumo Version v1_20_0+0685-fd40beaaee6
 This data file and the accompanying materials
 are made available under the terms of the Eclipse Public License v2.0
 which accompanies this distribution, and is available at
 http://www.eclipse.org/legal/epl-v20.html
-SPDX-License-Identifier: EPL-2.0
-<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
+This file may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License 2.0 are satisfied: GNU General Public License, version 2
+or later which is available at
+https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+<sumoConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
 
     <input>
         <net-file value="net2.net.xml"/>
@@ -25,7 +30,6 @@ SPDX-License-Identifier: EPL-2.0
 
     <report>
         <xml-validation value="never"/>
-        <xml-validation.routes value="never"/>
         <duration-log.disable value="true"/>
         <no-step-log value="true"/>
     </report>
@@ -34,7 +38,7 @@ SPDX-License-Identifier: EPL-2.0
         <device.glosa.probability value="1"/>
     </glosa_device>
 
-</configuration>
+</sumoConfiguration>
 -->
 
 <fcd-export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/fcd_file.xsd">
@@ -83,58 +87,58 @@ SPDX-License-Identifier: EPL-2.0
         <vehicle id="veh0" x="-97.67" y="95.20" angle="90.00" type="custom" speed="13.89" pos="102.33" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="28.00">
-        <vehicle id="veh0" x="-84.19" y="95.20" angle="90.00" type="custom" speed="13.48" pos="115.81" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-87.50" y="95.20" angle="90.00" type="custom" speed="10.17" pos="112.50" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="29.00">
-        <vehicle id="veh0" x="-71.12" y="95.20" angle="90.00" type="custom" speed="13.07" pos="128.88" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-77.23" y="95.20" angle="90.00" type="custom" speed="10.27" pos="122.77" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="30.00">
-        <vehicle id="veh0" x="-58.46" y="95.20" angle="90.00" type="custom" speed="12.66" pos="141.54" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-66.96" y="95.20" angle="90.00" type="custom" speed="10.27" pos="133.04" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="31.00">
-        <vehicle id="veh0" x="-46.21" y="95.20" angle="90.00" type="custom" speed="12.25" pos="153.79" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-56.69" y="95.20" angle="90.00" type="custom" speed="10.27" pos="143.31" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="32.00">
-        <vehicle id="veh0" x="-34.38" y="95.20" angle="90.00" type="custom" speed="11.83" pos="165.62" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-46.42" y="95.20" angle="90.00" type="custom" speed="10.27" pos="153.58" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="33.00">
-        <vehicle id="veh0" x="-22.96" y="95.20" angle="90.00" type="custom" speed="11.42" pos="177.04" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-36.15" y="95.20" angle="90.00" type="custom" speed="10.27" pos="163.85" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="34.00">
-        <vehicle id="veh0" x="-11.96" y="95.20" angle="90.00" type="custom" speed="11.00" pos="188.04" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-25.88" y="95.20" angle="90.00" type="custom" speed="10.27" pos="174.12" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="35.00">
-        <vehicle id="veh0" x="-1.39" y="95.20" angle="90.00" type="custom" speed="10.58" pos="198.61" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-15.61" y="95.20" angle="90.00" type="custom" speed="10.27" pos="184.39" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="36.00">
-        <vehicle id="veh0" x="8.77" y="95.20" angle="90.00" type="custom" speed="10.15" pos="208.77" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-5.34" y="95.20" angle="90.00" type="custom" speed="10.27" pos="194.66" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="37.00">
-        <vehicle id="veh0" x="18.48" y="95.20" angle="90.00" type="custom" speed="9.72" pos="218.48" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="4.92" y="95.20" angle="90.00" type="custom" speed="10.27" pos="204.92" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="38.00">
-        <vehicle id="veh0" x="27.76" y="95.20" angle="90.00" type="custom" speed="9.28" pos="227.76" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="15.19" y="95.20" angle="90.00" type="custom" speed="10.27" pos="215.19" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="39.00">
-        <vehicle id="veh0" x="36.58" y="95.20" angle="90.00" type="custom" speed="8.82" pos="236.58" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="25.46" y="95.20" angle="90.00" type="custom" speed="10.27" pos="225.46" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="40.00">
-        <vehicle id="veh0" x="44.93" y="95.20" angle="90.00" type="custom" speed="8.35" pos="244.93" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="35.73" y="95.20" angle="90.00" type="custom" speed="10.27" pos="235.73" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="41.00">
-        <vehicle id="veh0" x="52.75" y="95.20" angle="90.00" type="custom" speed="7.82" pos="252.75" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="46.00" y="95.20" angle="90.00" type="custom" speed="10.27" pos="246.00" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="42.00">
-        <vehicle id="veh0" x="59.89" y="95.20" angle="90.00" type="custom" speed="7.14" pos="259.89" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="56.27" y="95.20" angle="90.00" type="custom" speed="10.27" pos="256.27" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="43.00">
-        <vehicle id="veh0" x="66.69" y="95.20" angle="90.00" type="custom" speed="6.80" pos="266.69" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="66.54" y="95.20" angle="90.00" type="custom" speed="10.27" pos="266.54" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="44.00">
-        <vehicle id="veh0" x="76.10" y="95.20" angle="90.00" type="custom" speed="9.40" pos="276.10" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="76.81" y="95.20" angle="90.00" type="custom" speed="10.27" pos="276.81" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="45.00">
-        <vehicle id="veh0" x="88.10" y="95.20" angle="90.00" type="custom" speed="12.00" pos="288.10" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="88.10" y="95.20" angle="90.00" type="custom" speed="11.29" pos="288.10" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="46.00">
         <vehicle id="veh0" x="101.99" y="95.20" angle="90.00" type="custom" speed="13.89" pos="12.39" lane=":C_16_0" slope="0.00"/>

--- a/tests/sumo/devices/glosa/slowDown/tripinfos.sumo
+++ b/tests/sumo/devices/glosa/slowDown/tripinfos.sumo
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on Wed Apr 21 17:17:11 2021 by Eclipse SUMO sumo Version v1_9_0+0147-f1bb915
+<!-- generated on 2024-06-21 00:52:01 by Eclipse SUMO sumo Version v1_20_0+0685-fd40beaaee6
 This data file and the accompanying materials
 are made available under the terms of the Eclipse Public License v2.0
 which accompanies this distribution, and is available at
 http://www.eclipse.org/legal/epl-v20.html
-SPDX-License-Identifier: EPL-2.0
-<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
+This file may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License 2.0 are satisfied: GNU General Public License, version 2
+or later which is available at
+https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+<sumoConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
 
     <input>
         <net-file value="net2.net.xml"/>
@@ -25,7 +30,6 @@ SPDX-License-Identifier: EPL-2.0
 
     <report>
         <xml-validation value="never"/>
-        <xml-validation.routes value="never"/>
         <duration-log.disable value="true"/>
         <no-step-log value="true"/>
     </report>
@@ -34,9 +38,9 @@ SPDX-License-Identifier: EPL-2.0
         <device.glosa.probability value="1"/>
     </glosa_device>
 
-</configuration>
+</sumoConfiguration>
 -->
 
 <tripinfos xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/tripinfo_file.xsd">
-    <tripinfo id="veh0" depart="20.00" departLane="WC_0" departPos="5.10" departSpeed="13.89" departDelay="0.00" arrival="54.00" arrivalLane="CE_0" arrivalPos="89.60" arrivalSpeed="13.89" duration="34.00" routeLength="394.90" waitingTime="0.00" waitingCount="0" stopTime="0.00" timeLoss="4.63" rerouteNo="0" devices="tripinfo_veh0 routing_veh0 fcd_veh0 glosa_veh0" vType="custom" speedFactor="1.00" vaporized=""/>
+    <tripinfo id="veh0" depart="20.00" departLane="WC_0" departPos="5.10" departSpeed="13.89" departDelay="0.00" arrival="54.00" arrivalLane="CE_0" arrivalPos="89.60" arrivalSpeed="13.89" duration="34.00" routeLength="394.90" waitingTime="0.00" waitingCount="0" stopTime="0.00" timeLoss="0.00" rerouteNo="0" devices="tripinfo_veh0 routing_veh0 fcd_veh0 glosa_veh0" vType="custom" speedFactor="1.00" vaporized=""/>
 </tripinfos>

--- a/tests/sumo/devices/glosa/slowDown_no/fcd.sumo
+++ b/tests/sumo/devices/glosa/slowDown_no/fcd.sumo
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on Thu Apr 22 08:39:24 2021 by Eclipse SUMO sumo Version v1_9_0+0152-2e5ad4f
+<!-- generated on 2024-06-21 00:52:01 by Eclipse SUMO sumo Version v1_20_0+0685-fd40beaaee6
 This data file and the accompanying materials
 are made available under the terms of the Eclipse Public License v2.0
 which accompanies this distribution, and is available at
 http://www.eclipse.org/legal/epl-v20.html
-SPDX-License-Identifier: EPL-2.0
-<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
+This file may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License 2.0 are satisfied: GNU General Public License, version 2
+or later which is available at
+https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+<sumoConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
 
     <input>
         <net-file value="net2.net.xml"/>
@@ -25,7 +30,6 @@ SPDX-License-Identifier: EPL-2.0
 
     <report>
         <xml-validation value="never"/>
-        <xml-validation.routes value="never"/>
         <duration-log.disable value="true"/>
         <no-step-log value="true"/>
     </report>
@@ -34,7 +38,7 @@ SPDX-License-Identifier: EPL-2.0
         <device.glosa.probability value="1"/>
     </glosa_device>
 
-</configuration>
+</sumoConfiguration>
 -->
 
 <fcd-export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/fcd_file.xsd">
@@ -73,115 +77,112 @@ SPDX-License-Identifier: EPL-2.0
         <vehicle id="veh0" x="-97.67" y="95.20" angle="90.00" type="custom" speed="13.89" pos="102.33" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="18.00">
-        <vehicle id="veh0" x="-84.36" y="95.20" angle="90.00" type="custom" speed="13.31" pos="115.64" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-88.28" y="95.20" angle="90.00" type="custom" speed="9.39" pos="111.72" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="19.00">
-        <vehicle id="veh0" x="-71.62" y="95.20" angle="90.00" type="custom" speed="12.73" pos="128.38" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-82.17" y="95.20" angle="90.00" type="custom" speed="6.11" pos="117.83" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="20.00">
-        <vehicle id="veh0" x="-59.47" y="95.20" angle="90.00" type="custom" speed="12.15" pos="140.53" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-76.00" y="95.20" angle="90.00" type="custom" speed="6.17" pos="124.00" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="21.00">
-        <vehicle id="veh0" x="-47.90" y="95.20" angle="90.00" type="custom" speed="11.57" pos="152.10" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-69.84" y="95.20" angle="90.00" type="custom" speed="6.17" pos="130.16" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="22.00">
-        <vehicle id="veh0" x="-36.62" y="95.20" angle="90.00" type="custom" speed="11.28" pos="163.38" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-63.67" y="95.20" angle="90.00" type="custom" speed="6.17" pos="136.33" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="23.00">
-        <vehicle id="veh0" x="-25.63" y="95.20" angle="90.00" type="custom" speed="10.99" pos="174.37" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-57.51" y="95.20" angle="90.00" type="custom" speed="6.17" pos="142.49" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="24.00">
-        <vehicle id="veh0" x="-14.93" y="95.20" angle="90.00" type="custom" speed="10.70" pos="185.07" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-51.34" y="95.20" angle="90.00" type="custom" speed="6.17" pos="148.66" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="25.00">
-        <vehicle id="veh0" x="-4.52" y="95.20" angle="90.00" type="custom" speed="10.41" pos="195.48" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-45.18" y="95.20" angle="90.00" type="custom" speed="6.17" pos="154.82" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="26.00">
-        <vehicle id="veh0" x="5.60" y="95.20" angle="90.00" type="custom" speed="10.12" pos="205.60" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-39.01" y="95.20" angle="90.00" type="custom" speed="6.17" pos="160.99" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="27.00">
-        <vehicle id="veh0" x="15.43" y="95.20" angle="90.00" type="custom" speed="9.83" pos="215.43" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-32.85" y="95.20" angle="90.00" type="custom" speed="6.17" pos="167.15" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="28.00">
-        <vehicle id="veh0" x="24.96" y="95.20" angle="90.00" type="custom" speed="9.54" pos="224.96" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-26.68" y="95.20" angle="90.00" type="custom" speed="6.17" pos="173.32" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="29.00">
-        <vehicle id="veh0" x="34.21" y="95.20" angle="90.00" type="custom" speed="9.25" pos="234.21" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-20.52" y="95.20" angle="90.00" type="custom" speed="6.17" pos="179.48" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="30.00">
-        <vehicle id="veh0" x="43.17" y="95.20" angle="90.00" type="custom" speed="8.96" pos="243.17" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-14.35" y="95.20" angle="90.00" type="custom" speed="6.17" pos="185.65" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="31.00">
-        <vehicle id="veh0" x="51.83" y="95.20" angle="90.00" type="custom" speed="8.66" pos="251.83" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-8.19" y="95.20" angle="90.00" type="custom" speed="6.17" pos="191.81" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="32.00">
-        <vehicle id="veh0" x="60.20" y="95.20" angle="90.00" type="custom" speed="8.37" pos="260.20" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="-2.02" y="95.20" angle="90.00" type="custom" speed="6.17" pos="197.98" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="33.00">
-        <vehicle id="veh0" x="68.29" y="95.20" angle="90.00" type="custom" speed="8.08" pos="268.29" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="4.14" y="95.20" angle="90.00" type="custom" speed="6.17" pos="204.14" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="34.00">
-        <vehicle id="veh0" x="76.08" y="95.20" angle="90.00" type="custom" speed="7.79" pos="276.08" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="10.31" y="95.20" angle="90.00" type="custom" speed="6.17" pos="210.31" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="35.00">
-        <vehicle id="veh0" x="83.58" y="95.20" angle="90.00" type="custom" speed="7.50" pos="283.58" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="16.47" y="95.20" angle="90.00" type="custom" speed="6.17" pos="216.47" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="36.00">
-        <vehicle id="veh0" x="88.34" y="95.20" angle="90.00" type="custom" speed="4.76" pos="288.34" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="22.64" y="95.20" angle="90.00" type="custom" speed="6.17" pos="222.64" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="37.00">
-        <vehicle id="veh0" x="88.60" y="95.20" angle="90.00" type="custom" speed="0.26" pos="288.60" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="28.80" y="95.20" angle="90.00" type="custom" speed="6.17" pos="228.80" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="38.00">
-        <vehicle id="veh0" x="88.60" y="95.20" angle="90.00" type="custom" speed="0.00" pos="288.60" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="34.97" y="95.20" angle="90.00" type="custom" speed="6.17" pos="234.97" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="39.00">
-        <vehicle id="veh0" x="88.60" y="95.20" angle="90.00" type="custom" speed="0.00" pos="288.60" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="41.13" y="95.20" angle="90.00" type="custom" speed="6.17" pos="241.13" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="40.00">
-        <vehicle id="veh0" x="88.60" y="95.20" angle="90.00" type="custom" speed="0.00" pos="288.60" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="47.30" y="95.20" angle="90.00" type="custom" speed="6.17" pos="247.30" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="41.00">
-        <vehicle id="veh0" x="88.60" y="95.20" angle="90.00" type="custom" speed="0.00" pos="288.60" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="53.46" y="95.20" angle="90.00" type="custom" speed="6.17" pos="253.46" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="42.00">
-        <vehicle id="veh0" x="88.60" y="95.20" angle="90.00" type="custom" speed="0.00" pos="288.60" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="59.63" y="95.20" angle="90.00" type="custom" speed="6.17" pos="259.63" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="43.00">
-        <vehicle id="veh0" x="88.60" y="95.20" angle="90.00" type="custom" speed="0.00" pos="288.60" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="65.79" y="95.20" angle="90.00" type="custom" speed="6.17" pos="265.79" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="44.00">
-        <vehicle id="veh0" x="88.60" y="95.20" angle="90.00" type="custom" speed="0.00" pos="288.60" lane="WC_0" slope="0.00"/>
+        <vehicle id="veh0" x="74.48" y="95.20" angle="90.00" type="custom" speed="8.69" pos="274.48" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="45.00">
-        <vehicle id="veh0" x="91.20" y="95.20" angle="90.00" type="custom" speed="2.60" pos="1.60" lane=":C_16_0" slope="0.00"/>
+        <vehicle id="veh0" x="85.77" y="95.20" angle="90.00" type="custom" speed="11.29" pos="285.77" lane="WC_0" slope="0.00"/>
     </timestep>
     <timestep time="46.00">
-        <vehicle id="veh0" x="96.40" y="95.20" angle="90.00" type="custom" speed="5.20" pos="6.80" lane=":C_16_0" slope="0.00"/>
+        <vehicle id="veh0" x="99.66" y="95.20" angle="90.00" type="custom" speed="13.89" pos="10.06" lane=":C_16_0" slope="0.00"/>
     </timestep>
     <timestep time="47.00">
-        <vehicle id="veh0" x="104.20" y="95.20" angle="90.00" type="custom" speed="7.80" pos="14.60" lane=":C_16_0" slope="0.00"/>
+        <vehicle id="veh0" x="113.55" y="95.20" angle="90.00" type="custom" speed="13.89" pos="3.15" lane="CE_0" slope="0.00"/>
     </timestep>
     <timestep time="48.00">
-        <vehicle id="veh0" x="114.60" y="95.20" angle="90.00" type="custom" speed="10.40" pos="4.20" lane="CE_0" slope="0.00"/>
+        <vehicle id="veh0" x="127.44" y="95.20" angle="90.00" type="custom" speed="13.89" pos="17.04" lane="CE_0" slope="0.00"/>
     </timestep>
     <timestep time="49.00">
-        <vehicle id="veh0" x="127.60" y="95.20" angle="90.00" type="custom" speed="13.00" pos="17.20" lane="CE_0" slope="0.00"/>
+        <vehicle id="veh0" x="141.33" y="95.20" angle="90.00" type="custom" speed="13.89" pos="30.93" lane="CE_0" slope="0.00"/>
     </timestep>
     <timestep time="50.00">
-        <vehicle id="veh0" x="141.49" y="95.20" angle="90.00" type="custom" speed="13.89" pos="31.09" lane="CE_0" slope="0.00"/>
+        <vehicle id="veh0" x="155.22" y="95.20" angle="90.00" type="custom" speed="13.89" pos="44.82" lane="CE_0" slope="0.00"/>
     </timestep>
     <timestep time="51.00">
-        <vehicle id="veh0" x="155.38" y="95.20" angle="90.00" type="custom" speed="13.89" pos="44.98" lane="CE_0" slope="0.00"/>
+        <vehicle id="veh0" x="169.11" y="95.20" angle="90.00" type="custom" speed="13.89" pos="58.71" lane="CE_0" slope="0.00"/>
     </timestep>
     <timestep time="52.00">
-        <vehicle id="veh0" x="169.27" y="95.20" angle="90.00" type="custom" speed="13.89" pos="58.87" lane="CE_0" slope="0.00"/>
+        <vehicle id="veh0" x="183.00" y="95.20" angle="90.00" type="custom" speed="13.89" pos="72.60" lane="CE_0" slope="0.00"/>
     </timestep>
     <timestep time="53.00">
-        <vehicle id="veh0" x="183.16" y="95.20" angle="90.00" type="custom" speed="13.89" pos="72.76" lane="CE_0" slope="0.00"/>
+        <vehicle id="veh0" x="196.89" y="95.20" angle="90.00" type="custom" speed="13.89" pos="86.49" lane="CE_0" slope="0.00"/>
     </timestep>
-    <timestep time="54.00">
-        <vehicle id="veh0" x="197.05" y="95.20" angle="90.00" type="custom" speed="13.89" pos="86.65" lane="CE_0" slope="0.00"/>
-    </timestep>
-    <timestep time="55.00"/>
+    <timestep time="54.00"/>
 </fcd-export>

--- a/tests/sumo/devices/glosa/slowDown_no/tripinfos.sumo
+++ b/tests/sumo/devices/glosa/slowDown_no/tripinfos.sumo
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on Thu Apr 22 08:39:24 2021 by Eclipse SUMO sumo Version v1_9_0+0152-2e5ad4f
+<!-- generated on 2024-06-21 00:52:01 by Eclipse SUMO sumo Version v1_20_0+0685-fd40beaaee6
 This data file and the accompanying materials
 are made available under the terms of the Eclipse Public License v2.0
 which accompanies this distribution, and is available at
 http://www.eclipse.org/legal/epl-v20.html
-SPDX-License-Identifier: EPL-2.0
-<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
+This file may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License 2.0 are satisfied: GNU General Public License, version 2
+or later which is available at
+https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+<sumoConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
 
     <input>
         <net-file value="net2.net.xml"/>
@@ -25,7 +30,6 @@ SPDX-License-Identifier: EPL-2.0
 
     <report>
         <xml-validation value="never"/>
-        <xml-validation.routes value="never"/>
         <duration-log.disable value="true"/>
         <no-step-log value="true"/>
     </report>
@@ -34,9 +38,9 @@ SPDX-License-Identifier: EPL-2.0
         <device.glosa.probability value="1"/>
     </glosa_device>
 
-</configuration>
+</sumoConfiguration>
 -->
 
 <tripinfos xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/tripinfo_file.xsd">
-    <tripinfo id="veh0" depart="10.00" departLane="WC_0" departPos="5.10" departSpeed="13.89" departDelay="0.00" arrival="55.00" arrivalLane="CE_0" arrivalPos="89.60" arrivalSpeed="13.89" duration="45.00" routeLength="394.90" waitingTime="7.00" waitingCount="1" stopTime="0.00" timeLoss="15.78" rerouteNo="0" devices="tripinfo_veh0 routing_veh0 fcd_veh0 glosa_veh0" vType="custom" speedFactor="1.00" vaporized=""/>
+    <tripinfo id="veh0" depart="10.00" departLane="WC_0" departPos="5.10" departSpeed="13.89" departDelay="0.00" arrival="54.00" arrivalLane="CE_0" arrivalPos="89.60" arrivalSpeed="13.89" duration="44.00" routeLength="394.90" waitingTime="0.00" waitingCount="0" stopTime="0.00" timeLoss="-0.37" rerouteNo="0" devices="tripinfo_veh0 routing_veh0 fcd_veh0 glosa_veh0" vType="custom" speedFactor="1.00" vaporized=""/>
 </tripinfos>


### PR DESCRIPTION
I changed 3 main parts of the adaptSpeed calculation:

1. As pointed out in https://github.com/eclipse-sumo/sumo/issues/12217, targetSpeed can be higher than currentSpeed. This is considered now.
2. As pointed out in https://github.com/eclipse-sumo/sumo/issues/15061, targetSpeed was calculated similar to the green curve. Now it follows the orange curve.
3. Instead of using `setSpeedTimeLine`, I added `setChosenSpeedFactor`.