### PR TITLE
Additional GLOSA options

### DIFF
--- a/src/microsim/MSVehicle.cpp
+++ b/src/microsim/MSVehicle.cpp
@@ -59,6 +59,7 @@
 #include <microsim/devices/MSDevice_Taxi.h>
 #include <microsim/devices/MSDevice_Vehroutes.h>
 #include <microsim/devices/MSDevice_ElecHybrid.h>
+#include <microsim/devices/MSDevice_GLOSA.h>
 #include <microsim/output/MSStopOut.h>
 #include <microsim/trigger/MSChargingStation.h>
 #include <microsim/trigger/MSOverheadWire.h>
@@ -2675,6 +2676,10 @@ MSVehicle::planMoveInternal(const SUMOTime t, MSLeaderInfo ahead, DriveItemVecto
         }
         laneStopOffset = MAX2(POSITION_EPS, laneStopOffset);
         double stopDist = MAX2(0., seen - laneStopOffset);
+        if (yellowOrRed && getDevice(typeid(MSDevice_GLOSA)) != nullptr &&
+            static_cast<MSDevice_GLOSA*>(getDevice(typeid(MSDevice_GLOSA)))->getOverrideSafety()) {
+            stopDist = std::numeric_limits<double>::max();
+        }
         if (newStopDist != std::numeric_limits<double>::max()) {
             stopDist = MAX2(stopDist, newStopDist);
         }

--- a/src/microsim/cfmodels/MSCFModel_EIDM.cpp
+++ b/src/microsim/cfmodels/MSCFModel_EIDM.cpp
@@ -39,6 +39,7 @@
 #include <microsim/MSLane.h>
 #include <microsim/MSEdge.h>
 #include <microsim/MSLink.h>
+#include <microsim/devices/MSDevice_GLOSA.h>
 #include <utils/common/RandHelper.h>
 #include <utils/common/SUMOTime.h>
 
@@ -616,6 +617,12 @@ MSCFModel_EIDM::freeSpeed(const MSVehicle* const veh, double speed, double seen,
 
     VehicleVariables* vars = (VehicleVariables*)veh->getCarFollowVariables();
 
+    if (veh->getDevice(typeid(MSDevice_GLOSA)) != nullptr &&
+        static_cast<MSDevice_GLOSA*>(veh->getDevice(typeid(MSDevice_GLOSA)))->isSpeedAdviceActive() &&
+        maxSpeed < speed) {
+        seen = speed * (1 - (vars->v0_old - vars->v0_int) / (vars->v0_old - maxSpeed)) * myTpreview;
+    }
+
     double vSafe, remaining_time, targetDecel;
     double secGap;
     if (onInsertion) {
@@ -737,6 +744,10 @@ MSCFModel_EIDM::internalspeedlimit(MSVehicle* const veh, const double oldV) cons
     std::vector<MSLink*>::const_iterator link = MSLane::succLinkSec(*veh, view, *lane, bestLaneConts);
     double seen = lane->getLength() - veh->getPositionOnLane();
     double v0 = lane->getVehicleMaxSpeed(veh); // current desired lane speed
+    bool activeGLOSA = false;
+    if (veh->getDevice(typeid(MSDevice_GLOSA)) != nullptr) {
+        activeGLOSA = static_cast<MSDevice_GLOSA*>(veh->getDevice(typeid(MSDevice_GLOSA)))->isSpeedAdviceActive();
+    }
 
     // @ToDo: nextTurn is only defined in sublane-model calculation?!
     // @ToDo: So cannot use it yet, but the next turn or speed recommendation for the street curvature (e.g. vmax=sqrt(a_transverse*Radius), a_transverse=3-4m/s^2)
@@ -745,7 +756,7 @@ MSCFModel_EIDM::internalspeedlimit(MSVehicle* const veh, const double oldV) cons
 
     // When driving on the last lane/link, the vehicle shouldn't adapt to the lane after anymore.
     // Otherwise we check the <seen> time-distance and whether is lower than myTpreview
-    if (lane->isLinkEnd(link) != 1 && (seen < oldV * myTpreview || seen < v0 * myTpreview / 2)) {
+    if (lane->isLinkEnd(link) != 1 && (seen < oldV * myTpreview || seen < v0 * myTpreview / 2 || activeGLOSA)) {
         double speedlim = 200;
         while (true) { // loop over all upcoming edges/lanes/links until the <seen> time-distance is higher than myTpreview
             if (lane->isLinkEnd(link) != 1 && (seen < oldV * myTpreview || seen < v0 * myTpreview / 2)) { // @ToDo: add && (*link)->havePriority()???
@@ -794,7 +805,11 @@ MSCFModel_EIDM::internalspeedlimit(MSVehicle* const veh, const double oldV) cons
             // @ToDo: Vehicle now decelerates to new Speedlimit before reaching new edge (not /2 anymore)!
             // @ToDo: v0 for changing speed limits when seen < oldV*myTpreview, not seen < oldV*myTpreview/2 anymore!!!
             if (v0 > lane->getVehicleMaxSpeed(veh)) {
-                v0 = lane->getVehicleMaxSpeed(veh);
+                if (!activeGLOSA) {
+                    v0 = lane->getVehicleMaxSpeed(veh);
+                } else {
+                    v0 = MIN2(v0, static_cast<MSDevice_GLOSA*>(veh->getDevice(typeid(MSDevice_GLOSA)))->getOriginalSpeedFactor() * lane->getSpeedLimit());
+                }
             }
             seen += lane->getLength();
             link = MSLane::succLinkSec(*veh, view, *lane, bestLaneConts);

--- a/src/microsim/devices/MSDevice_GLOSA.h
+++ b/src/microsim/devices/MSDevice_GLOSA.h
@@ -106,6 +106,28 @@ public:
         return "glosa";
     }
 
+    /** @brief Returns the precomputed, original factor by which the driver
+               wants to be faster than the speed limit
+     * @return Speed limit factor
+     */
+    inline double getOriginalSpeedFactor() const {
+        return myOriginalSpeedFactor;
+    }
+
+    /** @brief Returns if the traffic light stop calculation of the CF model shall be ignored
+     * @return Override stop calculation before traffic light
+     */
+    inline bool getOverrideSafety() const {
+        return myOverrideSafety;
+    }
+
+    /** @brief Returns if the GLOSA device is currently changing the speedFactor
+     * @return If speedFactor has been changed by GLOSA
+     */
+    inline bool isSpeedAdviceActive() const {
+        return mySpeedAdviceActive;
+    }
+
     /// @brief try to retrieve the given parameter from this device. Throw exception for unsupported key
     std::string getParameter(const std::string& key) const;
 
@@ -145,7 +167,8 @@ private:
      * @param[in] holder The vehicle that holds this device
      * @param[in] id The ID of the device
      */
-    MSDevice_GLOSA(SUMOVehicle& holder, const std::string& id, double minSpeed, double range, double maxSpeedFactor);
+    MSDevice_GLOSA(SUMOVehicle& holder, const std::string& id, double minSpeed, double range, double maxSpeedFactor,
+        double addSwitchTime, bool overrideSafety, bool ignoreCFModel);
 
 
 
@@ -164,9 +187,18 @@ private:
     double myRange;
     /// @brief maximum speed factor when trying to reach green light
     double myMaxSpeedFactor;
+    /// @brief Additional time the vehicle shall need to reach the intersection after the signal turns green
+    double myAddSwitchTime;
+    /// @brief if true ignore the current light state, always follow GLOSA's predicted state
+    bool myOverrideSafety;
+    /// @brief if true ignore non-critical speed calculations from the CF model, follow GLOSA's perfect speed calculation
+    bool myIgnoreCFModel;
 
     /// @brief original speed factor
     double myOriginalSpeedFactor;
+
+    /// @brief If speedFactor is currently beeing changed by the GLOSA device
+    bool mySpeedAdviceActive;
 
 
 private:


### PR DESCRIPTION
I added three additional options for GLOSA and made some changes to EIDM/MSVehicle-Code.

1. `device.glosa.add-switchtime`: When the vehicle reaches the intersection just before the light signal turns green, it may brake due to safety and the still active red light. With this added time, the vehicle reaches the intersection X seconds later and will not have to brake (but is farther away from the intersection when the light turns green).
2. `device.glosa.override-safety`: When this is true, the light signal is ignored (stopSpeed is calculated with a distance of infinity). The vehicle will always follow GLOSA's predicted speed (turns off the braking behavior from above).
3. `device.glosa.ignore-cfmodel`: When this is true, the "triangle" speed behavior is adapted via the previously used speedTimeLine (perfect speed calculation without errors).