### PR TITLE
Multi-level arc flag router (aka stripped SHARC)

### DIFF
--- a/src/router/ROEdge.cpp
+++ b/src/router/ROEdge.cpp
@@ -18,6 +18,7 @@
 /// @author  Michael Behrisch
 /// @author  Melanie Knocke
 /// @author  Yun-Pang Floetteroed
+/// @author  Ruediger Ebendt
 /// @date    Sept 2002
 ///
 // A basic edge for routing applications
@@ -88,6 +89,7 @@ ROEdge::~ROEdge() {
         delete lane;
     }
     delete myReversedRoutingEdge;
+    delete myFlippedRoutingEdge;
     delete myRailwayRoutingEdge;
 }
 

--- a/src/router/ROEdge.h
+++ b/src/router/ROEdge.h
@@ -18,6 +18,7 @@
 /// @author  Michael Behrisch
 /// @author  Melanie Knocke
 /// @author  Yun-Pang Floetteroed
+/// @author  Ruediger Ebendt
 /// @date    Sept 2002
 ///
 // A basic edge for routing applications
@@ -42,6 +43,7 @@
 #include <utils/vehicle/SUMOVTypeParameter.h>
 #include "RONode.h"
 #include "ROVehicle.h"
+#include <utils/router/FlippedEdge.h>
 
 
 // ===========================================================================
@@ -542,6 +544,15 @@ public:
         return myReversedRoutingEdge;
     }
 
+    /// @brief Returns the flipped routing edge
+    // @note If not called before, the flipped routing edge is created
+    FlippedEdge<ROEdge, RONode, ROVehicle>* getFlippedRoutingEdge() const {
+        if (myFlippedRoutingEdge == nullptr) {
+            myFlippedRoutingEdge = new FlippedEdge<ROEdge, RONode, ROVehicle>(this);
+        }
+        return myFlippedRoutingEdge;
+    }
+
     RailEdge<ROEdge, ROVehicle>* getRailwayRoutingEdge() const {
         if (myRailwayRoutingEdge == nullptr) {
             myRailwayRoutingEdge = new RailEdge<ROEdge, ROVehicle>(this);
@@ -657,6 +668,8 @@ protected:
 
     /// @brief a reversed version for backward routing
     mutable ReversedEdge<ROEdge, ROVehicle>* myReversedRoutingEdge = nullptr;
+    /// @brief An extended version of the reversed edge for backward routing (used for the arc flag router)
+    mutable FlippedEdge<ROEdge, RONode, ROVehicle>* myFlippedRoutingEdge = nullptr;
     mutable RailEdge<ROEdge, ROVehicle>* myRailwayRoutingEdge = nullptr;
 
 #ifdef HAVE_FOX

--- a/src/router/RONode.cpp
+++ b/src/router/RONode.cpp
@@ -14,6 +14,7 @@
 /// @file    RONode.cpp
 /// @author  Daniel Krajzewicz
 /// @author  Michael Behrisch
+/// @author  Ruediger Ebendt
 /// @date    Sept 2002
 ///
 // A single router's node
@@ -30,8 +31,10 @@
 RONode::RONode(const std::string& id)
     : Named(id) {}
 
-
-RONode::~RONode() {}
+/// @brief Destructor
+RONode::~RONode() {
+    delete myFlippedRoutingNode;
+}
 
 
 void

--- a/src/router/RONode.h
+++ b/src/router/RONode.h
@@ -14,6 +14,7 @@
 /// @file    RONode.h
 /// @author  Daniel Krajzewicz
 /// @author  Michael Behrisch
+/// @author  Ruediger Ebendt
 /// @date    Sept 2002
 ///
 // Base class for nodes used by the router
@@ -25,6 +26,8 @@
 #include <vector>
 #include <utils/common/Named.h>
 #include <utils/geom/Position.h>
+#include <utils/router/FlippedNode.h>
+#include <router/ROVehicle.h>
 
 // ===========================================================================
 // class declarations
@@ -82,14 +85,25 @@ public:
         myOutgoing.push_back(edge);
     }
 
+    /// @brief Returns the flipped routing node
+    // @note If not called before, the flipped routing node is created
+    FlippedNode<ROEdge, RONode, ROVehicle>* getFlippedRoutingNode() const {
+        if (myFlippedRoutingNode == nullptr) {
+            myFlippedRoutingNode = new FlippedNode<ROEdge, RONode, ROVehicle>(this);
+        }
+        return myFlippedRoutingNode;
+    }
+
 private:
     /// @brief This node's position
     Position myPosition;
 
-    /// @brief incoming edges
+    /// @brief Incoming edges
     ConstROEdgeVector myIncoming;
-    /// @brief outgoing edges
+    /// @brief Outgoing edges
     ConstROEdgeVector myOutgoing;
+    /// @brief Flipped routing node
+    mutable FlippedNode<ROEdge, RONode, ROVehicle>* myFlippedRoutingNode = nullptr;
 
 
 private:

--- a/src/utils/router/AFBuild.h
+++ b/src/utils/router/AFBuild.h
@@ -1,0 +1,713 @@
+/****************************************************************************/
+// Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.org/sumo
+// Copyright (C) 2001-2023 German Aerospace Center (DLR) and others.
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0/
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License 2.0 are satisfied: GNU General Public License, version 2
+// or later which is available at
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+/****************************************************************************/
+/// @file    AFBuild.h
+/// @author  Ruediger Ebendt
+/// @date    01.12.2023
+///
+// Class for building the arc flags for (multi-level) arc flag routing
+/****************************************************************************/
+#pragma once
+#include <config.h>
+#include <memory>
+#include <vector>
+#include <unordered_set>
+#include <math.h>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <cinttypes>
+#include <utility>
+#include <utils/common/SUMOTime.h>
+#include <utils/common/SUMOVehicleClass.h>
+#include "KDTreePartition.h"
+#include "Node2EdgeRouter.h"
+#include "FlippedEdge.h"
+#include "AFCentralizedSPTree.h"
+
+//#define AFBU_WRITE_QGIS_FILTERS
+#ifdef AFBU_WRITE_QGIS_FILTERS
+#include <fstream>
+#include <sstream>
+#endif
+
+//#define AFBU_DEBUG_LEVEL_0
+//#define AFBU_DEBUG_LEVEL_1
+//#define AFBU_DEBUG_LEVEL_2
+
+#ifdef AFBU_DEBUG_LEVEL_2
+#define AFBU_DEBUG_LEVEL_1
+#endif
+
+#ifdef AFBU_DEBUG_LEVEL_1
+#define AFBU_DEBUG_LEVEL_0
+#endif
+
+// uncomment to disable assert()
+// #define NDEBUG
+#include <cassert>
+
+// ===========================================================================
+// class declarations
+// ===========================================================================
+template<class E, class N, class V>
+class AFRouter;
+
+// ===========================================================================
+// class definitions
+// ===========================================================================
+
+/**
+ * @class AFBuild
+ * @brief Builds the flags for (multi-level) arc flag routing (Hilger et al.) in its multi-level variant 
+ * (also called "stripped SHARC" by Delling et al.)
+ *
+ * The template parameters are:
+ * @param E The edge class to use (MSEdge/ROEdge )
+ * @param N The node class to use (MSJunction/RONode)
+ * @param V The vehicle class to use (MSVehicle/ROVehicle)
+ */
+template<class E, class N, class V>
+class AFBuild {
+public:
+    /// @brief Maximum difference of two path lengths considered to be equal   
+    const double EPS = 0.009;
+    typedef typename KDTreePartition<FlippedEdge<E, N, V>, FlippedNode<E, N, V>, V>::Cell Cell;
+    typedef typename AFInfo<FlippedEdge<E, N, V>>::ArcInfo ArcInfo;
+    typedef typename AFInfo<E>::FlagInfo FlagInfo;
+    typedef AbstractLookupTable<FlippedEdge<E, N, V>, V> FlippedLookupTable;
+
+    /** @brief Constructor
+     * @param[in] flippedEdges The flipped (aka reversed / backward) edges
+     * @param[in] flippedPartition The k-d tree partition of the backward graph with flipped edges
+     * @param[in] numberOfLevels The number of levels
+     * @param[in] unbuildIsWarning The flag indicating whether network unbuilds should issue warnings or errors
+     * @param[in] flippedOperation The operation for a backward graph with flipped edges
+     * @param[in] flippedLookup The lookup table for a backward graph with flipped edges
+     * @param[in] havePermissions The boolean flag indicating whether edge permissions need to be considered or not
+     * @param[in] haveRestrictions The boolean flag indicating whether edge restrictions need to be considered or not
+     * @param[in] toProhibit The list of explicitly prohibited edges
+     */ 
+    AFBuild(
+        const std::vector<FlippedEdge<E, N, V>*>& flippedEdges,
+        const KDTreePartition<FlippedEdge<E, N, V>, FlippedNode<E, N, V>, V>* const flippedPartition,
+        int numberOfLevels, bool unbuildIsWarning, 
+        typename SUMOAbstractRouter<FlippedEdge<E, N, V>, V>::Operation flippedOperation,
+        const std::shared_ptr<const FlippedLookupTable> flippedLookup = nullptr,
+        const bool havePermissions = false, const bool haveRestrictions = false, 
+        const std::vector<FlippedEdge<E, N, V>*>* toProhibit = nullptr) :
+        myFlippedEdges(flippedEdges),
+        myFlippedPartition(flippedPartition),
+        myNumberOfLevels(numberOfLevels),
+        myErrorMsgHandler(unbuildIsWarning ? MsgHandler::getWarningInstance() : MsgHandler::getErrorInstance()),
+        myFlippedOperation(flippedOperation),
+        myFlippedLookupTable(flippedLookup),
+        myHavePermissions(havePermissions),
+        myHaveRestrictions(haveRestrictions),
+        myProhibited(toProhibit),
+        myNode2EdgeRouter(new Node2EdgeRouter<FlippedEdge<E, N, V>, FlippedNode<E, N, V>, V>(myFlippedEdges, 
+            unbuildIsWarning, myFlippedOperation, myFlippedLookupTable, myHavePermissions, myHaveRestrictions)) 
+    {
+        myCentralizedSPTree = new AFCentralizedSPTree<FlippedEdge<E, N, V>, FlippedNode<E, N, V>, V>(myFlippedEdges, 
+            myArcInfos, unbuildIsWarning, myNode2EdgeRouter, myHavePermissions, myHaveRestrictions);
+        if (toProhibit) {
+            myNode2EdgeRouter->prohibit(*toProhibit);
+        }
+    }
+
+    /// @brief Destructor
+    ~AFBuild() {
+        delete myCentralizedSPTree;
+        delete myNode2EdgeRouter;
+    }
+
+    /// @brief Returns the operation for a backward graph with flipped edges
+    typename SUMOAbstractRouter<FlippedEdge<E, N, V>, V>::Operation getFlippedOperation() {
+        return myFlippedOperation;
+    }
+    /// @brief Returns the lookup table for the backward graph with flipped edges
+    const std::shared_ptr<const FlippedLookupTable> getFlippedLookup() {
+        return myFlippedLookupTable;
+    }
+    /** @brief Initialize the arc flag build
+     * @param[in] msTime The start time of the routes in milliseconds
+     * @param[in] vehicle The vehicle 
+     * @param[in] flagInfos The arc flag informations
+     */  
+    void init(SUMOTime time, const V* const vehicle, std::vector<FlagInfo*>& flagInfos);
+    /** @brief Set the flipped partition 
+     * param[in] flippedPartition The flipped partition
+     */
+    void setFlippedPartition(const KDTreePartition<FlippedEdge<E, N, V>, FlippedNode<E, N, V>, V>* flippedPartition) {
+        myFlippedPartition = flippedPartition;
+    }
+    /** @brief Converts a partition level number to a SHARC level number
+     * @param[in] partitionLevel The partition level
+     * @return The SHARC level number corresponding to the given partition level number
+     */ 
+    int partitionLevel2SHARCLevel(int partitionLevel) {
+        return AFRouter<E, N, V>::partitionLevel2SHARCLevel(partitionLevel, myNumberOfLevels);
+    }
+    /** @brief Converts a SHARC level number to a partition level number
+     * @param[in] sHARCLevel The SHARC level
+     * @return The partition level number corresponding to the given SHARC level number
+     */ 
+    int sHARCLevel2PartitionLevel(int sHARCLevel) {
+        return AFRouter<E, N, V>::sHARCLevel2PartitionLevel(sHARCLevel, myNumberOfLevels);
+    }
+
+protected:
+    /** @brief Computes the arc flags for all cells at a given level
+     * @param[in] msTime The start time of the routes in milliseconds
+     * @param[in] sHARCLevel The SHARC level
+     * @param[in] vehicle The vehicle
+     */ 
+    void computeArcFlags(SUMOTime msTime, int sHARCLevel, const V* const vehicle);
+    /** @brief Computes the arc flags for a given cell
+     * @param[in] msTime The start time of the routes in milliseconds
+     * @param sHARCLevel The SHARC level
+     * @param[in] cell The cell
+     * @param[in] vehicle The vehicle
+     */
+    void computeArcFlags(SUMOTime msTime, const int sHARCLevel, const Cell* cell, const V* const vehicle);
+    /** @brief Computes the arc flags for a given cell (naive version)
+     * @param[in] msTime The start time of the routes in milliseconds
+     * @param sHARCLevel The SHARC level
+     * @param[in] cell The cell
+     * @param[in] vehicle The vehicle
+     */
+    void computeArcFlagsNaive(SUMOTime msTime, const int sHARCLevel, const Cell* cell, const V* const vehicle);
+    /** @brief Put the arc flag of the edge in arcInfo  
+     * @note wrt the passed SHARC level, and the boolean flag indicating whether the respective cell is a left or lower one or not
+     * @param[in] arcInfo The arc information
+     * @param[in] sHARCLevel The SHARC level
+     * @param[in] isLeftOrLowerCell The boolean flag indicating whether the respective cell is a left or lower one or not
+     */
+    void putArcFlag(ArcInfo* arcInfo, const int sHARCLevel, const bool isLeftOrLowerCell);
+    /// @brief The flipped edges
+    const std::vector<FlippedEdge<E, N, V>*>& myFlippedEdges;
+    /// @brief The partition for the backward graph with flipped edges
+    const KDTreePartition<FlippedEdge<E, N, V>, FlippedNode<E, N, V>, V>* myFlippedPartition;
+    /// @brief The number of levels
+    const int myNumberOfLevels;
+    /// @brief The handler for routing errors
+    MsgHandler* const myErrorMsgHandler;
+    /// @brief The object's operation to perform on a backward graph with flipped edges
+    typename SUMOAbstractRouter<FlippedEdge<E, N, V>, V>::Operation myFlippedOperation;
+    /// @brief The lookup table for travel time heuristics
+    const std::shared_ptr<const FlippedLookupTable> myFlippedLookupTable;
+    /// @brief The boolean flag indicating whether edge permissions need to be considered or not
+    const bool myHavePermissions;
+    /// @brief The boolean flag indicating whether edge restrictions need to be considered or not
+    const bool myHaveRestrictions;
+    /// @brief The list of explicitly prohibited edges
+    const std::vector<FlippedEdge<E, N, V>*>* myProhibited;
+    /// @brief The node-to-edge router (for a backward graph with flipped edges)
+    Node2EdgeRouter<FlippedEdge<E, N, V>, FlippedNode<E, N, V>, V>* myNode2EdgeRouter;
+    /// @brief A Dijkstra based centralized label-correcting algorithm 
+    // @note Builds shortest path trees for all boundary nodes at once
+    // @note It operates on a backward graph with flipped edges
+    AFCentralizedSPTree<FlippedEdge<E, N, V>, FlippedNode<E, N, V>, V>* myCentralizedSPTree;
+    /// @brief The container of arc informations (for the centralized shortest path tree)
+    std::vector<ArcInfo*> myArcInfos;
+
+private: 
+    /** @brief Initialize the boundary edges 
+     * param[in] boundaryEdges The boundary edges
+     */
+    void initBoundaryEdges(const std::unordered_set<const FlippedEdge<E, N, V>*>& boundaryEdges);
+    /** @brief Initialize the supercell edges
+     * @param[in] supercell The supercell
+     * @param[in] boundaryEdges The boundary edges
+     * @param[in] numberOfBoundaryNodes The number of boundary nodes
+     */
+    void initSupercellEdges(const Cell* supercell, 
+        const std::unordered_set<const FlippedEdge<E, N, V>*>& boundaryEdges, 
+        size_t numberOfBoundaryNodes);
+    /** @brief Helper method for computeArcFlags(), which computes the arc flags for a given cell 
+     * @param[in] msTime The start time of the routes in milliseconds
+     * @param[in] sHARCLevel The SHARC level
+     * @param[in] cell The cell
+     * @param[in] vehicle The vehicle
+     */
+    void computeArcFlagsAux(SUMOTime msTime, const int sHARCLevel, const Cell* cell, const V* const vehicle);
+}; // end of class AFBuild declaration
+
+// ===========================================================================
+// method definitions
+// ===========================================================================
+
+template<class E, class N, class V>
+void AFBuild<E, N, V>::init(SUMOTime msTime, const V* const vehicle, std::vector<FlagInfo*>& flagInfos) {
+    if (myArcInfos.empty()) {
+        for (const FlippedEdge<E, N, V>* const flippedEdge : myFlippedEdges) {
+            myArcInfos.push_back(new ArcInfo(flippedEdge));
+        }
+    }
+    int sHARCLevel;
+    for (sHARCLevel = 0; sHARCLevel < myNumberOfLevels - 1; sHARCLevel++) {
+#ifdef AFBU_DEBUG_LEVEL_0
+        std::cout << "Starting computation of flags of level " << sHARCLevel << " (levels run from 0 to "
+            << myNumberOfLevels - 2 << ")." << std::endl;
+#endif
+#ifdef AFBU_DEBUG_LEVEL_2
+        if (sHARCLevel != 0) {
+            continue;
+        }
+#endif
+        computeArcFlags(msTime, sHARCLevel, vehicle);
+    }
+#ifdef AFBU_DEBUG_LEVEL_0
+    std::cout << "Copying arc flags from the arc infos... " << std::endl;
+#endif
+    int index = 0;
+    for (const ArcInfo* arcInfo : myArcInfos) {
+        flagInfos[index++]->arcFlags = arcInfo->arcFlags;
+        delete arcInfo;
+    }
+#ifdef AFBU_DEBUG_LEVEL_0
+    std::cout << "Arc flags copied from the arc infos. " << std::endl;
+#endif
+    myArcInfos.clear();
+}
+
+template<class E, class N, class V>
+void AFBuild<E, N, V>::computeArcFlags(SUMOTime msTime, const int sHARCLevel, const V* const vehicle) {
+    try {
+        assert(myFlippedPartition);
+        const std::vector<const Cell*>& levelCells = myFlippedPartition->getCellsAtLevel(sHARCLevel2PartitionLevel(sHARCLevel));
+#ifdef AFBU_DEBUG_LEVEL_0
+        int i = 0;
+#endif
+        for (const Cell* cell : levelCells) {
+#ifdef AFBU_DEBUG_LEVEL_0
+            std::cout << "Starting to compute core flags of the " << i++ << "th cell..." << std::endl;
+#endif
+#ifdef AFBU_DEBUG_LEVEL_2
+            if (cell->getNumber() == 4) {
+#endif
+                // kept to make comparisons possible
+                //computeArcFlagsNaive(msTime, sHARCLevel, cell, vehicle);
+                computeArcFlags(msTime, sHARCLevel, cell, vehicle);
+                // clean up (all except the computed flags, of course)
+#ifdef AFBU_DEBUG_LEVEL_0
+                std::cout << "Cleaning up after computeArcFlags..." << std::endl;
+#endif
+                for (ArcInfo* arcInfo : myArcInfos) {
+                    arcInfo->effortsToBoundaryNodes.clear();
+                    arcInfo->touched = false;
+                }
+#ifdef AFBU_DEBUG_LEVEL_0
+                std::cout << "Cleaned up." << std::endl;
+#endif
+#ifdef AFBU_DEBUG_LEVEL_2
+            }
+#endif
+        }
+    }
+    catch (const std::invalid_argument& e) {
+        std::cerr << "Exception: " << e.what() << std::endl;
+        exit(-1);
+    }
+}
+
+template<class E, class N, class V>
+void AFBuild<E, N, V>::computeArcFlagsNaive(SUMOTime msTime, const int sHARCLevel, const Cell* cell, const V* const vehicle) {
+    const Cell* supercell = cell->getSupercell();
+    const std::unordered_set<const FlippedEdge<E, N, V>*>& boundaryEdges = cell->getOutgoingBoundaryEdges();
+    const std::vector<const FlippedNode<E, N, V>*>& boundaryNodes = cell->getBoundaryFromNodes();
+#ifdef AFBU_DEBUG_LEVEL_1
+    std::cout << "Number of boundary edges: " << boundaryEdges.size() << std::endl;
+    std::cout << "Number of boundary nodes: " << boundaryNodes.size() << std::endl;
+    std::cout << "Cell number: " << cell->getNumber() << std::endl;
+    std::cout << "Supercell number: " << supercell->getNumber() << std::endl;
+#endif
+    //
+    // initialization of arc flag vectors
+    initBoundaryEdges(boundaryEdges);
+
+#ifdef AFBU_DEBUG_LEVEL_0
+    long long int startTime = SysUtils::getCurrentMillis();
+#endif
+    for (const FlippedNode<E, N, V>* boundaryNode : boundaryNodes) {
+        for (const FlippedEdge<E, N, V>* boundaryEdge : boundaryEdges) {
+            assert(!boundaryEdge->isInternal());
+            ArcInfo* arcInfo = myArcInfos[boundaryEdge->getNumericalID()];
+            if (boundaryNode == boundaryEdge->getFromJunction()) {
+                arcInfo->effortsToBoundaryNodes.push_back(0.);
+                continue;
+            }
+            // compute effort
+            std::vector<const FlippedEdge<E, N, V>*> into;
+#ifdef AFBU_DEBUG_LEVEL_2
+            std::vector<const FlippedEdge<E, N, V>*> into2;
+#endif
+            if (myNode2EdgeRouter->computeNode2Edge(boundaryNode, boundaryEdge, vehicle, msTime, into)) {
+                double recomputedEffort = myNode2EdgeRouter->recomputeCostsNoLastEdge(into, vehicle, msTime);
+                arcInfo->effortsToBoundaryNodes.push_back(recomputedEffort);
+#ifdef AFBU_DEBUG_LEVEL_2
+                if (!into.empty() && myNode2EdgeRouter->compute(into[0], boundaryEdge, vehicle, msTime, into2)) {
+                    double recomputedEffort2 = myNode2EdgeRouter->recomputeCosts(into2, vehicle, msTime);
+
+                    std::cout << "node2Edge router succeeded, effort: " << recomputedEffort << ", effort incl. last edge: " << recomputedEffort2 << std::endl;
+                    assert(recomputedEffort <= recomputedEffort2);
+                }
+#endif
+            }
+            else {
+                arcInfo->effortsToBoundaryNodes.push_back(UNREACHABLE);
+#ifdef AFBU_DEBUG_LEVEL_2
+                std::cout << "UNREACHABLE!" << std::endl;
+#endif
+            }
+        }
+    }
+#ifdef AFBU_DEBUG_LEVEL_0
+    long long int timeSpent = SysUtils::getCurrentMillis() - startTime;
+    std::cout << "Initial distance computation spent " + elapsedMs2string(timeSpent) + "." << std::endl;
+ #endif
+
+    // initialize all supercell edges' labels, arc flag vectors for the centralized shortest path tree algorithm / arc flag build
+    initSupercellEdges(supercell, boundaryEdges, boundaryNodes.size());
+#ifdef AFBU_DEBUG_LEVEL_0
+    std::cout << "Initialization of all supercell edges' labels and arc flag vectors done. Starting the centralized shortest path tree algorithm..." << std::endl;
+#endif
+    if (myCentralizedSPTree->computeCentralizedSPTree(msTime, cell, vehicle)) {
+        computeArcFlagsAux(msTime, sHARCLevel, cell, vehicle);
+    }
+#ifdef AFBU_DEBUG_LEVEL_0
+    std::cout << "Centralized shortest path tree algorithm finished." << std::endl;
+#endif
+}
+
+template<class E, class N, class V>
+void AFBuild<E, N, V>::computeArcFlags(SUMOTime msTime, const int sHARCLevel, const Cell* cell, const V* const vehicle) {
+    const Cell* supercell = cell->getSupercell();
+    const std::unordered_set<const FlippedEdge<E, N, V>*>& boundaryEdges = cell->getOutgoingBoundaryEdges(); 
+    const std::vector<const FlippedNode<E, N, V>*>& boundaryNodes = cell->getBoundaryFromNodes();
+#ifdef AFBU_DEBUG_LEVEL_1
+    std::cout << "Number of boundary edges: " << boundaryEdges.size() << std::endl;
+    std::cout << "Number of boundary nodes: " << boundaryNodes.size() << std::endl;
+    std::cout << "Cell number: " << cell->getNumber() << std::endl;
+    std::cout << "Supercell number: " << supercell->getNumber() << std::endl;
+#endif
+    // initialization of arc flag vectors
+    initBoundaryEdges(boundaryEdges);
+#ifdef AFBU_DEBUG_LEVEL_1
+    long long int startTime = SysUtils::getCurrentMillis();
+#endif
+    std::map<const FlippedEdge<E, N, V>*, std::vector<const FlippedEdge<E, N, V>*>> incomingEdgesOfOutgoingBoundaryEdges;
+    size_t numberOfBoundaryNodes = boundaryNodes.size();
+    for (const FlippedEdge<E, N, V>* boundaryEdge : boundaryEdges) {
+        incomingEdgesOfOutgoingBoundaryEdges[boundaryEdge] = std::vector<const FlippedEdge<E, N, V>*>(numberOfBoundaryNodes);
+    }
+    int index = 0; // boundary node index
+    for (const FlippedNode<E, N, V>* boundaryNode : boundaryNodes) {
+        myNode2EdgeRouter->reset(vehicle);
+        if (myNode2EdgeRouter->computeNode2Edges(boundaryNode, boundaryEdges, vehicle, msTime)) {
+#ifdef AFBU_DEBUG_LEVEL_2
+            std::cout << "Node-to-edge router succeeded." << std::endl;
+#endif
+        }
+        for (const FlippedEdge<E, N, V>* boundaryEdge : boundaryEdges) {
+            assert(!boundaryEdge->isInternal());
+            ArcInfo* arcInfo = myArcInfos[boundaryEdge->getNumericalID()];
+            if (boundaryNode == boundaryEdge->getFromJunction()) {
+                arcInfo->effortsToBoundaryNodes.push_back(0.);
+                (incomingEdgesOfOutgoingBoundaryEdges[boundaryEdge])[index] = nullptr;
+                continue;
+            }
+            double effort = (myNode2EdgeRouter->edgeInfo(boundaryEdge))->effort;
+            const FlippedEdge<E, N, V>* incomingEdge 
+                = (myNode2EdgeRouter->edgeInfo(boundaryEdge))->prev ? 
+                    (myNode2EdgeRouter->edgeInfo(boundaryEdge))->prev->edge : nullptr;
+            (incomingEdgesOfOutgoingBoundaryEdges[boundaryEdge])[index] = incomingEdge;
+            arcInfo->effortsToBoundaryNodes.push_back(effort == std::numeric_limits<double>::max() ? UNREACHABLE : effort);
+        }
+        index++;
+    } // end for boundary nodes
+#ifdef AFBU_DEBUG_LEVEL_0
+    long long int timeSpent = SysUtils::getCurrentMillis() - startTime;
+    std::cout << "Initial distance computation spent " + elapsedMs2string(timeSpent) + "." << std::endl;
+#endif
+    // initialize all supercell edges' labels and arc flag vectors for the centralized shortest path DAG algorithm / arc flag build
+    initSupercellEdges(supercell, boundaryEdges, boundaryNodes.size());
+#ifdef AFBU_DEBUG_LEVEL_0
+    std::cout << "Initialization of all supercell edges' labels and arc flag vectors done. Starting the centralized shortest path tree algorithm..." << std::endl;
+#endif
+#ifdef AFBU_DEBUG_LEVEL_0
+    startTime = SysUtils::getCurrentMillis();
+#endif
+    if (myCentralizedSPTree->computeCentralizedSPTree(msTime, cell, vehicle, incomingEdgesOfOutgoingBoundaryEdges)) {
+#ifdef AFBU_DEBUG_LEVEL_0
+        timeSpent = SysUtils::getCurrentMillis() - startTime;
+        std::cout << "Centralized SP tree computation spent " + elapsedMs2string(timeSpent) + "." << std::endl;
+#endif
+        computeArcFlagsAux(msTime, sHARCLevel, cell, vehicle);
+    }
+#ifdef AFBU_DEBUG_LEVEL_0
+    std::cout << "Centralized shortest path tree algorithm finished." << std::endl;
+#endif
+}
+
+template<class E, class N, class V>
+void AFBuild<E, N, V>::computeArcFlagsAux(SUMOTime msTime, const int sHARCLevel, const Cell* cell, const V* const vehicle) {
+    const Cell* supercell = cell->getSupercell();
+    std::pair<typename std::vector<const FlippedNode<E, N, V>*>::const_iterator,
+        typename std::vector<const FlippedNode<E, N, V>*>::const_iterator> supercellNodeIterators = supercell->nodeIterators();
+    typename std::vector<const FlippedNode<E, N, V>*>::const_iterator first = supercellNodeIterators.first;
+    typename std::vector<const FlippedNode<E, N, V>*>::const_iterator last = supercellNodeIterators.second;
+    typename std::vector<const FlippedNode<E, N, V>*>::const_iterator iter;
+    std::unordered_set<ArcInfo*> arcInfosOnAShortestPath;
+#ifdef AFBU_DEBUG_LEVEL_1
+    int numberOfSupercellEdges = 0;
+#endif
+    for (iter = first; iter != last; iter++) {
+        const std::vector<const FlippedEdge<E, N, V>*> incomingEdges = (*iter)->getIncoming();
+        for (const FlippedEdge<E, N, V>* supercellEdge : incomingEdges) {
+            if (supercellEdge->isInternal()) {
+                continue;
+            }
+            if ((myNode2EdgeRouter->edgeInfo(supercellEdge))->prohibited
+                || myNode2EdgeRouter->isProhibited(supercellEdge, vehicle)) {
+                continue;
+            }
+#ifdef AFBU_DEBUG_LEVEL_1
+            numberOfSupercellEdges++;
+#endif
+            ArcInfo* supercellArcInfo = myArcInfos[supercellEdge->getNumericalID()];
+            // start by initializing to set of all supercell edge arc infos
+            arcInfosOnAShortestPath.insert(supercellArcInfo);
+        }
+    }
+#ifdef AFBU_DEBUG_LEVEL_1
+    std::cout << "Number of supercell edges: " << numberOfSupercellEdges << std::endl;
+#endif
+    const SUMOVehicleClass vClass = vehicle == 0 ? SVC_IGNORING : vehicle->getVClass();
+#ifdef AFBU_DEBUG_LEVEL_1
+    std::cout << "Identifying shortest paths..." << std::endl;
+#endif
+#ifdef AFBU_DEBUG_LEVEL_0
+    long long int startTime = SysUtils::getCurrentMillis();
+#endif
+    std::unordered_set<ArcInfo*> erasedEdges;
+    for (auto iter2 = arcInfosOnAShortestPath.begin(); iter2 != arcInfosOnAShortestPath.end(); )
+    {
+        const ArcInfo* arcInfo = *iter2;
+        assert(!arcInfo->edge->isInternal());
+        assert(myNode2EdgeRouter);
+        assert(!(myNode2EdgeRouter->edgeInfo(arcInfo->edge))->prohibited
+            && !myNode2EdgeRouter->isProhibited(arcInfo->edge, vehicle));
+        size_t numberOfBoundaryNodes = arcInfo->effortsToBoundaryNodes.size();
+        size_t index;
+        bool onShortestPath = false;
+        // attempt to prove that the edge is on a shortest path for at least one boundary node
+        for (index = 0; index < numberOfBoundaryNodes; index++) {
+            double effort1ToBoundaryNode = arcInfo->effortsToBoundaryNodes[index];
+            if (effort1ToBoundaryNode == UNREACHABLE) {
+                continue;
+            }
+            if (effort1ToBoundaryNode == std::numeric_limits<double>::max()) {
+                continue;
+            }
+            double sTime = STEPS2TIME(msTime);
+            double edgeEffort = myNode2EdgeRouter->getEffort(arcInfo->edge, vehicle, sTime);
+            sTime += myNode2EdgeRouter->getTravelTime(arcInfo->edge, vehicle, sTime, edgeEffort);
+            double oldEdgeEffort = edgeEffort;
+            double oldSTime = sTime;
+
+            for (const std::pair<const FlippedEdge<E, N, V>*, const FlippedEdge<E, N, V>*>& follower : arcInfo->edge->getViaSuccessors(vClass)) {
+                assert(!follower.first->isInternal());
+                ArcInfo* followerInfo = myArcInfos[follower.first->getNumericalID()];
+
+                // check whether it can be used
+                if ((myNode2EdgeRouter->edgeInfo(follower.first))->prohibited
+                    || myNode2EdgeRouter->isProhibited(follower.first, vehicle)) {
+                    myErrorMsgHandler->inform("Vehicle '" + Named::getIDSecure(vehicle) + "' is not allowed on source edge '" + followerInfo->edge->getID() + "'.");
+                    continue;
+                }
+                if (followerInfo->effortsToBoundaryNodes.empty()) {
+                    continue;
+                }
+                double effort2ToBoundaryNode = followerInfo->effortsToBoundaryNodes[index];
+                if (effort2ToBoundaryNode == UNREACHABLE) {
+                    continue;
+                }
+                if (effort2ToBoundaryNode == std::numeric_limits<double>::max()) {
+                    continue;
+                }
+
+                // add via efforts to current follower to edge effort
+                double length = 0.; // dummy length for call of updateViaEdgeCost
+                myNode2EdgeRouter->updateViaEdgeCost(follower.second, vehicle,
+                    sTime /* has been updated to the time where the edge has been traversed */, edgeEffort, length);
+                // test whether edge is on a shortest path to a boundary node
+                if (effort1ToBoundaryNode + edgeEffort /* edge effort incl. via efforts to current follower of edge */
+                    <= effort2ToBoundaryNode /* efforts incl. via efforts to current follower o. e. */
+                    + EPS && effort1ToBoundaryNode + edgeEffort >= effort2ToBoundaryNode - EPS) {
+                    onShortestPath = true;
+                    break; // a shortest path to one boundary node suffices
+                }
+                edgeEffort = oldEdgeEffort;
+                sTime = oldSTime;
+            } // end of loop over outgoing edges
+        } // loop over indexes
+        if (!onShortestPath) {
+            erasedEdges.insert(*iter2);
+            iter2 = arcInfosOnAShortestPath.erase(iter2); // not on a shortest path, remove it
+        }
+        else {
+            ++iter2;
+        }
+    } // loop over edge infos
+
+#ifdef AFBU_DEBUG_LEVEL_0
+    std::cout << "Edges clearly not on a shortest path have been removed. Number of edges on a shortest path is now: "
+        << arcInfosOnAShortestPath.size() << std::endl;
+#endif
+
+    // set arc flags (for level sHARCLevel) for all edges completely inside the cell  
+    // (done since these edges all have a to-node inside the cell, i.e. we have to set the own-cell flag for them). 
+    std::unordered_set<const FlippedEdge<E, N, V>*>* pEdgesInsideCell = cell->edgeSet(vehicle);
+    std::unordered_set<const FlippedEdge<E, N, V>*> edgesInsideCell = *pEdgesInsideCell;
+#ifdef AFBU_DEBUG_LEVEL_0
+    std::cout << "Adding all edges completely inside the cell to set of edges on a shortest path, cell no:"
+        << cell->getNumber() << std::endl;
+#endif
+    for (const FlippedEdge<E, N, V>* edgeInsideCell : edgesInsideCell) {
+        ArcInfo* arcInfo = myArcInfos[edgeInsideCell->getNumericalID()];
+        if ((myNode2EdgeRouter->edgeInfo(edgeInsideCell))->prohibited
+            || myNode2EdgeRouter->isProhibited(edgeInsideCell, vehicle)) {
+            continue;
+        }
+        arcInfosOnAShortestPath.insert(arcInfo);
+    }
+    delete pEdgesInsideCell;
+#ifdef AFBU_DEBUG_LEVEL_0
+    std::cout << "Edges inside cell added." << std::endl;
+    long long int timeSpent = SysUtils::getCurrentMillis() - startTime;
+    std::cout << "Shortest path identification spent " + elapsedMs2string(timeSpent) + "." << std::endl;
+#endif
+
+#ifdef AFBU_WRITE_QGIS_FILTERS
+    std::string qgisFilterString = "id IN (";
+    std::unordered_set<const FlippedNode<E, N, V>*> nodesOnAShortestPath;
+    std::unordered_set<const FlippedNode<E, N, V>*> erasedNodes;
+    for (const ArcInfo* arcInfo : arcInfosOnAShortestPath) {
+        assert(!(myNode2EdgeRouter->edgeInfo(arcInfo->edge))->prohibited
+            && !myNode2EdgeRouter->isProhibited(arcInfo->edge, vehicle));
+        nodesOnAShortestPath.insert(arcInfo->edge->getFromJunction());
+        nodesOnAShortestPath.insert(arcInfo->edge->getToJunction());
+    }
+    for (const ArcInfo* erasedEdgeArcInfo : erasedEdges) {
+        erasedNodes.insert(erasedEdgeArcInfo->edge->getFromJunction());
+        erasedNodes.insert(erasedEdgeArcInfo->edge->getToJunction());
+    }
+    size_t k = 0;
+    // go through the relevant nodes of the supercell
+    size_t numberOfNodesOnAShortestPath = nodesOnAShortestPath.size();
+    for (const FlippedNode<E, N, V>* node : nodesOnAShortestPath) {
+        k++;
+        qgisFilterString += node->getID() + (k < numberOfNodesOnAShortestPath ? ", " : "");
+    }
+    qgisFilterString += ")";
+    std::ostringstream pathAndFileName;
+    pathAndFileName << "./filter_superset_nodes_cell_" << cell->getNumber() << "_supercell_" << supercell->getNumber() << ".qqf";
+    std::ofstream file;
+    file.open(pathAndFileName.str());
+    std::ostringstream content;
+    content << "<Query>" << qgisFilterString << "</Query>";
+    file << content.str();
+    file.close();
+    // erased nodes
+    k = 0;
+    qgisFilterString.clear();
+    qgisFilterString = "id IN (";
+    // go through the erased nodes of the supercell
+    size_t numberOfErasedNodes = erasedNodes.size();
+    for (const FlippedNode<E, N, V>* node : erasedNodes) {
+        k++;
+        qgisFilterString += node->getID() + (k < numberOfErasedNodes ? ", " : "");
+    }
+    qgisFilterString += ")";
+    pathAndFileName.str("");
+    pathAndFileName.clear();
+    pathAndFileName << "./filter_erased_nodes_cell_" << cell->getNumber() << "_supercell_" << supercell->getNumber() << ".qqf";
+    file.clear();
+    file.open(pathAndFileName.str());
+    content.str("");
+    content.clear();
+    content << "<Query>" << qgisFilterString << "</Query>";
+    file << content.str();
+    file.close();
+#endif
+    // put arc flags for level 'sHARCLevel' for all supercell edges which are on a shortest path 
+    for (ArcInfo* arcInfo : arcInfosOnAShortestPath) {
+        putArcFlag(arcInfo, sHARCLevel, cell->isLeftOrLowerCell());
+    }
+}
+
+template<class E, class N, class V>
+void AFBuild<E, N, V>::putArcFlag(ArcInfo* arcInfo, const int sHARCLevel, const bool isLeftOrLowerCell)
+{
+    assert(arcInfo);
+    (arcInfo->arcFlags)[sHARCLevel * 2 + (isLeftOrLowerCell ? 0 : 1)] = 1;
+}
+
+template<class E, class N, class V>
+void AFBuild<E, N, V>::initBoundaryEdges(const std::unordered_set<const FlippedEdge<E, N, V>*>& boundaryEdges) {
+    // initialization of arc flag vectors
+    for (const FlippedEdge<E, N, V>* boundaryEdge : boundaryEdges) {
+        assert(!boundaryEdge->isInternal());
+        ArcInfo* arcInfo;
+        arcInfo = myArcInfos[boundaryEdge->getNumericalID()];
+        if (arcInfo->arcFlags.empty()) {
+            std::fill_n(std::back_inserter(arcInfo->arcFlags),
+                myFlippedPartition->numberOfArcFlags(), false);
+        }
+        arcInfo->effortsToBoundaryNodes.clear();
+    }
+}
+
+template<class E, class N, class V>
+void AFBuild<E, N, V>::initSupercellEdges(
+    const Cell* supercell,
+    const std::unordered_set<const FlippedEdge<E, N, V>*>& boundaryEdges,
+    size_t numberOfBoundaryNodes) {
+    std::pair<typename std::vector<const FlippedNode<E, N, V>*>::const_iterator,
+        typename std::vector<const FlippedNode<E, N, V>*>::const_iterator> supercellNodeIterators = supercell->nodeIterators();
+    typename std::vector<const FlippedNode<E, N, V>*>::const_iterator first = supercellNodeIterators.first;
+    typename std::vector<const FlippedNode<E, N, V>*>::const_iterator last = supercellNodeIterators.second;
+    typename std::vector<const FlippedNode<E, N, V>*>::const_iterator iter;
+    for (iter = first; iter != last; iter++) {
+        const std::vector<const FlippedEdge<E, N, V>*> incomingEdges = (*iter)->getIncoming();
+        for (const FlippedEdge<E, N, V>* supercellEdge : incomingEdges) {
+            if (supercellEdge->isInternal()) {
+                continue;
+            }
+            if (boundaryEdges.count(supercellEdge)) {
+                continue;
+            }
+            ArcInfo* supercellArcInfo;
+            supercellArcInfo = myArcInfos[supercellEdge->getNumericalID()];
+            if (supercellArcInfo->arcFlags.empty()) {
+                std::fill_n(std::back_inserter(supercellArcInfo->arcFlags),
+                    myFlippedPartition->numberOfArcFlags(), false);
+            }
+            supercellArcInfo->effortsToBoundaryNodes.clear();
+            std::fill_n(std::back_inserter(supercellArcInfo->effortsToBoundaryNodes),
+                numberOfBoundaryNodes, std::numeric_limits<double>::max());
+        }
+    }
+}

--- a/src/utils/router/AFBuilder.h
+++ b/src/utils/router/AFBuilder.h
@@ -1,0 +1,294 @@
+/****************************************************************************/
+// Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.org/sumo
+// Copyright (C) 2001-2023 German Aerospace Center (DLR) and others.
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0/
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License 2.0 are satisfied: GNU General Public License, version 2
+// or later which is available at
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+/****************************************************************************/
+/// @file    AFBuilder.h
+/// @author  Ruediger Ebendt
+/// @date    01.11.2023
+///
+// Arc flags builder for the arc flag router
+/****************************************************************************/
+#pragma once
+#include <config.h>
+#include <vector>
+// uncomment to disable assert()
+// #define NDEBUG
+#include <cassert>
+
+#include "AFBuild.h"
+#include "FlippedEdge.h"
+
+//#define AFBL_DEBUG_LEVEL_0
+//#define AFBL_DEBUG_LEVEL_1
+//#define AFBL_DEBUG_LEVEL_2
+
+#ifdef AFBL_DEBUG_LEVEL_2
+#define AFBL_DEBUG_LEVEL_1
+#endif
+
+#ifdef AFBL_DEBUG_LEVEL_1
+#define AFBL_DEBUG_LEVEL_0
+#endif
+
+// ===========================================================================
+// class definitions
+// ===========================================================================
+/**
+ * @class AFBuilder
+ * @brief Builds arc flags for shortest path search with the arc flag router
+ */
+
+template<class E, class N, class V>
+class AFBuilder {
+public:
+    typedef typename AFInfo<E>::FlagInfo FlagInfo;
+    typedef AbstractLookupTable<FlippedEdge<E, N, V>, V> FlippedLookupTable;
+    
+    /** @brief Constructor
+     * @param[in] numberOfLevels The number of levels
+     * @param[in] edges The container with all edges of the network
+     * @param[in] unbuildIsWarning The flag indicating whether network unbuilds should issue warnings or errors
+     * @param[in] flippedOperation The operation for a backward graph with flipped edges
+     * @param[in] flippedLookup The lookup table for a backward graph with flipped edges
+     * @param[in] havePermissions The flag indicating whether edges have permissions which must be respected
+     * @param[in] haveRestrictions The flag indicating whether edges have restrictions which must be respected
+     * @param[in] toProhibit The list of explicitly prohibited edges
+     */ 
+    AFBuilder(int numberOfLevels, const std::vector<E*>& edges, bool unbuildIsWarning, 
+        typename SUMOAbstractRouter<FlippedEdge<E, N, V>, V>::Operation flippedOperation, 
+        const std::shared_ptr<const FlippedLookupTable> flippedLookup = nullptr,
+        const bool havePermissions = false, const bool haveRestrictions = false, 
+        const std::vector<FlippedEdge<E, N, V>*>* toProhibit = nullptr) :
+        myEdges(edges),
+        myNumberOfLevels(numberOfLevels), 
+        myNumberOfArcFlags(2 * (myNumberOfLevels - 1)), 
+#ifdef AFBL_DEBUG_LEVEL_0
+        myArcFlagsFileName("arcflags.csv"),
+#endif
+        myAmClean(true) 
+    {
+        for (const E* const edge : edges) {
+            myFlagInfos.push_back(new FlagInfo(edge));
+        }
+        // build the backward graph with flipped edges / nodes in advance
+#ifdef AFBL_DEBUG_LEVEL_0
+        std::cout << "Building flipped edges (" << edges.size() << " edges) / nodes..." << std::endl;
+#endif
+        for (const E* const edge : edges) {
+            myFlippedEdges.push_back(edge->getFlippedRoutingEdge());
+        }
+        for (FlippedEdge<E, N, V>* flippedEdge : myFlippedEdges) {
+            flippedEdge->init();
+        }
+#ifdef AFBL_DEBUG_LEVEL_0
+        std::cout << "Flipped edges / nodes are ready." << std::endl;
+#endif
+        myFlippedPartition = new KDTreePartition<FlippedEdge<E, N, V>, FlippedNode<E, N, V>, V>(myNumberOfLevels, 
+            myFlippedEdges, havePermissions, haveRestrictions);
+#ifdef AFBL_DEBUG_LEVEL_0
+        std::cout << "Instantiating arc flag build..." << std::endl;
+#endif
+        myArcFlagBuild = new AFBuild<E, N, V>(myFlippedEdges, myFlippedPartition, numberOfLevels, unbuildIsWarning,
+            flippedOperation, flippedLookup, havePermissions, haveRestrictions, toProhibit);
+
+#ifdef AFBL_DEBUG_LEVEL_0
+        std::cout << "Arc flag build is instantiated (but still uninitialized)." << std::endl;
+#endif
+    } // end of constructor
+
+    /// @brief Destructor
+    ~AFBuilder();
+
+    /// @brief Returns the arc flag build
+    AFBuild<E, N, V>* getArcFlagBuild() {
+        return myArcFlagBuild;
+    }
+    /// @brief Returns the edges
+    const std::vector<E*>& getEdges() {
+        return myEdges;
+    }
+    /// @brief Resets the builder
+    void reset();
+    /** @brief Build the arc flag information for the arc flag router
+     * @param[in] msTime The start time of the routes in milliseconds
+     * @param[in] The vehicle
+     * @return The vector with the arc flag information
+     */ 
+    std::vector<FlagInfo*>& build(SUMOTime msTime, const V* const vehicle);
+    /** @brief Converts a SHARC level number to a partition level number
+     * @param[in] sHARCLevel The SHARC level
+     * @return The partition level number
+     */
+    int sHARCLevel2PartitionLevel(int sHARCLevel) {
+        return AFRouter<E, N, V>::sHARCLevel2PartitionLevel(sHARCLevel, myNumberOfLevels);
+    }
+
+protected:
+#ifdef AFBL_DEBUG_LEVEL_0
+    /** @brief Loads already precomputed arc flags from a CSV file (for testing purposes)   
+     * @param[in] fileName The name of the CSV file
+     */
+    void loadFlagsFromCsv(const std::string fileName);
+    /** @brief Saves computed arc flags to a CSV file (for testing purposes)
+     * @param[in] fileName The name of the CSV file
+     */
+    void saveFlagsToCsv(const std::string fileName);
+    /** @brief Returns true iff a file with the given name exists
+     * @param[in] name The name of the file to test for existence 
+     * @return true iff a file with the given name exists
+     */
+    bool fileExists(const std::string& name) {
+        std::ifstream f(name.c_str());
+        return f.good();
+    }
+#endif
+    /// @brief The edges
+    const std::vector<E*>& myEdges;
+    /// @brief The flipped (backward) edges
+    std::vector<FlippedEdge<E, N, V>*> myFlippedEdges;
+    /// @brief The k-d tree partition of the backward graph with flipped edges
+    KDTreePartition<FlippedEdge<E, N, V>, FlippedNode<E, N, V>, V>* myFlippedPartition;
+    /// @brief The flag informations
+    std::vector<FlagInfo*> myFlagInfos;
+    /// @brief The arc flag build
+    AFBuild<E, N, V>* myArcFlagBuild;
+    /// @brief The number of levels of the k-d tree partition of the network
+    int myNumberOfLevels;
+    /// @brief The number of arc flags per each edge
+    int myNumberOfArcFlags;
+#ifdef AFBL_DEBUG_LEVEL_0
+    /// @brief The name of the arc flags file.
+    // @note This is a CSV file for convenience/testing purposes
+    const std::string myArcFlagsFileName;
+#endif
+    bool myAmClean;
+};
+
+// ===========================================================================
+// method definitions
+// ===========================================================================
+
+template<class E, class N, class V>
+AFBuilder<E, N, V>::~AFBuilder()
+{
+    delete myArcFlagBuild;
+    delete myFlippedPartition;
+    for (FlagInfo* flagInfo : myFlagInfos) {
+        delete flagInfo;
+    }
+}
+
+template<class E, class N, class V>
+void AFBuilder<E, N, V>::reset()
+{
+    for (FlagInfo* flagInfo : myFlagInfos) {
+        flagInfo->reset();
+    }
+    myAmClean = true;
+}
+
+template<class E, class N, class V>
+std::vector<typename AFInfo<E>::FlagInfo*>& AFBuilder<E, N, V>::build(SUMOTime msTime, const V* const vehicle) {
+    if (!myAmClean) {
+        reset();
+    }
+    assert(myFlippedPartition);
+    if (myFlippedPartition->isClean()) {
+        myFlippedPartition->init(vehicle);
+        myArcFlagBuild->setFlippedPartition(myFlippedPartition);
+    }
+    else {
+        myFlippedPartition->reset(vehicle);
+    }
+    assert(myArcFlagBuild);
+#ifdef AFBL_DEBUG_LEVEL_0
+    bool fileExists = this->fileExists(myArcFlagsFileName);
+    if (fileExists && myAmClean) {
+        std::cout << "Loading arc flags from file " << myArcFlagsFileName << std::endl; 
+        loadFlagsFromCsv(myArcFlagsFileName);
+        std::cout << "Arc flags loaded." << std::endl;
+    }
+    else {
+#endif
+        myArcFlagBuild->init(msTime, vehicle, myFlagInfos);
+#ifdef AFBL_DEBUG_LEVEL_0
+    }
+#endif
+    delete myFlippedPartition;
+    myFlippedPartition = nullptr;
+
+#ifdef AFBL_DEBUG_LEVEL_0
+    if (!fileExists) {
+        std::cout << "Saving arc flags..." << std::endl;
+        // save flag vectors in a CSV file (one column, flag vectors in the order of edges)
+        saveFlagsToCsv(myArcFlagsFileName);
+        std::cout << "Arc flags have been saved." << std::endl;
+    }
+#endif
+    myAmClean = false;
+    return myFlagInfos;
+}
+
+#ifdef AFBL_DEBUG_LEVEL_0
+template<class E, class N, class V>
+void AFBuilder<E, N, V>::saveFlagsToCsv(const std::string fileName)
+{
+    std::ofstream csvFile(fileName);
+    for (FlagInfo* flagInfo : myFlagInfos) {
+        if ((flagInfo->arcFlags).empty()) {
+            // default flag is false / zero
+            std::fill_n(std::back_inserter(flagInfo->arcFlags),
+                myNumberOfArcFlags, false);
+        }
+        for (bool flag : flagInfo->arcFlags) {
+            csvFile << flag;
+        }
+        csvFile << std::endl;
+    }
+    csvFile.close();
+}
+
+template<class E, class N, class V>
+void AFBuilder<E, N, V>::loadFlagsFromCsv(const std::string fileName) {
+    assert(myAmClean);
+    std::string fileNameCopy = fileName;
+    std::ifstream csvFile(fileNameCopy);
+    std::string result;
+    if (!csvFile.is_open()) {
+        result = fileNameCopy.insert(0, "Could not open CSV file ");
+        throw std::runtime_error(result);
+    }
+    for (FlagInfo* flagInfo : myFlagInfos) {
+        (flagInfo->arcFlags).clear();
+        std::fill_n(std::back_inserter(flagInfo->arcFlags),
+            myNumberOfArcFlags, false);
+        std::string line;
+        if (std::getline(csvFile, line)) {
+            if (line.empty()) {
+                continue;
+            }
+            std::stringstream stringStream(line);
+            std::string flagAsString(1, '\0');
+            int pos = 0;
+            while (stringStream.read(&flagAsString[0], 1)) {
+                (flagInfo->arcFlags)[pos++] = (!flagAsString.compare("0") ? 0 : 1);
+            }
+        }
+        else {
+            result = fileNameCopy.insert(0, "CSV file ");
+            throw std::runtime_error(result.append(" has not enough lines - wrong or corrupted file?"));
+        }
+    }
+    myAmClean = false;
+    csvFile.close();
+}
+#endif

--- a/src/utils/router/AFCentralizedSPTree.h
+++ b/src/utils/router/AFCentralizedSPTree.h
@@ -1,0 +1,370 @@
+/****************************************************************************/
+// Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.org/sumo
+// Copyright (C) 2012-2023 German Aerospace Center (DLR) and others.
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0/
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License 2.0 are satisfied: GNU General Public License, version 2
+// or later which is available at
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+/****************************************************************************/
+/// @file    AFCentralizedSPTree.h
+/// @author  Ruediger Ebendt
+/// @date    01.12.2023
+///
+// Class for a label-correcting algorithm calculating multiple shortest path 
+// trees at once (centralized shortest path tree, cf. Hilger et al.) 
+// Used for setting the arc flags for the arc flag router
+// @note Intended use is on a backward graph with flipped edges
+/****************************************************************************/
+#pragma once
+#include <config.h>
+
+#include <cassert>
+#include <string>
+#include <functional>
+#include <vector>
+#include <set>
+#include <limits>
+#include <algorithm>
+#include <iterator>
+#include <map>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <cstddef>
+#include <utils/common/MsgHandler.h>
+#include <utils/common/StringTokenizer.h>
+#include <utils/common/StringUtils.h>
+#include <utils/common/StdDefs.h>
+#include <utils/common/ToString.h>
+#include <utils/iodevices/OutputDevice.h>
+#include <utils/common/SUMOTime.h>
+#include "SUMOAbstractRouter.h"
+#include "KDTreePartition.h"
+#include "AFInfo.h"
+
+//#define CSPT_WRITE_QGIS_FILTERS
+//#define CSPT_DEBUG_LEVEL_0
+
+template<class E, class N, class V>
+class AFCentralizedSPTree {
+public:
+    typedef typename KDTreePartition<E, N, V>::Cell Cell;
+    typedef typename AFInfo<E>::ArcInfo ArcInfo;
+ 
+    class EdgeInfoComparator {
+    public:
+        /** @brief Constructor
+         * @param[in] arcInfos The arc informations
+         */ 
+        EdgeInfoComparator(std::vector<ArcInfo*>& arcInfos) : myArcInfos(arcInfos)
+        {
+        }
+
+        /** @brief Comparing method
+         * @param[in] edgeInfo1 The first edge information
+         * @param[in] edgeInfo2 The second edge information
+         * @return true iff arc info key of the first edge is greater than that of the second
+         * @note In case of ties: returns true iff the numerical id of the first edge is greater that that of the second
+         */ 
+        bool operator()(const typename SUMOAbstractRouter<E, V>::EdgeInfo* edgeInfo1, 
+            const typename SUMOAbstractRouter<E, V>::EdgeInfo* edgeInfo2) const {
+            int index1 = edgeInfo1->edge->getNumericalID();
+            int index2 = edgeInfo2->edge->getNumericalID();
+            ArcInfo* arcInfo1 = myArcInfos[index1];
+            ArcInfo* arcInfo2 = myArcInfos[index2];
+            double key1 = arcInfo1->key;
+            double key2 = arcInfo2->key;
+
+            if (key1 == key2) { // tie
+                return index1 > index2;
+            }
+            return key1 > key2;
+        }
+    private:
+        std::vector<ArcInfo*>& myArcInfos;
+    };
+
+    /** @brief Constructor
+     * @param[in] edges The edges
+     * @param[in] arcInfos The arc informations (for arc flag routing)
+     * @param[in] unbuildIsWarning The flag indicating whether network unbuilds should issue warnings or errors
+     * @param[in] effortProvider The effort provider
+     * @param[in] havePermissions The boolean flag indicating whether edge permissions need to be considered or not
+     * @param[in] haveRestrictions The boolean flag indicating whether edge restrictions need to be considered or not
+     */ 
+    AFCentralizedSPTree(const std::vector<E*>& edges, std::vector<ArcInfo*>& arcInfos, bool unbuildIsWarning,
+        SUMOAbstractRouter<E, V>* effortProvider, 
+        const bool havePermissions = false, const bool haveRestrictions = false) :
+        myArcInfos(arcInfos),
+        myHavePermissions(havePermissions),
+        myHaveRestrictions(haveRestrictions),
+        myErrorMsgHandler(unbuildIsWarning ? MsgHandler::getWarningInstance() : MsgHandler::getErrorInstance()),
+        myEffortProvider(effortProvider), 
+        myMaxSpeed(NUMERICAL_EPS) {
+        for (const E* const edge : edges) {
+            myEdgeInfos.push_back(typename SUMOAbstractRouter<E, V>::EdgeInfo(edge));
+            myMaxSpeed = MAX2(myMaxSpeed, edge->getSpeedLimit() * MAX2(1.0, edge->getLengthGeometryFactor()));
+        }
+        myComparator = new EdgeInfoComparator(myArcInfos);
+    }
+ 
+    /// @brief Destructor
+    ~AFCentralizedSPTree() {
+        delete myComparator;
+    }
+    
+    /** @brief Returns true iff driving the given vehicle on the given edge is prohibited 
+     * @param[in] edge The edge
+     * @param[in] vehicle The vehicle
+     * @return true iff driving the given vehicle on the given edge is prohibited
+     */ 
+    bool isProhibited(const E* const edge, const V* const vehicle) const {
+        return (myHavePermissions && edge->prohibits(vehicle)) || (myHaveRestrictions && edge->restricts(vehicle));
+    }
+
+    /** @brief Computes a shortest path tree for each boundary edge of the given cell, returns true iff this was successful
+     * @note This is done for all such shortest path trees at once (i.e., a centralized shortest path tree is computed, see Hilger et al.)
+     * @param[in] msTime The start time of the paths/routes in milliseconds  
+     * @param[in] cell The cell as a part of a k-d tree partition of the network
+     * @param[in] vehicle The vehicle
+     * @param[in] incomingEdgesOfOutgoingBoundaryEdges Maps each outgoing boundary edge to its incoming edges
+     * @param[in] silent The boolean flag indicating whether the method stays silent or puts out messages
+     * @return true iff the centralized shortest path tree could successfully be calculated
+     */ 
+    bool computeCentralizedSPTree(SUMOTime msTime, const Cell* cell, const V* const vehicle, 
+        const std::map<const E*, std::vector<const E*>>& incomingEdgesOfOutgoingBoundaryEdges,
+        bool silent = false) {
+        assert(cell != nullptr);
+        const std::unordered_set<const E*>& fromEdges = cell->getOutgoingBoundaryEdges();
+        if (fromEdges.empty()) { // nothing to do here
+            return false;
+        }
+        double length = 0.; // dummy for the via edge cost update
+        const SUMOVehicleClass vClass = vehicle == 0 ? SVC_IGNORING : vehicle->getVClass();
+        std::vector<const E*> fromEdgesAsVector(fromEdges.begin(), fromEdges.end());
+        init(fromEdgesAsVector, vehicle, msTime);
+        int num_visited = 0;
+        size_t numberOfVisitedFromEdges = 0;
+        bool minIsFromEdge = false;
+#ifdef CSPT_DEBUG_LEVEL_0
+        size_t numberOfTouchedSupercellEdges = 0;
+#endif
+#ifdef _DEBUG
+        const Cell* supercell = cell->getSupercell();
+#endif
+        const bool mayRevisit = true;
+
+        while (!myFrontierList.empty()) {
+            num_visited += 1;
+            // use the edge with the minimal length
+            typename SUMOAbstractRouter<E, V>::EdgeInfo* minimumInfo = myFrontierList.front();
+            const E* const minEdge = minimumInfo->edge;
+            assert(!minEdge->isInternal());
+            ArcInfo* minimumArcInfo = myArcInfos[minEdge->getNumericalID()];
+            if (minimumInfo->visited || numberOfVisitedFromEdges < fromEdges.size()) {
+                minIsFromEdge = incomingEdgesOfOutgoingBoundaryEdges.find(minEdge) != incomingEdgesOfOutgoingBoundaryEdges.end();
+            }
+            else {
+                minIsFromEdge = false;
+            }
+            if (minIsFromEdge) {
+                if (numberOfVisitedFromEdges < fromEdges.size()) {
+                    numberOfVisitedFromEdges++;
+                }
+            }
+            assert(incomingEdgesOfOutgoingBoundaryEdges.size() == fromEdges.size());
+            assert(minimumArcInfo->key != std::numeric_limits<double>::max() && minimumArcInfo->key != UNREACHABLE);
+            size_t index;
+#ifdef CSPT_DEBUG_LEVEL_0
+            if (supercell->contains(minEdge->getToJunction())) {
+                // minEdge is a supercell edge (we check for the to-node since we work on a backward graph)
+                if (!minimumArcInfo->touched) {
+                    numberOfTouchedSupercellEdges++;
+                    minimumArcInfo->touched = true;
+                }
+            }
+#endif
+#ifdef CSPT_DEBUG_LEVEL_0
+            if (num_visited % 500 == 0) {
+                std::cout << "num_visited: " << num_visited << ", numberOfTouchedSupercellEdges: " << numberOfTouchedSupercellEdges
+                    << ", minimumArcInfo->key: " << minimumArcInfo->key << std::endl;
+            }
+#endif
+            std::pop_heap(myFrontierList.begin(), myFrontierList.end(), *myComparator);
+            myFrontierList.pop_back();
+            myFound.push_back(minimumInfo);
+            minimumInfo->visited = true;
+            const double effortDelta = myEffortProvider->getEffort(minEdge, vehicle, minimumInfo->leaveTime);
+            const double leaveTime = minimumInfo->leaveTime + myEffortProvider->getTravelTime(minEdge, vehicle, minimumInfo->leaveTime, effortDelta);
+
+            // check all ways from the edge with the minimal length
+            for (const std::pair<const E*, const E*>& follower : minEdge->getViaSuccessors(vClass)) {
+                assert(!follower.first->isInternal());
+                bool wasPushedToHeap = false;
+                auto& followerInfo = myEdgeInfos[follower.first->getNumericalID()];
+                ArcInfo* followerArcInfo = myArcInfos[follower.first->getNumericalID()];
+                // check whether it can be used
+                if (followerInfo.prohibited || isProhibited(follower.first, vehicle)) {
+                    if (!silent) {
+                        myErrorMsgHandler->inform("Vehicle '" + Named::getIDSecure(vehicle) + "' is not allowed on source edge '" + followerInfo.edge->getID() + "'.");
+                    }
+                    continue;
+                }
+
+                if (followerArcInfo->effortsToBoundaryNodes.empty()) { // non-initialized non-supercell edge 
+                    assert(!supercell->contains(follower.first->getToJunction()));
+                    std::fill_n(std::back_inserter(followerArcInfo->effortsToBoundaryNodes),
+                        minimumArcInfo->effortsToBoundaryNodes.size(), std::numeric_limits<double>::max());
+                }
+
+                double key = std::numeric_limits<double>::max();
+                assert(followerArcInfo->effortsToBoundaryNodes.size() == minimumArcInfo->effortsToBoundaryNodes.size());
+                bool hasImproved = false;
+                // loop over all boundary nodes
+                for (index = 0; index < followerArcInfo->effortsToBoundaryNodes.size(); index++) {
+                    // is minEdge a from-edge (i.e., an outgoing boundary edge of the passed cell), 
+                    // and 'index' not the index of its from-node (i.e., not of the 'own' boundary node)?
+                    if (minIsFromEdge && (incomingEdgesOfOutgoingBoundaryEdges.at(minEdge))[index]) {
+                        // if yes, assign the successor edges of the incoming edge of minEdge on the shortest route from 
+                        // the boundary node with the index 'index' to followersOfIncomingEdge
+                        assert((incomingEdgesOfOutgoingBoundaryEdges.at(minEdge)).size() 
+                            == followerArcInfo->effortsToBoundaryNodes.size());
+                        const std::vector<std::pair<const E*, const E*>>& followersOfIncomingEdge 
+                            = ((incomingEdgesOfOutgoingBoundaryEdges.at(minEdge))[index])->getViaSuccessors(vClass);
+                        // is the current follower among said successor edges?
+                        bool turningAllowed = false;
+                        for (std::pair<const E*, const E*> followerOfIncomingEdge : followersOfIncomingEdge) {
+                            if (follower.first == followerOfIncomingEdge.first) {
+                                turningAllowed = true;
+                                break;
+                            }                          
+                        }
+                        // if not, then turning from said incoming edge to the current follower is not allowed
+                        // and we mustn't propagate the distance to said boundary node
+                        // instead simply skip this follower
+                        if (!turningAllowed) {
+                            continue;
+                        }
+                    }
+                    // propagate distances to other boundary nodes
+                    double effortToFollower = minimumArcInfo->effortsToBoundaryNodes[index] == UNREACHABLE ?
+                        UNREACHABLE : minimumArcInfo->effortsToBoundaryNodes[index] + effortDelta;
+                    if (effortToFollower == UNREACHABLE) {
+                        continue; // no need to consider this follower 
+                    }
+                    double time = leaveTime;
+                    myEffortProvider->updateViaEdgeCost(follower.second, vehicle, time, effortToFollower, length);
+                    if (effortToFollower < key) {
+                        key = effortToFollower;
+                    }
+                    const double oldEffort = followerArcInfo->effortsToBoundaryNodes[index];
+                    if (oldEffort != std::numeric_limits<double>::max()) {
+                        wasPushedToHeap = true; // must have been pushed to heap during an earlier visit
+                    }
+
+                    if ((!followerInfo.visited || mayRevisit)
+                        && effortToFollower < oldEffort) {
+                        hasImproved = true;
+                        followerArcInfo->effortsToBoundaryNodes[index] = effortToFollower;
+                    }
+                } // end index loop
+
+                if (!hasImproved) {
+                    continue; // no need to re-enque this follower, continue w/ next one
+                }
+                followerArcInfo->key = key;
+                if (!wasPushedToHeap) {
+                    myFrontierList.push_back(&followerInfo);
+                    std::push_heap(myFrontierList.begin(), myFrontierList.end(), *myComparator);
+                }
+                else {
+                    auto fi = std::find(myFrontierList.begin(), myFrontierList.end(), &followerInfo);
+                    if (fi == myFrontierList.end()) { // has already been expanded, reinsert into frontier
+                        assert(mayRevisit);
+                        myFrontierList.push_back(&followerInfo);
+                        std::push_heap(myFrontierList.begin(), myFrontierList.end(), *myComparator);
+                    }
+                    else {
+                        std::push_heap(myFrontierList.begin(), fi + 1, *myComparator);
+                    }
+                }
+            } // end follower loop
+        } // end while (!myFrontierList.empty())
+  
+#ifdef CSPT_DEBUG_LEVEL_0
+        std::cout << "centralizedSPTree finished (queue empty)." << std::endl;
+#endif
+        return true;
+    }
+
+protected:
+    /** @brief Initialize the arc flag router
+     * @param[in] fromEdges The container of from-/head/source edges
+     * @param[in] vehicle The vehicle
+     * @param[in] msTime The start time of the paths/routes in milliseconds 
+     */   
+    void init(std::vector<const E*> fromEdges, const V* const vehicle, SUMOTime msTime);
+    /// @brief The min edge heap
+    /// @note A container for reusage of the min edge heap
+    std::vector<typename SUMOAbstractRouter<E, V>::EdgeInfo*> myFrontierList;
+    /// @brief The list of visited edges (for resetting)
+    std::vector<typename SUMOAbstractRouter<E, V>::EdgeInfo*> myFound;
+    /// The container of edge information
+    std::vector<typename SUMOAbstractRouter<E, V>::EdgeInfo> myEdgeInfos;
+    /// @brief The edge informations specific to arc flag routing 
+    /// @note As opposed to the standard informations in SUMOAbstractRouter<E, V>::EdgeInfo
+    std::vector<ArcInfo*>& myArcInfos;
+    /// @brief The boolean flag indicating whether edge permissions need to be considered or not
+    const bool myHavePermissions;
+    /// @brief The boolean flag indicating whether edge restrictions need to be considered or not
+    const bool myHaveRestrictions;
+    /// @brief The handler for routing errors
+    MsgHandler* const myErrorMsgHandler;
+    /// @brief The object's operation to perform
+    SUMOAbstractRouter<E, V>* myEffortProvider;
+    /// @brief The comparator
+    EdgeInfoComparator* myComparator;
+    /// @brief The maximum speed in the network
+    double myMaxSpeed;
+};
+
+// ===========================================================================
+// method definitions
+// ===========================================================================
+
+template<class E, class N, class V>
+void AFCentralizedSPTree<E, N, V>::init(std::vector<const E*> fromEdges, const V* const vehicle, SUMOTime msTime) {
+    // all EdgeInfos touched in the previous query are either in myFrontierList or myFound: clean those up
+    for (auto& edgeInfo : myFrontierList) {
+        edgeInfo->reset();
+    }
+    myFrontierList.clear();
+    for (auto& edgeInfo : myFound) {
+        edgeInfo->reset();
+    }
+    for (auto& arcInfo : myArcInfos) {
+        arcInfo->reset(); // does not reset effortsToBoundaryNodes
+    }
+    myFound.clear();
+    for (const E* from : fromEdges) {
+        if (from->isInternal()) {
+            continue;
+        }
+        int edgeID = from->getNumericalID();
+        auto& fromInfo = myEdgeInfos[edgeID];
+        if (fromInfo.prohibited || isProhibited(from, vehicle)) {
+            continue;
+        }
+        fromInfo.heuristicEffort = 0.;
+        fromInfo.prev = nullptr;
+        fromInfo.leaveTime = STEPS2TIME(msTime);
+        myFrontierList.push_back(&fromInfo);
+        ArcInfo* fromArcInfo = myArcInfos[edgeID];
+        fromArcInfo->key = 0;
+    }
+}

--- a/src/utils/router/AFInfo.h
+++ b/src/utils/router/AFInfo.h
@@ -1,0 +1,156 @@
+/****************************************************************************/
+// Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.org/sumo
+// Copyright (C) 2012-2023 German Aerospace Center (DLR) and others.
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0/
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License 2.0 are satisfied: GNU General Public License, version 2
+// or later which is available at
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+/****************************************************************************/
+/// @file    AFInfo.h
+/// @author  Ruediger Ebendt
+/// @date    01.12.2023
+///
+// Definitions of informations associated with an edge for use in the arc flag 
+// routing algorithm (Hilger et al.). In more detail, these informations are: 
+// flag information for arc flag routing, a key for sorting the heap, a flag 
+// indicating whether the edge has already been touched, labels for holding
+// (tentative / final) distances to the boundary nodes
+/****************************************************************************/
+#pragma once
+#include <config.h>
+#include <unordered_set>
+
+template<class E>
+class AFInfo {
+public:
+    /**
+     * @class FlagInfo
+     *
+     * It holds a pointer to the associated edge, and flag information 
+     * for arc flag routing 
+     */
+    class FlagInfo {
+    public:
+        /** @brief Constructor
+        * param[in] e The edge
+        */
+        FlagInfo(const E* const e) :
+            edge(e)
+        {
+        }
+        /** @brief Copy constructor
+         * @param[in] other The other FLAG info instance to copy
+         * @return This instance (i.e., the result of the copy)
+         */
+        FlagInfo& operator=(const FlagInfo& other)
+        {
+            // guard self assignment
+            if (this == &other)
+                return *this;
+            edge = other.edge;
+            arcFlags = other.arcFlags;
+            return *this;
+        }
+        /// @brief Destructor
+        virtual ~FlagInfo() {}
+        /// @brief Reset the flag information
+        virtual void reset() {
+            arcFlags.clear();
+        }
+        /// @brief The current edge
+        const E* const edge;
+        /// @brief The arc flags
+        std::vector<bool> arcFlags;
+    }; // end of class FlagInfo declaration
+    
+    /**
+     * @class ArcInfoBase
+     *
+     * Derived from FlagInfo. Therefore holds a pointer 
+     * to the associated edge, and flag information for arc flag routing. 
+     * Additionally, it holds a key for sorting the heap, and a flag 
+     * indicating whether the edge has already been touched
+     */
+    class ArcInfoBase : public FlagInfo {
+    public:
+        /** @brief Constructor
+         * param[in] e The edge
+         */
+        ArcInfoBase(const E* const e) :
+            FlagInfo(e),
+            key(std::numeric_limits<double>::max()),
+            touched(false)
+        {
+        }
+        /** @brief Copy constructor
+         * @param[in] other The other ArcInfoBase instance to copy
+         * @return This instance (i.e., the result of the copy)
+         */
+        ArcInfoBase& operator=(const ArcInfoBase& other)
+        {
+            // guard self assignment
+            if (this == &other)
+                return *this;
+            static_cast<FlagInfo>(this) = static_cast<FlagInfo>(other);
+            key = other.key;
+            touched = other.touched;
+            return *this;
+        }
+        ~ArcInfoBase() {}
+        void reset() {
+            // do nothing
+        }
+        /// @brief The arc flags
+        std::vector<bool> arcFlags;
+        /// @brief The key for sorting the heap
+        double key;
+        /// @brief The flag indicating whether the edge has already been touched or not
+        bool touched;
+    }; // end of class ArcInfoBase declaration
+
+    /**
+     * @class ArcInfo
+     * 
+     * Derived from ArcInfoBase. Therefore it tholds a 
+     * pointer to the associated edge, flag information for arc flag routing, 
+     * a key for sorting the heap, a flag indicating whether the edge has 
+     * already been touched. Additionally, it has labels for holding 
+     * (tentative/final) distances to the boundary nodes
+     */
+    class ArcInfo : public ArcInfoBase {
+    public:
+        /** @brief Constructor
+         * param[in] e The edge
+         */ 
+        ArcInfo(const E* const e) :
+            ArcInfoBase(e)
+        {
+        }
+        /** @brief Copy constructor
+          * @param[in] other The other arc info instance to copy
+          * @return This instance (i.e., the result of the copy)
+          */
+        ArcInfo& operator=(const ArcInfo& other)
+        {
+            // guard self assignment
+            if (this == &other)
+                return *this;
+            static_cast<ArcInfoBase>(this) = static_cast<ArcInfoBase>(other);
+            effortsToBoundaryNodes = other.effortsToBoundaryNodes;
+            return *this;
+        }
+        /// @brief Destructor
+        ~ArcInfo() {}
+        /// @brief Reset the arc information
+        void reset() {
+            // do nothing
+        }
+        /// @brief The efforts to boundary nodes
+        std::vector<double> effortsToBoundaryNodes;
+    }; // end of class ArcInfo declaration
+};

--- a/src/utils/router/AFRouter.h
+++ b/src/utils/router/AFRouter.h
@@ -1,0 +1,777 @@
+/****************************************************************************/
+// Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.org/sumo
+// Copyright (C) 2012-2023 German Aerospace Center (DLR) and others.
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0/
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License 2.0 are satisfied: GNU General Public License, version 2
+// or later which is available at
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+/****************************************************************************/
+/// @file    AFRouter.h
+/// @author  Ruediger Ebendt
+/// @date    01.12.2023
+///
+// Realizes an arc flag routing algorithm (Hilger et al.) in its multi-level variant 
+// (also called "stripped SHARC" by Delling et al.)
+/****************************************************************************/
+#pragma once
+#include <config.h>
+
+#include <cassert>
+#include <string>
+#include <functional>
+#include <vector>
+#include <set>
+#include <limits>
+#include <algorithm>
+#include <iterator>
+#include <map>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <cstddef>
+#include <utils/common/MsgHandler.h>
+#include <utils/common/StringTokenizer.h>
+#include <utils/common/StringUtils.h>
+#include <utils/common/StdDefs.h>
+#include <utils/common/ToString.h>
+#include <utils/iodevices/OutputDevice.h>
+#include "AStarLookupTable.h"
+#include "SUMOAbstractRouter.h"
+#include "KDTreePartition.h"
+#include "FlippedEdge.h"
+#include "AFInfo.h"
+#include "AFBuilder.h"
+
+#define UNREACHABLE (std::numeric_limits<double>::max() / 1000.0)
+#define AFRO_WRITE_QGIS_FILTERS
+
+//#define AFRO_DEBUG_LEVEL_0
+//#define AFRO_DEBUG_LEVEL_1
+//#define AFRO_DEBUG_LEVEL_2
+//#define AFRO_DEBUG_LEVEL_3
+
+#ifdef AFRO_DEBUG_LEVEL_3
+#define AFRO_DEBUG_LEVEL_2
+#endif
+
+#ifdef AFRO_DEBUG_LEVEL_2
+#define AFRO_DEBUG_LEVEL_1
+#endif
+
+#ifdef AFRO_DEBUG_LEVEL_1
+#define AFRO_DEBUG_LEVEL_0
+#endif
+
+// ===========================================================================
+// class definitions
+// ===========================================================================
+/**
+ * @class AFRouter
+ * Computes the shortest path through a network with an arc flag routing 
+ * algorithm (Hilger et al.) in its multi-level variant (also called 
+ * "stripped SHARC" by Delling et al.)
+ *
+ * The template parameters are:
+ * @param E The edge class to use (MSEdge/ROEdge)
+ * @param N The node class to use (MSJunction/RONode)
+ * @param V The vehicle class to use (MSVehicle/ROVehicle)
+ *
+ * The router is edge-based 
+ * It must know the number of edges for internal reasons
+ * and whether a missing connection between two given edges (unbuild route) shall
+ * be reported as an error or as a warning
+ *
+ */
+template<class E, class N, class V>
+class AFRouter : public SUMOAbstractRouter<E, V> {
+public:
+    typedef AbstractLookupTable<E, V> LookupTable;
+    typedef typename KDTreePartition<E, N, V>::Cell Cell;
+    typedef typename AFInfo<E>::FlagInfo FlagInfo;
+    typedef AbstractLookupTable<FlippedEdge<E, N, V>, V> FlippedLookupTable;
+    
+    /** @brief Returns the edge information for the passed edge
+     * @param[in] edge The edge
+     * @note Non-const version
+     * @return The edge information
+     */
+    typename SUMOAbstractRouter<E, V>::EdgeInfo* edgeInfo(const E* const edge) {
+        return &(this->myEdgeInfos[edge->getNumericalID()]);
+    }
+
+    /** @brief Returns the edge information for the passed edge
+     * @param[in] edge The edge
+     * @note Const version
+     * @return The edge information
+     */
+    const typename SUMOAbstractRouter<E, V>::EdgeInfo* edgeInfo(const E* const edge) const {
+        return &(this->myEdgeInfos[edge->getNumericalID()]);
+    }
+
+    /**
+     * @class EdgeInfoComparator
+     * 
+     * Class to compare (and so sort) nodes by their effort
+     */
+    class EdgeInfoComparator {
+    public:
+        /** @brief Comparing method
+         * @param[in] edgeInfo1 First edge information
+         * @param[in] edgeInfo2 Second edge information
+         * @return true iff heuristic effort of first edge information is greater than that of the second
+         * @note In case of ties: true iff first edge information's numerical id is greater than that of the second
+         */ 
+        
+        bool operator()(const typename SUMOAbstractRouter<E, V>::EdgeInfo* edgeInfo1, const typename SUMOAbstractRouter<E, V>::EdgeInfo* edgeInfo2) const {
+            if (edgeInfo1->heuristicEffort == edgeInfo2->heuristicEffort) {
+                return edgeInfo1->edge->getNumericalID() > edgeInfo2->edge->getNumericalID();
+            }
+            return edgeInfo1->heuristicEffort > edgeInfo2->heuristicEffort;
+        }
+    };
+
+    /** @brief Constructor
+     * @param[in] edges The edges
+     * @param[in] partition A partition of the router's network wrt a k-d tree subdivision scheme
+     * @param[in] unbuildIsWarning The flag indicating whether network unbuilds should issue warnings or errors
+     * @param[in] operation The operation for a forward graph
+     * @param[in] flippedOperation The operation for a backward graph with flipped edges
+     * @param[in] weightPeriod The validity duration of one weight interval
+     * @param[in] lookup The lookup table for a forward graph
+     * @param[in] flippedLookup The lookup table for a backward graph  with flipped edges
+     * @param[in] havePermissions The boolean flag indicating whether edge permissions need to be considered or not
+     * @param[in] haveRestrictions The boolean flag indicating whether edge restrictions need to be considered or not
+     */ 
+    AFRouter(const std::vector<E*>& edges, 
+        const KDTreePartition<E, N, V>* partition,
+        bool unbuildIsWarning,
+        typename SUMOAbstractRouter<E, V>::Operation operation, typename SUMOAbstractRouter<FlippedEdge<E, N, V>, V>::Operation flippedOperation,
+        SUMOTime weightPeriod, const std::shared_ptr<const LookupTable> lookup = nullptr,
+        const std::shared_ptr<const FlippedLookupTable> flippedLookup = nullptr,
+        const bool havePermissions = false, const bool haveRestrictions = false) :
+        SUMOAbstractRouter<E, V>("arcFlagRouter", unbuildIsWarning, operation, nullptr, havePermissions, haveRestrictions),
+        myFlagInfos(nullptr),
+        myPartition(partition),
+        myLookupTable(lookup),
+        myMaxSpeed(NUMERICAL_EPS),
+        myWeightPeriod(weightPeriod),
+        myValidUntil(0),
+        myBuilder(new AFBuilder<E, N, V>(myPartition->getNumberOfLevels(), edges, unbuildIsWarning,
+            flippedOperation, flippedLookup, havePermissions, haveRestrictions)),
+        myType("arcFlagRouter"),
+        myQueryVisits(0),
+        myNumQueries(0),
+        myQueryStartTime(0),
+        myQueryTimeSum(0),
+#ifdef AFRO_DEBUG_LEVEL_2
+        myFlagContextStartTime(0),
+        myFlagContextTimeSum(0),
+#endif
+        myLastSettledEdgeCell(nullptr),
+        myTargetEdgeCellLevel0(nullptr)
+    {
+        for (const E* const edge : edges) {
+            this->myEdgeInfos.push_back(typename SUMOAbstractRouter<E, V>::EdgeInfo(edge));
+            myMaxSpeed = MAX2(myMaxSpeed, edge->getSpeedLimit() * MAX2(1.0, edge->getLengthGeometryFactor()));
+        }
+    }
+
+    /** @brief "Normal" cloning constructor for uninitialized or time-dependent instances
+     * @param[in] edges The edges
+     * @param[in] partition A partition of the router's network wrt a k-d tree subdivision scheme
+     * @param[in] unbuildIsWarning The flag indicating whether network unbuilds should issue warnings or errors
+     * @param[in] operation The operation for a forward graph
+     * @param[in] flippedOperation The operation for a backward graph with flipped edges
+     * @param[in] weightPeriod The validity duration of one weight interval
+     * @param[in] lookup The lookup table for a forward graph
+     * @param[in] flippedLookup The lookup table for a backward graph with flipped edges
+     * @param[in] havePermissions The boolean flag indicating whether edge permissions need to be considered
+     * @param[in] haveRestrictions The boolean flag indicating whether edge restrictions need to be considered
+     */
+    AFRouter(const std::vector<typename SUMOAbstractRouter<E, V>::EdgeInfo>& edgeInfos,
+        const std::vector<E*>& edges, 
+        const KDTreePartition<E, N, V>* partition,
+        bool unbuildIsWarning,
+        typename SUMOAbstractRouter<E, V>::Operation operation, 
+        typename SUMOAbstractRouter<FlippedEdge<E, N, V>, V>::Operation flippedOperation,
+        SUMOTime weightPeriod, const std::shared_ptr<const LookupTable> lookup = nullptr,
+        const std::shared_ptr<const FlippedLookupTable> flippedLookup = nullptr,
+        const bool havePermissions = false, const bool haveRestrictions = false) :
+        SUMOAbstractRouter<E, V>("arcFlagRouter", unbuildIsWarning, operation, nullptr, havePermissions, haveRestrictions),
+        myFlagInfos(nullptr),
+        myPartition(partition),
+        myLookupTable(lookup),
+        myMaxSpeed(NUMERICAL_EPS),
+        myWeightPeriod(weightPeriod),
+        myValidUntil(0),
+        myBuilder(new AFBuilder<E, N, V>(myPartition->getNumberOfLevels(), edges, unbuildIsWarning,
+            flippedOperation, flippedLookup, havePermissions, haveRestrictions)), 
+        myType("arcFlagRouter"),
+        myQueryVisits(0),
+        myNumQueries(0),
+        myQueryStartTime(0),
+        myQueryTimeSum(0),
+#ifdef AFRO_DEBUG_LEVEL_2
+        myFlagContextStartTime(0),
+        myFlagContextTimeSum(0),
+#endif
+        myLastSettledEdgeCell(nullptr),
+        myTargetEdgeCellLevel0(nullptr)
+    {
+        for (const auto& edgeInfo : edgeInfos) {
+            this->myEdgeInfos.push_back(typename SUMOAbstractRouter<E, V>::EdgeInfo(edgeInfo.edge));
+            myMaxSpeed = MAX2(myMaxSpeed, edgeInfo.edge->getSpeedLimit() * edgeInfo.edge->getLengthGeometryFactor());
+        }
+    }
+
+    /** @brief Special cloning constructor, only for time-independent instances which never rebuild arc infos
+     * @param[in] edgeInfos The vector of edge information
+     * @param[in] partition A partition of the router's network wrt a k-d tree subdivision scheme
+     * @param[in] unbuildIsWarning The flag indicating whether network unbuilds should issue warnings or errors
+     * @param[in] operation The operation for a forward graph
+     * @param[in] flagInfos The vector of arc flag information
+     * @param[in] lookup The lookup table for a forward graph
+     * @param[in] havePermissions The boolean flag indicating whether edge permissions need to be considered
+     * @param[in] haveRestrictions The boolean flag indicating whether edge restrictions need to be considered
+     */
+   AFRouter(const std::vector<typename SUMOAbstractRouter<E, V>::EdgeInfo>& edgeInfos, 
+        const KDTreePartition<E, N, V>* partition,
+        bool unbuildIsWarning, typename SUMOAbstractRouter<E, V>::Operation operation, 
+        std::vector<FlagInfo*>* flagInfos, 
+        const std::shared_ptr<const LookupTable> lookup = nullptr,
+        const bool havePermissions = false, const bool haveRestrictions = false) :
+        SUMOAbstractRouter<E, V>("arcFlagRouterClone", unbuildIsWarning, operation, nullptr, havePermissions, haveRestrictions),
+        myFlagInfos(flagInfos),
+        myPartition(partition),
+        myLookupTable(lookup),
+        myMaxSpeed(NUMERICAL_EPS),
+        myWeightPeriod(SUMOTime_MAX),
+        myValidUntil(SUMOTime_MAX),
+        myBuilder(nullptr), 
+        myType("arcFlagRouterClone"),
+        myQueryVisits(0),
+        myNumQueries(0),
+        myQueryStartTime(0),
+        myQueryTimeSum(0),
+#ifdef AFRO_DEBUG_LEVEL_2
+        myFlagContextStartTime(0),
+        myFlagContextTimeSum(0),
+#endif
+        myLastSettledEdgeCell(nullptr),
+        myTargetEdgeCellLevel0(nullptr)
+    {
+        for (const auto& edgeInfo : edgeInfos) {
+            this->myEdgeInfos.push_back(typename SUMOAbstractRouter<E, V>::EdgeInfo(edgeInfo.edge));
+            myMaxSpeed = MAX2(myMaxSpeed, edgeInfo.edge->getSpeedLimit() * edgeInfo.edge->getLengthGeometryFactor());
+        }
+    }
+
+    /// @brief Destructor
+    virtual ~AFRouter() {
+        delete myBuilder;
+    }
+
+    /// @brief Cloning method
+    virtual SUMOAbstractRouter<E, V>* clone() {
+        // I am either a clone myself, or I am already initialized and time-independent 
+        // (i.e., I have been created with a maximum weight period)
+        if (myWeightPeriod == SUMOTime_MAX && myFlagInfos != nullptr) { 
+            // we only need the arc infos once:
+            return new AFRouter(this->myEdgeInfos, myPartition, this->myErrorMsgHandler == MsgHandler::getWarningInstance(), 
+                this->myOperation, myFlagInfos, myLookupTable, this->myHavePermissions, this->myHaveRestrictions);
+        }
+        // I am not a clone: I am either uninitialized, or initialized but time-dependent: 
+        // create another such guy (also flagged as a non-clone)
+        return new AFRouter(this->myEdgeInfos, myBuilder->getEdges(), myPartition, 
+            this->myErrorMsgHandler == MsgHandler::getWarningInstance(),
+            this->myOperation, myBuilder->getArcFlagBuild()->getFlippedOperation(),
+            myWeightPeriod, myLookupTable, myBuilder->getArcFlagBuild()->getFlippedLookup(), 
+            this->myHavePermissions, this->myHaveRestrictions);
+    }
+
+    /** @brief Converts a partition level number to a SHARC level number
+     * @param[in] partitionLevel The partition level
+     * @param[in] numberOfPartitionLevels The number of partition levels
+     * @return The SHARC level number
+     */ 
+    static int partitionLevel2SHARCLevel(int partitionLevel, int numberOfPartitionLevels)
+    {
+        // heads up: partition levels must start at zero, with zero being an illegal argument 
+        // (since it would corresponds to level L = V, which is not a valid SHARC level)
+        if (partitionLevel <= 0) {
+            throw std::invalid_argument("partitionLevel2SHARCLevel: given partition level is zero (0) or below. This does not correspond to a valid SHARC level. Partition levels valid for conversion to SHARC levels go from one to number of partition levels minus one.");
+        }
+        // heads up: partition levels must start at zero
+        if (partitionLevel > numberOfPartitionLevels - 1) {
+            throw std::invalid_argument("partitionLevel2SHARCLevel: given partition level exceeds the number of partition levels minus one. Most likely you did not start the partition level numbering at zero (0), which is required here.");
+        }
+        return (numberOfPartitionLevels - 1) - partitionLevel;
+    }
+
+    /** @brief Converts a SHARC level number to a partition level number
+     * @param[in] sHARCLevel The SHARC level
+     * @param[in] numberOfPartitionLevels The number of partition levels
+     * @return The partition level number
+     */
+    static int sHARCLevel2PartitionLevel(int sHARCLevel, int numberOfPartitionLevels)
+    {
+        int numberOfSHARCLevels = numberOfPartitionLevels - 1;
+        if (sHARCLevel < 0) {
+            throw std::invalid_argument("sHARCLevel2PartitionLevel: given SHARC level is negative.");
+        }
+        // heads up: SHARC levels must start at zero (0), 
+        // and end at number of partition levels minus two
+        if (sHARCLevel > numberOfSHARCLevels - 1) {
+            throw std::invalid_argument("sHARCLevel2PartitionLevel: given SHARC level exceeds the number of SHARC levels minus one. Most likely you did not start the SHARC level numbering at zero (0), which is required here.");
+        }
+        return numberOfSHARCLevels - sHARCLevel;
+    }
+
+    /** @brief Returns the arc flag of the edge in flagInfo wrt flagContext
+     * @param[in] flagInfo The arc flag information
+     * @param[in] flagContext The flag context tuple
+     * @return The flag indicating whether the arc flag is set or not, wrt given arc flag information and context
+     */
+    static bool flag(const FlagInfo* flagInfo, const std::tuple<int, int, bool> flagContext)
+    {
+            assert(flagInfo);
+            return flagInfo->arcFlags.empty() ? true : /* play it safe */
+                (flagInfo->arcFlags)[std::get<0>(flagContext) /* assumed to be the SHARC level */ * 2
+                + std::get<1>(flagContext) /* assumed to be the cell index */];
+            
+    }
+
+    /** @brief Returns the arc flags of the passed edge
+     * @param[in] edge The edge
+     * @return The arc flags of the given edge
+     */ 
+    std::vector<bool>& flags(const E* edge);
+    
+    /** @brief Trigger arc flags rebuild
+     * @param[in] The vehicle
+     */  
+    virtual void reset(const V* const vehicle) {
+        if (myValidUntil == 0) {
+            myValidUntil = myWeightPeriod;
+        }
+        assert(myBuilder);
+#ifdef AFRO_DEBUG_LEVEL_0
+        long long int firstCallStart = 0;
+        long long int firstCallTime = 0;
+        firstCallStart = SysUtils::getCurrentMillis();
+        std::cout << "Calling arc flag router for the first time during current weight period (arc flags build). This might take a while... " << std::endl;
+#endif
+        myFlagInfos = &(myBuilder->build(myValidUntil - myWeightPeriod, vehicle));
+#ifdef AFRO_DEBUG_LEVEL_0
+        firstCallTime = (SysUtils::getCurrentMillis() - firstCallStart);
+        std::cout << "Time spent for arc flags build: " << elapsedMs2string(firstCallTime) << std::endl;
+#endif
+     }
+
+    /** @brief Initialize the arc flag router
+     * param[in] edgeID The edge id(entifier)
+     * param[in] msTime The start time of the routes in milliseconds
+     */   
+    void init(const int edgeID, const SUMOTime msTime);
+    /** @brief Returns the flag context for a route query from given settled edge to the target edge
+     * @param[in] settledEdge The settled edge
+     * @param[in] targetEdge The target edge
+     */
+    std::tuple<int, int, bool> flagContext(const E* settledEdge, const E* targetEdge);
+    /// @brief Kept for runtime comparisons
+    std::tuple<int, int, bool> flagContextNaive(const E* settledEdge, const E* targetEdge);
+
+    /** @brief Builds the route between the given edges using the minimum travel time
+     * param[in] from The from-/start/source/head edge
+     * param[in] to The to-/end/target/tail edge
+     * param[in] vehicle The vehicle
+     * param[in] msTime The start time of the routes in milliseconds
+     * param[out] into The vector of edges, into which the solution route is written
+     * @param[in] silent The boolean flag indicating whether the method stays silent or puts out messages
+     */
+    bool compute(const E* from, const E* to, const V* const vehicle,
+        SUMOTime msTime, std::vector<const E*>& into, bool silent = false) {
+        assert(from != nullptr && to != nullptr);
+        // check whether from and to can be used
+        if (this->myEdgeInfos[from->getNumericalID()].prohibited || this->isProhibited(from, vehicle)) {
+            if (!silent) {
+                this->myErrorMsgHandler->inform("Vehicle '" + Named::getIDSecure(vehicle) + "' is not allowed on source edge '" + from->getID() + "'.");
+            }
+            return false;
+        }
+        if (this->myEdgeInfos[to->getNumericalID()].prohibited || this->isProhibited(to, vehicle)) {
+            if (!silent) {
+                this->myErrorMsgHandler->inform("Vehicle '" + Named::getIDSecure(vehicle) + "' is not allowed on destination edge '" + to->getID() + "'.");
+            }
+            return false;
+        }
+
+        if (msTime >= myValidUntil) {
+            assert(myBuilder != nullptr); // only time independent clones do not have a builder
+            while (msTime >= myValidUntil) {
+                myValidUntil += myWeightPeriod;
+            }
+            reset(vehicle);
+        } 
+        // rewind routing start time to building time (this can only be a gross approximation 
+        // of time-dependent routing)
+        msTime = myValidUntil - myWeightPeriod;
+
+        double length = 0.; // dummy for the via edge cost update
+        this->startQuery();
+        const SUMOVehicleClass vClass = vehicle == 0 ? SVC_IGNORING : vehicle->getVClass();
+        this->init(from->getNumericalID(), msTime);
+        this->myAmClean = false;
+        // loop
+        int num_visited = 0;
+        int numberOfFollowers = 0;
+        int numberOfAvoidedFollowers = 0;
+        int numberOfEmptyFlagVectors = 0;
+        const bool mayRevisit = myLookupTable != nullptr && !myLookupTable->consistent();
+        const double speed = vehicle == nullptr ? myMaxSpeed : MIN2(vehicle->getMaxSpeed(), myMaxSpeed * vehicle->getChosenSpeedFactor());
+
+        while (!this->myFrontierList.empty()) {
+            num_visited += 1;
+            // use the edge with the minimal length
+            auto* const minimumInfo = this->myFrontierList.front();
+            const E* const minEdge = minimumInfo->edge;
+            // check whether the destination edge was already reached
+            if (minEdge == to) {
+                this->buildPathFrom(minimumInfo, into);
+                this->endQuery(num_visited);
+#ifdef AFRO_DEBUG_LEVEL_1
+                std::cout << "Found to, to->getID(): " << to->getID() << std::endl;
+                std::cout << static_cast<double>(numberOfFollowers - numberOfAvoidedFollowers) / static_cast<double>(num_visited)
+                    << " followers considered (out of " << static_cast<double>(numberOfFollowers) / static_cast<double>(num_visited) << ") on average." << std::endl;
+                std::cout << static_cast<double>(numberOfFollowers - numberOfAvoidedFollowers)
+                    << " followers considered (out of " << static_cast<double>(numberOfFollowers) << ")." << std::endl;
+                std::cout << numberOfEmptyFlagVectors << " out of " << numberOfFollowers << " flag vectors of followers were unassigned (i.e., empty)." << std::endl;
+                std::cout << "num_visited: " << num_visited << std::endl;
+#endif
+                return true;
+            }
+            std::pop_heap(this->myFrontierList.begin(), this->myFrontierList.end(), myComparator);
+            this->myFrontierList.pop_back();
+            this->myFound.push_back(minimumInfo);
+            minimumInfo->visited = true;
+
+            const double effortDelta = this->getEffort(minEdge, vehicle, minimumInfo->leaveTime);
+            const double leaveTime = minimumInfo->leaveTime + this->getTravelTime(minEdge, vehicle, minimumInfo->leaveTime, effortDelta);
+
+            // admissible A* heuristic: straight line distance at maximum speed
+            // this is calculated from the end of minEdge so it possibly includes via efforts to the followers
+            double heuristic_remaining = 0.; 
+            double heuristicEffort = minimumInfo->effort + effortDelta + heuristic_remaining;
+            // check all ways from the edge with the minimal length
+            for (const std::pair<const E*, const E*>& follower : minEdge->getViaSuccessors(vClass)) {
+                auto& followerInfo = this->myEdgeInfos[follower.first->getNumericalID()];
+                const FlagInfo* followerFlagInfo = (*myFlagInfos)[follower.first->getNumericalID()];
+                // check whether it can be used
+                if (followerInfo.prohibited || this->isProhibited(follower.first, vehicle)) {
+                    continue;
+                }
+                numberOfFollowers++;
+                if (followerFlagInfo->arcFlags.empty()) {
+                    numberOfEmptyFlagVectors++;
+                }
+#ifdef AFRO_DEBUG_LEVEL_2
+                myFlagContextStartTime = SysUtils::getCurrentMillis();
+#endif
+                std::tuple<int, int, bool> flagContext = this->flagContext(follower.first, to);
+                //std::tuple<int, int, bool> flagContext = this->flagContextNaive(follower.first, to);
+#ifdef AFRO_DEBUG_LEVEL_2
+                myFlagContextTimeSum += (SysUtils::getCurrentMillis() - myFlagContextStartTime);
+#endif
+                if (!flag(followerFlagInfo, flagContext)) {
+                    numberOfAvoidedFollowers++;
+                    continue;
+                } 
+                
+                // admissible A* heuristic: straight line distance at maximum speed
+                // this is calculated from the end of minEdge so it possibly includes via efforts to the followers
+                if (heuristic_remaining == 0 && std::get<0>(flagContext) == 0 && std::get<2>(flagContext)) {
+                    // arrived at the target cell at level 0? use heuristic
+                    heuristic_remaining =
+                        (myLookupTable == nullptr ? minEdge->getDistanceTo(to) / speed :
+                            myLookupTable->lowerBound(minEdge, to, speed, vehicle->getChosenSpeedFactor(),
+                                minEdge->getMinimumTravelTime(nullptr), to->getMinimumTravelTime(nullptr)));
+                    if (heuristic_remaining == UNREACHABLE) {
+                        break; // -> skip remaining followers, continue with next min heap element
+                    }
+                    heuristicEffort += heuristic_remaining;
+                }
+
+                double effort = minimumInfo->effort + effortDelta;
+                double time = leaveTime;
+                this->updateViaEdgeCost(follower.second, vehicle, time, effort, length);
+                const double oldEffort = followerInfo.effort;
+                if ((!followerInfo.visited || mayRevisit) && effort < oldEffort) {
+                    followerInfo.effort = effort;
+                    // if we use the effort including the via effort below we would count the via twice as shown by the ticket676 test
+                    // but we should never get below the real effort, see #12463
+                    followerInfo.heuristicEffort = MAX2(MIN2(heuristicEffort, followerInfo.heuristicEffort), effort);
+                    followerInfo.leaveTime = time;
+                    followerInfo.prev = minimumInfo;
+                    if (oldEffort == std::numeric_limits<double>::max()) {
+                        this->myFrontierList.push_back(&followerInfo);
+                        std::push_heap(this->myFrontierList.begin(), this->myFrontierList.end(), myComparator);
+                    }
+                    else {
+                        auto fi = std::find(this->myFrontierList.begin(), this->myFrontierList.end(), &followerInfo);
+                        if (fi == this->myFrontierList.end()) {
+                            assert(mayRevisit);
+                            this->myFrontierList.push_back(&followerInfo);
+                            std::push_heap(this->myFrontierList.begin(), this->myFrontierList.end(), myComparator);
+                        }
+                        else {
+                            std::push_heap(this->myFrontierList.begin(), fi + 1, myComparator);
+                        }
+                    }
+                }
+            } // for followers
+        }
+        this->endQuery(num_visited);
+#ifdef AFRO_DEBUG_LEVEL_1
+        std::cout << "Queue ran empty, no solution." << std::endl;
+        std::cout << static_cast<double>(numberOfFollowers - numberOfAvoidedFollowers) / static_cast<double>(num_visited) 
+            << " followers considered (out of " << static_cast<double>(numberOfFollowers) / static_cast<double>(num_visited) << ") on average." << std::endl;
+        std::cout << static_cast<double>(numberOfFollowers - numberOfAvoidedFollowers)
+            << " followers considered (out of " << static_cast<double>(numberOfFollowers) << ")." << std::endl;
+        std::cout << numberOfEmptyFlagVectors << " out of " << numberOfFollowers << " flag vectors of followers were unassigned (i.e., empty)." << std::endl;
+        std::cout << "num_visited: " << num_visited << std::endl;
+#endif
+        if (!silent) {
+            this->myErrorMsgHandler->informf("No connection between edge '%' and edge '%' found.", from->getID(), to->getID());
+        }
+        return false;
+    }
+
+    /// @brief Start timer for query time sum
+    void startQuery();
+    /// @brief Stop timer for query time sum
+    void endQuery(int visits);
+    /// @brief Report query time statistics
+    void reportStatistics();
+    /// @brief Reset query time statistics
+    void resetStatistics();
+    /// @brief Bulk mode is not supported
+    virtual void setBulkMode(const bool mode) {
+        UNUSED_PARAMETER(mode);
+        throw std::runtime_error("Bulk mode is not supported by the arc flag router.");
+    }
+
+protected:
+    /// @brief Edge infos containing the associated edge and its arc flags 
+    std::vector<FlagInfo*>* myFlagInfos;
+    /// @brief The partition
+    const KDTreePartition<E, N, V>* myPartition;
+    /// @brief The comparator for edge information
+    EdgeInfoComparator myComparator;
+    /// @brief The lookup table for travel time heuristics
+    const std::shared_ptr<const LookupTable> myLookupTable;
+    /// @brief The maximum speed in the network
+    double myMaxSpeed;
+    /// @brief The validity duration of one weight interval
+    const SUMOTime myWeightPeriod;
+    /// @brief The validity duration of the current flag infos (exclusive)
+    SUMOTime myValidUntil;
+    /// @brief The builder
+    AFBuilder<E, N, V>* myBuilder;
+    /// @brief The type of this router
+    /// @note The one in SUMOAbstractRouter is private, required for more flexible performance logging (see below)
+    const std::string myType;
+    /// @brief Counters for performance logging
+    /// @note The ones in SUMOAbstractRouter are private - introduced to reset stats / recalculate before destruction
+    long long int myQueryVisits;
+    long long int myNumQueries;
+    /// @brief The time spent querying in milliseconds
+    /// @note The ones in SUMOAbstractRouter are private - introduced to reset stats / recalculate before destruction
+    long long int myQueryStartTime;
+    long long int myQueryTimeSum;
+#ifdef AFRO_DEBUG_LEVEL_2
+    /// @brief The time spent for flagContext in milliseconds
+    long long int myFlagContextStartTime;
+    long long int myFlagContextTimeSum;
+#endif
+private:
+    /// @brief The cell of the last settled edge
+    const Cell* myLastSettledEdgeCell;
+    /// @brief The last flag context
+    std::tuple<int, int, bool> myLastFlagContext;
+    /// @brief The cell of the target edge at SHARC level 0
+    const Cell* myTargetEdgeCellLevel0;
+};
+
+// ===========================================================================
+// method definitions
+// ===========================================================================
+
+template<class E, class N, class V>
+std::vector<bool>& AFRouter<E, N, V>::flags(const E* edge) {
+    assert(edge);
+    if (!myFlagInfos) {
+        throw std::runtime_error("flag infos not initialized, call compute() at least once before calling flags().");
+    }
+    return ((*myFlagInfos)[edge->getNumericalID()])->arcFlags;
+}
+
+template<class E, class N, class V>
+void AFRouter<E, N, V>::init(const int edgeID, const SUMOTime msTime) {
+    // all EdgeInfos touched in the previous query are either in myFrontierList or myFound: clean those up
+    myTargetEdgeCellLevel0 = nullptr;
+    for (auto& edgeInfo : this->myFrontierList) {
+        edgeInfo->reset();
+    }
+    this->myFrontierList.clear();
+    for (auto& edgeInfo : this->myFound) {
+        edgeInfo->reset();
+    }
+    this->myFound.clear();
+    if (edgeID > -1) {
+        // add begin node
+        auto& fromInfo = this->myEdgeInfos[edgeID];
+        fromInfo.heuristicEffort = 0.;
+        fromInfo.effort = 0.;
+        fromInfo.leaveTime = STEPS2TIME(msTime);
+        fromInfo.prev = nullptr;
+        this->myFrontierList.push_back(&fromInfo);
+    }
+}
+
+template<class E, class N, class V>
+std::tuple<int, int, bool> AFRouter<E, N, V>::flagContextNaive(const E* settledEdge, const E* targetEdge)
+{
+    assert(settledEdge != nullptr && targetEdge != nullptr);
+    int sHARCLevel;
+    for (sHARCLevel = 0; sHARCLevel < myPartition->getNumberOfLevels() - 1; sHARCLevel++) {
+        int partitionLevel = sHARCLevel2PartitionLevel(sHARCLevel, myPartition->getNumberOfLevels());
+        const std::vector<const Cell*>& levelCells = myPartition->getCellsAtLevel(partitionLevel);
+        typename std::vector<const Cell*>::const_iterator first = levelCells.begin();
+        typename std::vector<const Cell*>::const_iterator last = levelCells.end();
+        typename std::vector<const Cell*>::const_iterator iter;
+        const Cell* settledEdgeCell = nullptr;
+        const Cell* targetEdgeCell = nullptr;
+        // go through the cells of the level
+        for (iter = first; iter != last; iter++) {
+            // myPartition is assumed to partition a non-reversed (forward) graph
+            if (!settledEdgeCell && (*iter)->contains(settledEdge->getFromJunction())) {
+                settledEdgeCell = *iter;
+            }
+            if (!targetEdgeCell && (*iter)->contains(targetEdge->getFromJunction())) {
+                targetEdgeCell = *iter;
+            }
+            if (settledEdgeCell && targetEdgeCell) {
+                break;
+            }
+        }
+        assert(settledEdgeCell && targetEdgeCell); // we should find both edges on each level
+        if (settledEdgeCell->getSupercell() == targetEdgeCell->getSupercell()) {
+            return std::make_tuple(sHARCLevel, targetEdgeCell->isLeftOrLowerCell() ? 0 : 1, 
+                settledEdgeCell == targetEdgeCell);
+        }
+    }
+    // we should never arrive here
+    throw std::runtime_error("flagContext: relevant level could not be determined.");
+}
+
+template<class E, class N, class V>
+std::tuple<int, int, bool> AFRouter<E, N, V>::flagContext(const E* settledEdge, const E* targetEdge)
+{
+    assert(settledEdge != nullptr && targetEdge != nullptr);
+    int sHARCLevel = 0; // lowest level with smallest cells
+    const Cell* settledEdgeCell = nullptr;
+    const Cell* targetEdgeCell = nullptr;
+    if (myLastSettledEdgeCell
+        && myLastSettledEdgeCell->contains(settledEdge->getFromJunction())) {
+        // exploit the partial locality of Dijkstra's algorithm: settled edge is still 
+        // in the same cell as the last one? Then we can simply return the 
+        // last flagContext tuple again.
+        return myLastFlagContext;
+    }
+    int numberOfPartitionLevels = myPartition->getNumberOfLevels();
+    if (numberOfPartitionLevels <= 4) { // small number of bottom cells -> go through them, no use of k-d tree
+        int partitionLevel = sHARCLevel2PartitionLevel(sHARCLevel, myPartition->getNumberOfLevels());
+        const std::vector<const Cell*>& levelCells = myPartition->getCellsAtLevel(partitionLevel);
+        typename std::vector<const Cell*>::const_iterator first = levelCells.begin();
+        typename std::vector<const Cell*>::const_iterator last = levelCells.end();
+        typename std::vector<const Cell*>::const_iterator iter;
+        // go through the cells of the level
+        for (iter = first; iter != last; iter++) {
+            // myPartition is assumed to partition a non-reversed (forward) graph
+            if (!settledEdgeCell 
+                && (*iter)->contains(settledEdge->getFromJunction())) {
+                settledEdgeCell = *iter;
+            }
+            if (!targetEdgeCell && myTargetEdgeCellLevel0) {
+                targetEdgeCell = myTargetEdgeCellLevel0;
+            } else if (!targetEdgeCell 
+                && (*iter)->contains(targetEdge->getFromJunction())) {
+                myTargetEdgeCellLevel0 = *iter;
+                targetEdgeCell = myTargetEdgeCellLevel0;
+            }
+            if (settledEdgeCell && targetEdgeCell) {
+                assert(myTargetEdgeCellLevel0);
+                break;
+            }
+        }
+    } else { // larger number of bottom cells -> use a k-d tree
+        settledEdgeCell = myPartition->searchNode(settledEdge->getFromJunction());
+        if (!targetEdgeCell && myTargetEdgeCellLevel0) {
+            // search only once per query
+            targetEdgeCell = myTargetEdgeCellLevel0;
+        }
+        else if (!targetEdgeCell) {
+            myTargetEdgeCellLevel0 = myPartition->searchNode(targetEdge->getFromJunction());
+            targetEdgeCell = myTargetEdgeCellLevel0; // myTargetEdgeCellLevel0 is reset in init()
+        }
+    }
+    assert(settledEdgeCell && targetEdgeCell); // we should find both edges on each level
+    while (settledEdgeCell->getSupercell() != targetEdgeCell->getSupercell()) {
+        settledEdgeCell = settledEdgeCell->getSupercell();
+        targetEdgeCell = targetEdgeCell->getSupercell();
+        sHARCLevel++;
+    }
+    myLastSettledEdgeCell = settledEdgeCell;
+    std::tuple<int, int, bool> flagContext = std::make_tuple(sHARCLevel, targetEdgeCell->isLeftOrLowerCell() ? 0 : 1,
+        settledEdgeCell == targetEdgeCell);
+    myLastFlagContext = flagContext;
+    return flagContext;
+}
+
+template<class E, class N, class V>
+void AFRouter<E, N, V>::startQuery() {
+    myNumQueries++;
+    myQueryStartTime = SysUtils::getCurrentMillis();
+    SUMOAbstractRouter<E, V>::startQuery();
+}
+
+template<class E, class N, class V>
+void AFRouter<E, N, V>::endQuery(int visits) {
+    myQueryVisits += visits;
+    myQueryTimeSum += (SysUtils::getCurrentMillis() - myQueryStartTime);
+    SUMOAbstractRouter<E, V>::endQuery(visits);
+}
+
+template<class E, class N, class V>
+void AFRouter<E, N, V>::reportStatistics() {
+    if (myNumQueries > 0) {
+        WRITE_MESSAGE(myType + " answered " + toString(myNumQueries) + " queries and explored " + toString((double)myQueryVisits / (double)myNumQueries) + " edges on average.");
+        WRITE_MESSAGE(myType + " spent " + elapsedMs2string(myQueryTimeSum) + " answering queries (" + toString((double)myQueryTimeSum / (double)myNumQueries) + " ms on average).");
+#ifdef AFRO_DEBUG_LEVEL_2
+        WRITE_MESSAGE("flagContext spent " + elapsedMs2string(myFlagContextTimeSum) + " (" + toString((double)myFlagContextTimeSum / (double)myNumQueries) + " ms on average).");
+#endif
+    }
+}
+
+template<class E, class N, class V>
+void AFRouter<E, N, V>::resetStatistics() {
+    myNumQueries = 0;
+    myQueryVisits = 0;
+    myQueryTimeSum = 0;
+    myQueryStartTime = 0;
+}

--- a/src/utils/router/FlippedEdge.h
+++ b/src/utils/router/FlippedEdge.h
@@ -1,0 +1,208 @@
+/****************************************************************************/
+// Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.org/sumo
+// Copyright (C) 2001-2023 German Aerospace Center (DLR) and others.
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0/
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License 2.0 are satisfied: GNU General Public License, version 2
+// or later which is available at
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+/****************************************************************************/
+/// @file    FlippedEdge.h
+/// @author  Ruediger Ebendt
+/// @date    01.12.2023
+///
+// Extension of ReversedEdge, which is a wrapper around a ROEdge  
+// or an MSEdge used for backward search. In contrast to reversed 
+// edges, flipped edges have flipped nodes instead of standard nodes. 
+// Introduced for the arc flag router.
+/****************************************************************************/
+#pragma once
+#include <config.h>
+#include <utils/common/SUMOVehicleClass.h>
+#ifdef HAVE_FOX
+#include <utils/foxtools/MsgHandlerSynchronized.h>
+#endif
+#include "ReversedEdge.h"
+
+
+// ===========================================================================
+// class declarations
+// ===========================================================================
+template<class E, class N, class V>
+class FlippedNode;
+
+// ===========================================================================
+// class definitions
+// ===========================================================================
+/// @brief The edge type representing backward edges with flipped nodes
+template<class E, class N, class V>
+class FlippedEdge : public ReversedEdge<E, V> {
+public:
+
+    typedef std::vector<std::pair<const FlippedEdge<E, N, V>*, const FlippedEdge<E, N, V>*> > ConstFlippedEdgePairVector;
+
+    /** @brief Constructor
+     * @param[in] originalEdge The original (forward) edge
+     */
+    FlippedEdge(const E* originalEdge) :
+        ReversedEdge<E, V>(originalEdge), 
+        myFromJunction(this->getOriginalEdge()->getToJunction()->getFlippedRoutingNode()),
+        myToJunction(this->getOriginalEdge()->getFromJunction()->getFlippedRoutingNode())
+    {}
+    
+    /// @brief Destructor
+    ~FlippedEdge() {}
+
+    /// @brief Initialize the flipped edge
+    void init();
+    /// @brief Returns the from-junction
+    const FlippedNode<E, N, V>* getFromJunction() const {
+        return myFromJunction;
+    }
+    /// @brief Returns the to-junction
+    const FlippedNode<E, N, V>* getToJunction() const {
+        return myToJunction;
+    }
+    /** @brief Returns the time for travelling on the given edge with the given vehicle at the given time 
+     * @param[in] edge The edge
+     * @param[in] veh The vehicle
+     * @param[in] time The time
+     * @return The time for travelling on the given edge with the given vehicle at the given time 
+     */
+    static double getTravelTimeStatic(const FlippedEdge<E, N, V>* const edge, const V* const veh, double time) {
+        return edge->getOriginalEdge()->getTravelTime(veh, time);
+    }
+    /** @brief Returns the randomized time for travelling on the given edge with the given vehicle at the given time
+     * @param[in] edge The edge
+     * @param[in] veh The vehicle
+     * @param[in] time The time
+     * @return The randomized time for travelling on the given edge with the given vehicle at the given time
+     */
+    static double getTravelTimeStaticRandomized(const FlippedEdge<E, N, V>* const edge, const V* const veh, double time) {
+        return edge->getOriginalEdge()->getTravelTimeStaticRandomized(edge->getOriginalEdge(), veh, time);
+    }
+
+    /** @brief Returns the via successors
+     * @param[in] vClass The vehicle class
+     * @param[in] ignoreTransientPermissions Unused parameter
+     * @return The via successors
+     */
+    const ConstFlippedEdgePairVector& getViaSuccessors(SUMOVehicleClass vClass = SVC_IGNORING, bool ignoreTransientPermissions = false) const {
+        UNUSED_PARAMETER(ignoreTransientPermissions); // @todo this should be changed (somewhat hidden by #14756)
+        if (vClass == SVC_IGNORING || this->getOriginalEdge()->isTazConnector()) { // || !MSNet::getInstance()->hasPermissions()) {
+            return myViaSuccessors;
+        }
+#ifdef HAVE_FOX
+        FXMutexLock lock(mySuccessorMutex);
+#endif
+        auto i = myClassesViaSuccessorMap.find(vClass);
+        if (i != myClassesViaSuccessorMap.end()) {
+            // can use cached value
+            return i->second;
+        }
+        // instantiate vector
+        ConstFlippedEdgePairVector& result = myClassesViaSuccessorMap[vClass];
+        // this vClass is requested for the first time. rebuild all successors
+        for (const auto& viaPair : myViaSuccessors) {
+            if (viaPair.first->getOriginalEdge()->isTazConnector() 
+                || viaPair.first->getOriginalEdge()->isConnectedTo(*(this->getOriginalEdge()), vClass)) {
+                result.push_back(viaPair);
+            }
+        }
+        return result;
+    }
+
+    /** @brief Returns the bidirectional edge
+     * @return The bidirectional edge
+     */
+    const FlippedEdge<E, N, V>* getBidiEdge() const {
+        return this->getOriginalEdge()->getBidiEdge()->getFlippedRoutingEdge();
+    }
+    /** @brief Returns the distance to another flipped edge
+     * param[in] other The other flipped edge
+     * param[in] doBoundaryEstimate The boolean flag indicating whether the distance is estimated using both boundaries or not
+     * @return The distance to another flipped edge
+     */
+    double getDistanceTo(const FlippedEdge<E, N, V>* other, const bool doBoundaryEstimate = false) const {
+        return this->getOriginalEdge()->getDistanceTo(other->getOriginalEdge(), doBoundaryEstimate);
+    }
+    /** @brief Returns the minimum travel time
+     * @param[in] veh The vehicle
+     * @return The minimum travel time
+     */
+    double getMinimumTravelTime(const V* const veh) const {
+        return this->getOriginalEdge()->getMinimumTravelTime(veh);
+    }
+    /** @brief Returns the time penalty
+     * @return The time penalty
+     */ 
+    double getTimePenalty() const {
+        return this->getOriginalEdge()->getTimePenalty();
+    }
+    /** @brief Returns a boolean flag indicating whether this edge has loaded travel times or not
+     * @return true iff this edge has loaded travel times
+     */
+    bool hasLoadedTravelTimes() const {
+        return this->getOriginalEdge()->hasLoadedTravelTimes();
+    }
+    /** @brief Returns the speed allowed on this edge
+     * @return The speed allowed on this edge
+     */
+    double getSpeedLimit() const {
+        return this->getOriginalEdge()->getSpeedLimit();
+    }
+    /** @brief Returns a lower bound on shape.length() / myLength
+     * @note The bound is sufficient for the astar air-distance heuristic
+     * @return A lower bound on shape.length() / myLength
+     */
+    double getLengthGeometryFactor() const {
+        return this->getOriginalEdge()->getLengthGeometryFactor();
+    }
+    /** @brief Returns the edge priority (road class)
+     * @return The edge priority (road class)
+     */ 
+    int getPriority() const {
+        return this->getOriginalEdge()->getPriority();
+    }
+
+protected:
+    /// @brief The junctions for this edge
+    FlippedNode<E, N, V>* myFromJunction;
+    FlippedNode<E, N, V>* myToJunction;
+
+private:
+    /// @brief The successors available for a given vClass
+    mutable std::map<SUMOVehicleClass, ConstFlippedEdgePairVector> myClassesViaSuccessorMap;
+    mutable ConstFlippedEdgePairVector myViaSuccessors;
+
+#ifdef HAVE_FOX
+    /// @brief Mutex for accessing successor edges
+    mutable FXMutex mySuccessorMutex;
+#endif
+};
+
+// ===========================================================================
+// method definitions
+// ===========================================================================
+
+template<class E, class N, class V>
+void FlippedEdge<E, N, V>::init() {
+    if (!this->getOriginalEdge()->isInternal()) {
+        for (const auto& viaPair : this->getOriginalEdge()->getViaSuccessors()) {
+            const FlippedEdge<E, N, V>* revSource = viaPair.first->getFlippedRoutingEdge();
+            const E* via = viaPair.second;
+            const FlippedEdge<E, N, V>* preVia = nullptr;
+            while (via != nullptr && via->isInternal()) {
+                via->getFlippedRoutingEdge()->myViaSuccessors.push_back(std::make_pair(this, preVia));
+                preVia = via->getFlippedRoutingEdge();
+                via = via->getViaSuccessors().front().second;
+            }
+            revSource->myViaSuccessors.push_back(std::make_pair(this, preVia));
+        }
+    }
+}
+

--- a/src/utils/router/FlippedNode.h
+++ b/src/utils/router/FlippedNode.h
@@ -1,0 +1,95 @@
+/****************************************************************************/
+// Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.org/sumo
+// Copyright (C) 2001-2024 German Aerospace Center (DLR) and others.
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0/
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License 2.0 are satisfied: GNU General Public License, version 2
+// or later which is available at
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+/****************************************************************************/
+/// @file    FlippedNode.h
+/// @author  Ruediger Ebendt
+/// @date    01.12.2023
+///
+// Wrapper around an RONode used for backward search. It swaps incoming 
+// with outgoing edges, and replaces the original edges by reversed 
+// ones (i.e., by instances of FlippedEdge)
+/****************************************************************************/
+#pragma once
+#include <config.h>
+#include <vector>
+#include "FlippedEdge.h"
+
+// ===========================================================================
+// class definitions
+// ===========================================================================
+/// @brief the node type representing nodes used for backward search
+template<class E, class N, class V>
+class FlippedNode {
+public:
+    typedef std::vector<const FlippedEdge<E, N, V>*> ConstFlippedEdgeVector;
+
+    /** Constructor
+     * @param[in] originalNode The original node
+     */
+    FlippedNode(const N* originalNode) : 
+        myOriginalNode(originalNode) {}
+
+    /// @brief Destructor
+    ~FlippedNode() {}
+
+    /** @brief Returns the position of the node
+     * @return This node's position
+     */
+    const Position& getPosition() const {
+        return myOriginalNode->getPosition();
+    }
+    /** @brief Returns the id(entifier) of the node
+     * @return This node's id(entifier)
+     */
+    const std::string& getID() const {
+        return myOriginalNode->getID();
+    }
+    
+    /** @brief Returns the incoming edges of the node
+     * @return The incoming edges of the node
+     */
+    const ConstFlippedEdgeVector& getIncoming() const {
+        if (myIncoming.empty()) {
+            const std::vector<const E*>& incoming = myOriginalNode->getOutgoing();
+            for (const E* edge : incoming) {
+                myIncoming.push_back(edge->getFlippedRoutingEdge());
+            }
+        }
+        return myIncoming;
+    }
+
+    /** @brief Returns the outgoing edges of the node
+      * @return The outgoing edges of the node
+      */
+    const ConstFlippedEdgeVector& getOutgoing() const {
+        if (myOutgoing.empty()) {
+            const std::vector<const E*>& outgoing = myOriginalNode->getIncoming();
+            for (const E* edge : outgoing) {
+                myOutgoing.push_back(edge->getFlippedRoutingEdge());
+            }
+        }
+        return myOutgoing;
+    }
+
+    /// @brief Returns the original node
+    const N* getOriginalNode() const {
+        return myOriginalNode;
+    }
+private:
+    /// @brief The original node
+    const N* const myOriginalNode;
+    /// @brief The incoming edges
+    mutable ConstFlippedEdgeVector myIncoming;
+    /// @brief The outgoing edges
+    mutable ConstFlippedEdgeVector myOutgoing;
+};

--- a/src/utils/router/KDTreePartition.h
+++ b/src/utils/router/KDTreePartition.h
@@ -1,0 +1,1515 @@
+/****************************************************************************/
+// Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.org/sumo
+// Copyright (C) 2001-2023 German Aerospace Center (DLR) and others.
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0/
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License 2.0 are satisfied: GNU General Public License, version 2
+// or later which is available at
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+/****************************************************************************/
+/// @file    KDTreePartition.h
+/// @author  Ruediger Ebendt
+/// @date    01.11.2023
+///
+// Class for partitioning the router's network's nodes wrt a k-d tree subdivision scheme. 
+// All nodes are inserted at once at creation. Offers an O(log n) method to search a 
+// node within the bottom / leaf cells (i.e., the cell containing the respective node 
+// is returned). Here, n denotes the number of cells.
+/****************************************************************************/
+#pragma once
+#include <config.h>
+#include <vector>
+#include <unordered_set>
+#include <math.h>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <cinttypes>
+#include <utility>
+
+#define KDTP_EXCLUDE_INTERNAL_EDGES
+// Use KDTP_KEEP_OUTGOING_BOUNDARY_EDGES and KDTP_KEEP_BOUNDARY_FROM_NODES on a reversed graph to build arc infos 
+// for the arc flag shortest path routing algorithm
+#define KDTP_KEEP_OUTGOING_BOUNDARY_EDGES
+// Use KDTP_KEEP_INCOMING_BOUNDARY_EDGES on a forward graph to apply arc flag shortest path routing algorithm
+#define KDTP_KEEP_INCOMING_BOUNDARY_EDGES
+//#define KDTP_KEEP_BOUNDARY_EDGES
+//#define KDTP_KEEP_BOUNDARY_NODES
+// Use KDTP_KEEP_BOUNDARY_FROM_NODES on a reversed graph to build arc infos 
+// for the arc flag shortest path routing algorithm
+#define KDTP_KEEP_BOUNDARY_FROM_NODES
+//#define KDTP_KEEP_BOUNDARY_TO_NODES
+//#define KDTP_FOR_SYNTHETIC_NETWORKS
+// Use KDTP_WRITE_QGIS_FILTERS to filter boundary nodes of cells in QGIS operating on a (e.g. PostGreSQL) database of 
+// the (e.g. OSM) network
+//#define KDTP_WRITE_QGIS_FILTERS
+#ifdef KDTP_WRITE_QGIS_FILTERS
+#include <fstream>
+#include <sstream>
+#endif
+
+//#define KDTP_DEBUG_LEVEL_0
+//#define KDTP_DEBUG_LEVEL_1
+//#define KDTP_DEBUG_LEVEL_2
+
+#ifdef KDTP_DEBUG_LEVEL_2
+#define KDTP_DEBUG_LEVEL_1
+#endif
+
+#ifdef KDTP_DEBUG_LEVEL_1
+#define KDTP_DEBUG_LEVEL_0
+#endif
+
+// uncomment to disable assert()
+// #define NDEBUG
+#include <cassert>
+
+// ===========================================================================
+// class definitions
+// ===========================================================================
+
+/**
+ * @class KDTreePartition
+ * @brief Partitions the router's network wrt a k-d tree subdivision scheme
+ *
+ * The template parameters are:
+ * @param E The edge class to use (MSEdge/ROEdge)
+ * @param N The node class to use (MSJunction/RONode)
+ * @param V The vehicle class to use (MSVehicle/ROVehicle)
+ */
+template<class E, class N, class V>
+class KDTreePartition {
+public:
+    /// @brief Enum type for cell axis
+    enum class Axis {
+        X, Y
+    };
+
+    /**
+     * @class NodeXComparator
+     * Class to compare (and so sort) nodes by x-coordinate value
+     */
+    class NodeXComparator {
+    public:
+       /** @brief Comparing method for X-axis
+        * @param[in] firstNode The first node
+        * @param[in] secondNode The second node
+        * @return true iff first node's x-coordinate is smaller than that of the second
+        * @note In case of ties: true iff integer interpretation of first node's id is smaller than that of the second
+        */
+        bool operator()(const N* firstNode, const N* secondNode) const {
+            if (firstNode->getPosition().x() == secondNode->getPosition().x()) { // tie
+                std::string str = firstNode->getID();
+                std::intmax_t firstValue = std::strtoimax(str.c_str(), nullptr, 10);
+                str = secondNode->getID();
+                std::intmax_t secondValue = std::strtoimax(str.c_str(), nullptr, 10);
+                return firstValue < secondValue;
+            }
+            return firstNode->getPosition().x() < secondNode->getPosition().x();
+        }
+    };
+
+    /**
+     * @class NodeYComparator
+     * Class to compare (and so sort) nodes by y-coordinate value
+     */
+    class NodeYComparator {
+    public:
+        /** @brief Comparing method for Y-axis
+         * @param[in] firstNode The first node
+         * @param[in] secondNode The second node
+         * @return true iff first node's y-coordinate is smaller than that of the second
+         * @note In case of ties: true iff integer interpretation of first node's id is smaller than that of the second
+         */
+        bool operator()(const N* firstNode, const N* secondNode) const {
+            if (firstNode->getPosition().y() == secondNode->getPosition().y()) { // tie
+                std::string str = firstNode->getID();
+                std::intmax_t firstValue = std::strtoimax(str.c_str(), nullptr, 10);
+                str = secondNode->getID();
+                std::intmax_t secondValue = std::strtoimax(str.c_str(), nullptr, 10);
+                return firstValue < secondValue;
+            }
+            return firstNode->getPosition().y() < secondNode->getPosition().y();
+        }
+    };
+
+    /**
+     * @class Cell 
+     * @brief Represents an element of the node partition (i.e. a node set)
+     */
+    class Cell {
+    public:
+#ifdef KDTP_FOR_SYNTHETIC_NETWORKS        
+        /** @brief Constructor
+         * @note Works recursively, builds the median-based k-d tree
+         * @param[in] cells The vector of all cells
+         * @param[in] sortedNodes The vector of nodes
+         * @note Initially unsorted, gets sorted wrt to the divisional scheme of the k-dtree after instantiation of the k-d tree
+         * @param[in] numberOfLevels The number of levels
+         * @param[in] level The level
+         * @param[in] levelCells The vector of all level cell vectors
+         * @param[in] axis The axis (X or X)
+         * @param[in] fromInclusive The from-index (inclusive)
+         * @param[in] toExclusive The to-index (exclusive)
+         * @param[in] supercell The supercell
+         * @param[in] minX The minimum X-value of nodes in the cell
+         * @param[in] maxX The maximum X-value of nodes in the cell
+         * @param[in] minY The minimum Y-value of nodes in the cell
+         * @param[in] maxY The maximum Y-value of nodes in the cell
+         * @param[in] northernConflictNodes The northern spatial conflict nodes
+         * @param[in] easternConflictNodes The eastern spatial conflict nodes
+         * @param[in] southernConflictNodes The southern spatial conflict nodes
+         * @param[in] westernConflictNodes The western spatial conflict nodes
+         * @param[in] isLeftOrLowerCell Boolean flag indicating whether this cell is a left or lower cell or not
+         * @param[in] vehicle The vehicle. 
+         * @param[in] havePermissions The boolean flag indicating whether edge permissions need to be considered.
+         * @param[in] haveRestrictions The boolean flag indicating whether edge restrictions need to be considered.
+         */
+        Cell(std::vector<const Cell*>* cells, std::vector<std::vector<const Cell*>>* levelCells, std::vector<const N*>* sortedNodes, int numberOfLevels, 
+            int level, Axis axis, size_t fromInclusive, size_t toExclusive, Cell* supercell, double minX, double maxX, double minY, double maxY, 
+            std::unordered_set<const N*>* northernConflictNodes, std::unordered_set<const N*>* easternConflictNodes, 
+            std::unordered_set<const N*>* southernConflictNodes, std::unordered_set<const N*>* westernConflictNodes, 
+            bool isLeftOrLowerCell, const V* const vehicle, const bool havePermissions, const bool haveRestrictions);
+#else
+         /** @brief Constructor
+          * @note Works recursively, builds the median-based k-d tree
+          * @param[in] cells The vector of all cells
+          * @param[in] levelCells The vector of all level cell vectors
+          * @param[in] sortedNodes The vector of nodes
+          * @note Initially unsorted, after instantiation gets sorted wrt to the k-d tree subdivision scheme
+          * @param[in] numberOfLevels The number of levels
+          * @param[in] level The level
+          * @param[in] axis The axis (X or X)
+          * @param[in] fromInclusive The from-index (inclusive)
+          * @param[in] toExclusive The to-index (exclusive)
+          * @param[in] supercell The supercell
+          * @param[in] minX The minimum X-value of nodes in the cell
+          * @param[in] maxX The maximum X-value of nodes in the cell
+          * @param[in] minY The minimum Y-value of nodes in the cell
+          * @param[in] maxY The maximum Y-value of nodes in the cell
+          * @param[in] isLeftOrLowerCell Boolean flag indicating whether this cell is a left or lower cell or not
+          * @param[in] vehicle The vehicle 
+          * @param[in] havePermissions The boolean flag indicating whether edge permissions need to be considered or not
+          * @param[in] haveRestrictions The boolean flag indicating whether edge restrictions need to be considered or not
+          */
+        Cell(std::vector<const Cell*>* cells, std::vector<std::vector<const Cell*>>* levelCells, std::vector<const N*>* sortedNodes, 
+            int numberOfLevels, int level, Axis axis, size_t fromInclusive, size_t toExclusive, Cell* supercell, double minX, double maxX, 
+            double minY, double maxY, bool isLeftOrLowerCell, const V* const vehicle, const bool havePermissions, const bool haveRestrictions);
+#endif
+
+        /// @brief Destructor
+        virtual ~Cell() {
+            delete myLeftOrLowerSubcell;
+            delete myRightOrUpperSubcell;
+        }
+
+        /// @brief Returns the axis of the cell's spatial extension (x or y)
+        Axis getAxis() const {
+            return myAxis;
+        };
+        /** 
+         * @brief Returns all edges situated inside the cell
+         * @param[in] vehicle The vehicle
+         */ 
+        std::unordered_set<const E*>* edgeSet(const V* const vehicle) const;
+        /**
+         * @brief Returns the number of edges ending in the cell
+         * @param[in] vehicle The vehicle.
+         */
+        size_t numberOfEdgesEndingInCell(const V* const vehicle) const;
+        /**
+         * @brief Returns the number of edges starting in the cell
+         * @param[in] vehicle The vehicle.
+         */
+        size_t numberOfEdgesStartingInCell(const V* const vehicle) const;
+        /// @brief Returns the cell's number
+        int getNumber() const {
+            return myNumber;
+        }
+        /// @brief Returns the cell's level
+        // @note Level 0: root 
+        int getLevel() const {
+            return myLevel;
+        }
+        /** @brief Returns the number of cells
+         * @return The number of the cells
+         */
+        int getNumberOfCells() const {
+            return cellCounter();
+        }
+        /** @brief Returns a pair of iterators (first, last) to iterate over the nodes of the cell
+         * @return A pair of iterators (first, last) to iterate over the nodes of the cell
+         */  
+        std::pair<typename std::vector<const N*>::const_iterator, 
+            typename std::vector<const N*>::const_iterator> nodeIterators() const;
+        /** @brief Returns a new vector of nodes in the cell
+         * @return A new vector of nodes in the cell
+         */ 
+        std::vector<const N*>* nodes() const;
+#ifdef KDTP_KEEP_BOUNDARY_NODES
+        /// @brief Returns the vector of boundary nodes
+        const std::vector<const N*>& getBoundaryNodes() const {
+            return myBoundaryNodes;
+        }
+#endif
+#ifdef KDTP_KEEP_BOUNDARY_FROM_NODES
+        /// @brief Returns the vector of boundary nodes which are from-nodes of outgoing boundary edges
+        const std::vector<const N*>& getBoundaryFromNodes() const {
+            return myBoundaryFromNodes;
+        }
+#endif
+#ifdef KDTP_KEEP_BOUNDARY_TO_NODES
+        /// @brief Returns the vector of boundary nodes which are to-nodes of incoming boundary edges
+        const std::vector<const N*>& getBoundaryToNodes() const {
+            return myBoundaryToNodes;
+        }
+#endif
+#ifdef KDTP_KEEP_BOUNDARY_EDGES
+        /// @brief Returns the set of boundary edges
+        const std::unordered_set<const E*>& getBoundaryEdges() const {
+            return myBoundaryEdges;
+        }
+#endif
+#ifdef KDTP_KEEP_INCOMING_BOUNDARY_EDGES
+        /// @brief Returns the set of incoming boundary edges
+        const std::unordered_set<const E*>& getIncomingBoundaryEdges() const {
+            return myIncomingBoundaryEdges;
+        }
+#endif
+#ifdef KDTP_KEEP_OUTGOING_BOUNDARY_EDGES
+        /// @brief Returns the set of outgoing boundary edges
+        const std::unordered_set<const E*>& getOutgoingBoundaryEdges() const {
+            return myOutgoingBoundaryEdges;
+        }
+#endif
+        /// @brief Returns the left (cell's axis is X) or lower (cell's axis is Y) subcell
+        const Cell* getLeftOrLowerSubcell() const {
+            return myLeftOrLowerSubcell;
+        }
+        /// @brief Returns the right (cell's axis is X) or upper (cell's axis is Y) subcell
+        const Cell* getRightOrUpperSubcell() const {
+            return myRightOrUpperSubcell;
+        }
+        /// @brief Returns the supercell
+        const Cell* getSupercell() const {
+            return mySupercell;
+        }
+        /// @brief Returns the minimum coordinate of a cell node in X-direction (aka left border coordinate)
+        double getMinX() const {
+            return myMinX;
+        }
+        /// @brief Returns the maximum coordinate of a cell node in X-direction (aka right border coordinate)
+        double getMaxX() const {
+            return myMaxX;
+        }
+        /// @brief Returns the minimum coordinate of a cell node in Y-direction (aka lower border coordinate)
+        double getMinY() const {
+            return myMinY;
+        }
+        /// @brief Returns the maximum coordinate of a cell node in Y-direction (aka upper border coordinate)
+        double getMaxY() const {
+            return myMaxY;
+        }
+        /** @brief Tests whether the given node belongs to the cell
+         * @param node The node
+         * @return true iff the given node belongs to the cell
+         */
+        bool contains(const N* node) const;
+        /// @brief Returns the boolean flag indicating whether this cell is a left or lower cell or not
+        bool isLeftOrLowerCell() const {
+            return myIsLeftOrLowerCell;
+        }
+        /// @brief Returns the median coordinate
+        double getMedianCoordinate() const {
+            return myMedianCoordinate;
+        }
+
+    private:
+        /** @brief Performs one partition step on the set of nodes sorted wrt to the k-d tree subdivision scheme
+         * @returns The median index
+         */
+        size_t partition();
+        /** @brief Returns the global cell counter
+         * @return The global cell counter
+         */
+
+        static int& cellCounter() {
+            static int cellCounter{ 0 };
+            return cellCounter;
+        }
+
+        /** @brief Returns true iff driving the given vehicle on the given edge is prohibited
+         * @param[in] edge The edge
+         * @param[in] vehicle The vehicle
+         * @return true iff driving the given vehicle on the given edge is prohibited
+         */
+        bool isProhibited(const E* const edge, const V* const vehicle) const {
+            return (myHavePermissions && edge->prohibits(vehicle)) || (myHaveRestrictions && edge->restricts(vehicle));
+        }
+#ifdef KDTP_FOR_SYNTHETIC_NETWORKS
+        /** @brief Returns a pair with sets of spatial conflict nodes for a) the left / lower subcell and b) the right / upper subcell
+         * @param medianIndex The index into mySortedNodes dividing the cell nodes into two halves of equal size
+         * @return A pair with sets of spatial conflict nodes for a) the left / lower subcell and b) the right / upper subcell
+         */
+        std::pair<std::unordered_set<const N*>*, std::unordered_set<const N*>*> spatialConflictNodes(size_t medianIndex) const;
+#endif
+        /** @brief Tests whether a given node is situated within the spatial bounds of the cell
+         * @param node The node
+         * @return true iff a given node is situated within the spatial bounds of the cell
+         */
+        bool isInBounds(const N* node) const;
+        /// @brief Completes the information about the spatial extent
+        void completeSpatialInfo();
+        /** @brief Returns the minimum coordinate of the cell nodes' positions, in the direction of the given axis (X or Y)
+         * @param axis The axis
+         * @return The minimum coordinate of the cell nodes' positions, in the direction of the given axis (X or Y)
+         */ 
+        double minAxisValue(Axis axis) const;
+        /** @brief Returns the minimum coordinate of the cell nodes' positions, in the direction of the cell's axis (X or Y)
+         * @return The minimum coordinate of the cell nodes' positions, in the direction of the cell's axis(X or Y)
+         */
+        double minAxisValue() const;
+       /** @brief Returns the maximum coordinate of the cell nodes' positions, in the direction of the given axis (X or Y)
+        * @param axis The axis
+        * @return The maximum coordinate of the cell nodes' positions, in the direction of the given axis (X or Y)
+        */
+        double maxAxisValue(Axis axis) const;
+        /** @brief Returns the maximum coordinate of the cell nodes' positions, in the direction of the cell's axis (X or Y)
+         * @return The minimum coordinate of the cell nodes' positions, in the direction of the cell's axis(X or Y)
+         */
+        double maxAxisValue() const;
+        /// @brief The cells
+        std::vector<const Cell*>* myCells;
+        /// @brief The cells of all partitions at all levels of the k-d tree subdivisional scheme
+        std::vector<std::vector<const Cell*>>* myLevelCells;
+        /// @brief The container with all nodes, sorted wrt to the k-d tree subdivisional scheme
+        std::vector<const N*>* mySortedNodes;
+        /// @brief The total number of levels of the k-d tree
+        const int myNumberOfLevels;
+        /// @brief The level
+        const int myLevel;
+        /// @brief The number
+        const int myNumber;
+        /// @brief The axis of the spatial extension
+        const Axis myAxis;
+        /// @brief The from-index (inclusive)
+        const size_t myFromInclusive;
+        /// @brief The to-index (exclusive)
+        const size_t myToExclusive;
+#if defined(KDTP_KEEP_BOUNDARY_NODES) || defined(KDTP_WRITE_QGIS_FILTERS)
+        /// @brief The nodes on the cell boundary
+        std::vector<const N*> myBoundaryNodes;
+#endif
+#ifdef KDTP_KEEP_BOUNDARY_FROM_NODES
+        /// @brief Those nodes on the cell boundary, which are from-nodes of outgoing boundary edges
+        std::vector<const N*> myBoundaryFromNodes;
+#endif
+#ifdef KDTP_KEEP_BOUNDARY_TO_NODES
+        /// @brief Those nodes on the cell boundary, which are to-nodes of incoming boundary edges
+        std::vector<const N*> myBoundaryToNodes;
+#endif
+#ifdef KDTP_KEEP_INCOMING_BOUNDARY_EDGES
+        /// @brief The incoming edges on the cell boundary
+        std::unordered_set<const E*> myIncomingBoundaryEdges;
+
+#endif
+#ifdef KDTP_KEEP_OUTGOING_BOUNDARY_EDGES
+        /// @brief The outgoing edges on the cell boundary
+        // @note Used for arc flag setter's shortest path tree algorithm, working on a reversed graph
+        std::unordered_set<const E*> myOutgoingBoundaryEdges;
+#endif
+#ifdef KDTP_KEEP_BOUNDARY_EDGES
+        /// @brief The edges on the cell boundary
+        std::unordered_set<const E*> myBoundaryEdges;
+#endif
+        /// @brief The super cell
+        Cell* mySupercell;
+        /// @brief The left (cell's axis is X) or lower (cell's axis is Y) subcell
+        Cell* myLeftOrLowerSubcell;
+        /// @brief The right (cell's axis is X) or upper (cell's axis is Y) subcell
+        Cell* myRightOrUpperSubcell;
+        /// @brief The minimum x-value of a node in the cell
+        double myMinX;
+        /// @brief The maximum x-value of a node in the cell
+        double myMaxX;
+        /// @brief The minimum y-value of a node in the cell
+        double myMinY;
+        /// @brief The maximum y-value of a node in the cell
+        double myMaxY;
+        /// @brief The boolean flag indicating whether the information about the cell's spatial extent is complete or not
+        bool myHasCompleteSpatialInfo;
+        /// @brief The boolean flag indicating whether the cell's nodes are sorted wrt to the cell's axis or not
+        bool myHasNodesSortedWrtToMyAxis;
+        /// @brief The boolean flag indicating whether this cell is a left/lower cell or not
+        bool myIsLeftOrLowerCell;
+#ifdef KDTP_FOR_SYNTHETIC_NETWORKS
+        /// @brief The northern spatial conflict nodes
+        std::unordered_set<const N*>* myNorthernConflictNodes;
+        /// @brief The eastern spatial conflict nodes
+        std::unordered_set<const N*>* myEasternConflictNodes;
+        /// @brief The southern spatial conflict nodes
+        std::unordered_set<const N*>* mySouthernConflictNodes;
+        /// @brief The western spatial conflict nodes
+        std::unordered_set<const N*>* myWesternConflictNodes;
+#endif
+        /// @brief The boolean flag indicating whether edge permissions need to be considered or not
+        const bool myHavePermissions;
+        /// @brief The boolean flag indicating whether edge restrictions need to be considered or not
+        const bool myHaveRestrictions;
+        /// @brief The coordinate in the axis' direction of the node at the median index
+        double myMedianCoordinate;
+    }; // end of class Cell declaration
+
+    /** @brief Constructor
+     * @param[in] numberOfLevels The number of levels
+     * @param[in] edges The container with all edges of the network
+     * @param[in] havePermissions The boolean flag indicating whether edge permissions need to be considered or not
+     * @param[in] haveRestrictions The boolean flag indicating whether edge restrictions need to be considered or not
+     */
+    KDTreePartition(int numberOfLevels, const std::vector<E*>& edges, 
+        const bool havePermissions, const bool haveRestrictions);
+
+    /// @brief Destructor
+    ~KDTreePartition() {
+        std::vector<const N*>().swap(mySortedNodes);
+        std::vector<const Cell*>().swap(myCells);
+        std::vector<std::vector<const Cell*>>().swap(myLevelCells);
+        delete myRoot;
+    };
+
+    /** @brief Initialize the k-d tree wrt to the given vehicle's permissions
+     * @param[in] vehicle The vehicle
+     */
+    void init(const V* const vehicle);
+    /** @brief Delete the k-d tree, and create a new one
+     * param[in] vehicle The vehicle
+     * @note Recreated wrt the network given at construction and the given edge
+     */ 
+    void reset(const V* const vehicle) {
+        delete myRoot;
+        init(vehicle);
+    }
+    /// @brief Returns the root of the k-d tree
+    const Cell* getRoot() const {
+        return myRoot;
+    }
+    /// @brief Returns all cells
+    const std::vector<const Cell*>& getCells() {
+        return myCells;
+    }
+    /** @brief Returns the cell with the given number
+     * @note Returns nullptr, if no such cell exists
+     * @param[in] number The cell number
+     * @return The cell with the given number
+     */ 
+    const Cell* cell(int number) const;
+    /// @brief Returns all cells of a level
+    const std::vector<const Cell*>& getCellsAtLevel(int level) const {
+        return myLevelCells[level];
+    }
+    /** @brief Returns the numbers of the cells which the given node is situated in
+     * @param[in] node The node
+     * @return The numbers of the cells which the given node is situated in
+     */
+    std::vector<int>* cellNumbers(const N* node) const;
+    /** @brief Returns the conjugated 2D axis
+     * @note X->Y / Y->X
+     * @param[in] axis The axis
+     * @return The conjugated 2D axis
+     */
+    static Axis flip(Axis axis) {
+        return axis == Axis::X ? Axis::Y : Axis::X;
+    }
+    /** @brief Returns the number of arc flags required in a multi-level approach
+     * @note E.g.: number of levels := 3 -> 2 + 2 = 4 bits are required
+     * @note No flag(s) for root level 0; each non-leaf cell has two subcells
+     * @return The number of arc flags required in a multi-level approach
+     */ 
+    int numberOfArcFlags() const {
+        return 2 * (myNumberOfLevels-1);
+    }
+    /// @brief Returns the number of levels L incl. the zeroth level
+    // @note Levels go from 0 to L-1
+    int getNumberOfLevels() const {
+        return myNumberOfLevels;
+    }
+    /** @brief Returns the number of cells at all levels
+     * @return The number of cells at all levels
+     */
+    size_t numberOfCells() const {
+        return static_cast<size_t>(std::lround(std::pow(2, myNumberOfLevels)) - 1);
+    }
+    /** @brief Returns the number of regions, i.e. the number of cells at the shallowest (bottom/leaf) level
+     * @return The number of regions, i.e. the number of cells at the shallowest (bottom/leaf) level
+     */
+    size_t numberOfRegions() const {
+        return static_cast<size_t>(std::lround(std::pow(2, myNumberOfLevels - 1)));
+    }
+    /// @brief Returns true iff the k-d tree is uninitialized
+    bool isClean() {
+        return myAmClean;
+    }
+    /** @brief Search a node in the bottom cells (i.e., return the respective cell)
+     * @note Uses the position of the node and the divisional structure of the k-d tree for the search. 
+     * @note O(log n) where n = number of cells
+     * @param[in] node The node
+     * @return The bottom cell containing the node, or nullptr if the node could not be found
+     */
+    const Cell* searchNode(const N* node) const;
+    
+private:
+    /** @brief Helper method for {@link #cellNumbers()}.
+     * @param node The node
+     * @param cell The cell
+     * @param level The level
+     * @param nodeCellNumbers The vector of cell numbers for the passed node
+     */
+    void cellNumbersAux(const N* node, const Cell* cell, int level, std::vector<int>* nodeCellNumbers) const;
+    /// @brief The root of the k-d tree
+    const Cell* myRoot;
+    /// @brief The number of levels
+    const int myNumberOfLevels;
+    /// @brief The reference to a constant container with pointers to edges
+    const std::vector<E*>& myEdges;
+    /// @brief The container with all nodes, sorted wrt to the k-d tree subdivision scheme
+    std::vector<const N*> mySortedNodes;
+    /// @brief The cells 
+    std::vector<const Cell*> myCells;
+    /// @brief The cells of all partitions at all levels of the k-d tree subdivision scheme
+    std::vector<std::vector<const Cell*>> myLevelCells;
+    /// @brief The boolean flag indicating whether edge permissions need to be considered or not
+    const bool myHavePermissions;
+    /// @brief The boolean flag indicating whether edge restrictions need to be considered or not
+    const bool myHaveRestrictions;
+    /// @brief The boolean flag indicating whether the k-d tree is a clean (empty, uninitialized) instance or not
+    bool myAmClean;
+}; // end of class KDTreePartition declaration
+
+// ===========================================================================
+// method definitions
+// ===========================================================================
+
+template<class E, class N, class V>
+KDTreePartition<E, N, V>::KDTreePartition(int numberOfLevels, const std::vector<E*>& edges, 
+    const bool havePermissions, const bool haveRestrictions) :
+    myNumberOfLevels(numberOfLevels),
+    myEdges(edges),
+    myHavePermissions(havePermissions),
+    myHaveRestrictions(haveRestrictions),
+    myAmClean(true) /* still uninitialized */ {
+    if (numberOfLevels <= 0) {
+        throw std::invalid_argument("KDTreePartition::KDTreePartition: zero or negative number of levels has been passed!");
+    }
+}
+
+template<class E, class N, class V>
+void KDTreePartition<E, N, V>::init(const V* const vehicle) {
+    size_t edgeCounter = 0;
+    std::unordered_set<const N*> nodeSet;
+    // extract nodes from edges
+    mySortedNodes.resize(myEdges.size() * 2);
+#ifdef KDTP_DEBUG_LEVEL_1
+    std::cout << "Extracting nodes from edges..." << std::endl;
+#endif
+    for (E* edge : myEdges) {
+        if ((myHavePermissions && edge->prohibits(vehicle))
+            || (myHaveRestrictions && edge->restricts(vehicle))) {
+            continue;
+        }
+        const N* node = edge->getFromJunction();
+        typename std::unordered_set<const N*>::const_iterator it = nodeSet.find(node);
+        if (it == nodeSet.end()) {
+            nodeSet.insert(node);
+            assert(edgeCounter < mySortedNodes.size());
+            mySortedNodes[edgeCounter++] = node;
+        }
+        node = edge->getToJunction();
+        it = nodeSet.find(node);
+        if (it == nodeSet.end()) {
+            nodeSet.insert(node);
+            assert(edgeCounter < mySortedNodes.size());
+            mySortedNodes[edgeCounter++] = node;
+        }
+    }
+    mySortedNodes.shrink_to_fit();
+#ifdef KDTP_DEBUG_LEVEL_1
+    std::cout << "Nodes extracted from edges." << std::endl;
+#endif
+    mySortedNodes.resize(edgeCounter);
+    myCells.resize(numberOfCells());
+    myLevelCells.resize(myNumberOfLevels);
+    // call the recursive cell constructor at the root (instantiates the whole k-d tree of cells)
+#ifdef KDTP_DEBUG_LEVEL_1
+    std::cout << "Calling root cell constructor..." << std::endl;
+#endif
+#ifdef KDTP_FOR_SYNTHETIC_NETWORKS
+    myRoot = new Cell(&myCells, &myLevelCells, &mySortedNodes, myNumberOfLevels, 0, Axis::Y, 0, mySortedNodes.size(), nullptr, -1, -1, -1, -1, 
+        nullptr, nullptr, nullptr, nullptr, false, vehicle, havePermissions, haveRestrictions);
+#else
+    myRoot = new Cell(&myCells, &myLevelCells, &mySortedNodes, myNumberOfLevels, 0, Axis::Y, 0, mySortedNodes.size(), nullptr, -1, -1, -1, -1, 
+        false, vehicle, myHavePermissions, myHaveRestrictions);
+#endif
+#ifdef KDTP_DEBUG_LEVEL_1
+    std::cout << "Done." << std::endl;
+#endif
+    assert(myCells[0] == myRoot);
+    assert(myRoot->getNumber() == 0);
+    // nodes are now sorted wrt to the k-d tree's subdivisional scheme
+#ifdef KDTP_DEBUG_LEVEL_0
+    const N* node = mySortedNodes[0];
+    std::vector<int>* numbers = cellNumbers(node);
+    int i;
+    for (i = 0; i < myNumberOfLevels; ++i) {
+        std::cout << "Cell numbers of test node: " << (*numbers)[i] << std::endl;
+    }
+    delete numbers;
+    for (i = 0; i < myNumberOfLevels; ++i) {
+        const std::vector<const Cell*>& levelCells = getCellsAtLevel(i);
+        size_t size = levelCells.size();
+        std::cout << "Level " << i << " has " << size << " cells." << std::endl;
+        std::cout << "The numbers of the cells are: " << std::endl;
+        size_t k = 0;
+        for (const Cell* cell : levelCells) {
+            std::cout << cell->getNumber() << (k++ < size ? ", " : "") << std::endl;
+        }
+    }
+#endif
+    myAmClean = false;
+}
+
+template<class E, class N, class V>
+const typename KDTreePartition<E, N, V>::Cell* KDTreePartition<E, N, V>::cell(int number) const {
+    // for now fast enough since the number of cells is usually small
+    for (const KDTreePartition<E, N, V>::Cell* cell : myCells) { 
+        if (cell->getNumber() == number) {
+            return cell;
+        }
+    }
+    return nullptr;
+}
+
+template<class E, class N, class V>
+std::vector<int>* KDTreePartition<E, N, V>::cellNumbers(const N* node) const {
+    std::vector<int>* nodeCellNumbers = new std::vector<int>(myNumberOfLevels);
+    int i;
+    for (i = 0; i < myNumberOfLevels; ++i) {
+        (*nodeCellNumbers)[i] = -1;
+    }
+    cellNumbersAux(node, myCells[0], 0, nodeCellNumbers);
+#ifdef KDTP_DEBUG_LEVEL_1
+    std::cout << "The following entries in nodeCellNumbers should all be set (!=-1): " << std::endl;
+    for (i = 0; i < myNumberOfLevels; ++i) {
+        assert((*nodeCellNumbers)[i] != -1);
+        std::cout << "nodeCellNumbers[" << i << "]:" << (*nodeCellNumbers)[i] << std::endl;
+    }
+#endif
+    return nodeCellNumbers;
+}
+
+template<class E, class N, class V>
+void KDTreePartition<E, N, V>::cellNumbersAux(const N* node, const Cell* cell, int level, std::vector<int>* nodeCellNumbers) const {
+#ifdef KDTP_DEBUG_LEVEL_1
+    std::cout << "Call ...aux, level: " << level << ", cell->getAxis(): " << (cell->getAxis() == Axis::X ? "X" : "Y") << std::endl;
+#endif
+    assert(level < myNumberOfLevels);
+#ifdef KDTP_DEBUG_LEVEL_1
+    Axis flippedCellAxis = flip(cell->getAxis());
+    double nodeAxisValue = flippedCellAxis == Axis::Y ? node->getPosition().y() : node->getPosition().x();
+    std::cout << "Flipped axis of cell (=parent cell axis): " << (flippedCellAxis == Axis::X ? "X" : "Y") 
+        << ", cell min axis value in flipped axis: " << (flippedCellAxis == Axis::X ? cell->getMinX() : cell->getMinY()) 
+        << ", node axis value in flipped axis: " << nodeAxisValue << ", cell max axis value in flipped axis: " 
+        << (flippedCellAxis == Axis::X ? cell->getMaxX() : cell->getMaxY()) << std::endl;
+#endif
+    if (cell->contains(node)) {
+        // node is inside the cell, hence cell is one of the cells of node
+        (*nodeCellNumbers)[level] = cell->getNumber();
+#ifdef KDTP_DEBUG_LEVEL_1
+        std::cout << "Just filled nodeCellNumbers[" << level << "]:" << (*nodeCellNumbers)[level] << std::endl;
+#endif
+        // only one of the below two calls may actually alter array nodeCellNumbers
+        const Cell* leftOrLowerSubcell = cell->getLeftOrLowerSubcell();
+        if (leftOrLowerSubcell) { // no more calls at shallowest (i.e. leaf) level
+            cellNumbersAux(node, leftOrLowerSubcell, level + 1, nodeCellNumbers);
+        }
+        const Cell* rightOrUpperSubcell = cell->getRightOrUpperSubcell();
+        if (rightOrUpperSubcell) {
+            cellNumbersAux(node, rightOrUpperSubcell, level + 1, nodeCellNumbers);
+        }
+    }
+#ifdef KDTP_DEBUG_LEVEL_1
+    else { // node is not inside the cell, no need to look for node in subcells (consequently, do nothing more, return)
+        std::cout << "Not inside cell, do nothing." << std::endl;
+    }
+#endif
+}
+
+template<class E, class N, class V>
+#ifdef KDTP_FOR_SYNTHETIC_NETWORKS
+KDTreePartition<E, N, V>::Cell::Cell(std::vector<const Cell*>* cells, std::vector<std::vector<const Cell*>>* levelCells, std::vector<const N*>* sortedNodes, int numberOfLevels, int level, 
+    Axis axis, size_t fromInclusive, size_t toExclusive, Cell* supercell, double minX, double maxX, double minY, double maxY, std::unordered_set<const N*>* northernConflictNodes, 
+    std::unordered_set<const N*>* easternConflictNodes, std::unordered_set<const N*>* southernConflictNodes, std::unordered_set<const N*>* westernConflictNodes, const V* const vehicle,
+    const bool havePermissions, const bool haveRestrictions) :
+    myCells(cells), 
+    myLevelCells(levelCells), 
+    mySortedNodes(sortedNodes), 
+    myNumberOfLevels(numberOfLevels), 
+    myLevel(level), myNumber(cellCounter()++), 
+    myAxis(axis), 
+    myFromInclusive(fromInclusive), 
+    myToExclusive(toExclusive), 
+    mySupercell(supercell), 
+    myMinX(minX), 
+    myMaxX(maxX), 
+    myMinY(minY), 
+    myMaxY(maxY), 
+    myNorthernConflictNodes(northernConflictNodes), 
+    myEasternConflictNodes(easternConflictNodes), 
+    mySouthernConflictNodes(southernConflictNodes), 
+    myWesternConflictNodes(westernConflictNodes), 
+    myIsLeftOrLowerCell(isLeftOrLowerCell), 
+    myHavePermissions(havePermissions), 
+    myHaveRestrictions(haveRestrictions),
+    myMedianCoordinate(-1.) {
+#else
+KDTreePartition<E, N, V>::Cell::Cell(std::vector<const Cell*>*cells, std::vector<std::vector<const Cell*>>* levelCells, std::vector<const N*>*sortedNodes, int numberOfLevels, int level, 
+    Axis axis, size_t fromInclusive, size_t toExclusive, Cell* supercell, double minX, double maxX, double minY, double maxY, bool isLeftOrLowerCell, const V* const vehicle,
+    const bool havePermissions, const bool haveRestrictions) :
+    myCells(cells), 
+    myLevelCells(levelCells), 
+    mySortedNodes(sortedNodes), 
+    myNumberOfLevels(numberOfLevels), 
+    myLevel(level), 
+    myNumber(cellCounter()++), 
+    myAxis(axis), 
+    myFromInclusive(fromInclusive), 
+    myToExclusive(toExclusive), 
+    mySupercell(supercell), 
+    myMinX(minX), 
+    myMaxX(maxX), 
+    myMinY(minY), 
+    myMaxY(maxY), 
+    myIsLeftOrLowerCell(isLeftOrLowerCell),
+    myHavePermissions(havePermissions),
+    myHaveRestrictions(haveRestrictions),
+    myMedianCoordinate(-1.) {
+#endif
+    // throw invalid argument exception if fromInclusive is greater than or equal to toExclusive
+    if (myFromInclusive >= myToExclusive) {
+        throw std::invalid_argument("Cell::Cell: myFromInclusive greater than or equal to myToExclusive!");
+    }
+    myHasCompleteSpatialInfo = false;
+    myHasNodesSortedWrtToMyAxis = false;
+    (*myCells)[myNumber] = this;
+    (*myLevelCells)[myLevel].push_back(this);
+#ifdef KDTP_DEBUG_LEVEL_1
+    std::cout << "Cell number: " << myNumber << ", cell's extent: minX=" << myMinX << ", maxX=" 
+        << myMaxX << ", minY=" << myMinY << ", maxY=" << myMaxY << std::endl;
+    std::vector<const N*>* cellNodes = nodes();
+    int cnt = 0;
+    for (const N* node : *cellNodes) {
+        if (++cnt % 10000 == 0) {
+            std::cout << "Testing node " << cnt << std::endl;
+        }
+        assert(contains(node));
+    }
+    delete cellNodes;
+#endif
+    typename std::vector<const N*>::const_iterator first = mySortedNodes->begin() + myFromInclusive;
+    typename std::vector<const N*>::const_iterator last = mySortedNodes->begin() + myToExclusive;
+    typename std::vector<const N*>::const_iterator iter;
+#ifdef KDTP_WRITE_QGIS_FILTERS
+    size_t numberOfNodes = myToExclusive - myFromInclusive;
+    size_t k = 0;
+    std::string qgisFilterString = "id IN (";
+    // go through the nodes of the cell
+    for (iter = first; iter != last; iter++) {
+        k++;
+        qgisFilterString += (*iter)->getID() + (k < numberOfNodes ? ", " : "");
+    }
+    qgisFilterString += ")";
+    std::ostringstream pathAndFileName;
+    pathAndFileName << "./filter_nodes_of_cell_" << myNumber << ".qqf";
+    std::ofstream file;
+    file.open(pathAndFileName.str());
+    std::ostringstream content;
+    content << "<Query>" << qgisFilterString << "</Query>";
+    file << content.str();
+    file.close();
+#endif
+    // compute the set of of edges inside the cell
+#ifdef KDTP_DEBUG_LEVEL_1
+    std::cout << "Computing the set of of edges inside the cell..." << std::endl;
+#endif
+    std::unordered_set<const E*>* edgeSet = this->edgeSet(vehicle);
+#ifdef KDTP_DEBUG_LEVEL_1
+    std::cout << "Done. Now collecting boundary edges..." << std::endl;
+    int i = 0;
+#endif
+    /// go through the nodes of the cell in order to identify and collect boundary nodes / edges
+    for (iter = first; iter != last; iter++) {
+#if defined(KDTP_KEEP_BOUNDARY_EDGES) || defined(KDTP_KEEP_BOUNDARY_NODES) || defined(KDTP_WRITE_QGIS_FILTERS)
+        std::unordered_set<const E*> nodeEdgeSet;
+#endif
+#ifdef KDTP_DEBUG_LEVEL_1
+        if ((i++%10000)==0) {
+            std::cout << i << " cell nodes processed..." << std::endl;
+        }
+#endif
+#if defined(KDTP_KEEP_BOUNDARY_EDGES) || defined(KDTP_KEEP_BOUNDARY_NODES) || defined(KDTP_WRITE_QGIS_FILTERS)
+        const std::vector<const E*>& incomingEdges = (*iter)->getIncoming();
+        for (const E* incomingEdge : incomingEdges) {
+            if (isProhibited(incomingEdge, vehicle)) {
+                continue;
+            }
+#ifdef KDTP_EXCLUDE_INTERNAL_EDGES
+            if (incomingEdge->isInternal()) {
+                continue;
+            }
+#endif
+            nodeEdgeSet.insert(incomingEdge);
+        }
+        const std::vector<const E*>& outgoingEdges = (*iter)->getOutgoing();
+        for (const E* outgoingEdge : outgoingEdges) {
+            if (isProhibited(outgoingEdge, vehicle)) {
+                continue;
+            }
+#ifdef KDTP_EXCLUDE_INTERNAL_EDGES
+            if (outgoingEdge->isInternal()) {
+                continue;
+            }
+#endif
+            nodeEdgeSet.insert(outgoingEdge);
+        }
+        bool containsAll = true;
+        for (const E* nodeEdge : nodeEdgeSet) {
+            if (edgeSet->find(nodeEdge) == edgeSet->end()) {
+                containsAll = false;
+#ifndef KDTP_KEEP_BOUNDARY_EDGES
+                break; // cancel at first element which is not found
+#else
+                myBoundaryEdges.insert(nodeEdge); // boundary edge!
+#endif
+            }
+        }
+#if defined(KDTP_KEEP_BOUNDARY_NODES) || defined(KDTP_WRITE_QGIS_FILTERS)
+        if (!containsAll) {
+            myBoundaryNodes.push_back(*iter);
+        }
+#endif
+#endif
+#if defined(KDTP_KEEP_INCOMING_BOUNDARY_EDGES) || defined(KDTP_KEEP_BOUNDARY_TO_NODES)
+        const std::vector<const E*>& incoming = (*iter)->getIncoming();
+        std::unordered_set<const N*> boundaryToNodesSet;
+        for (const E* nodeEdge : incoming) {
+            if (isProhibited(nodeEdge, vehicle)) {
+                continue;
+            }
+#ifdef KDTP_EXCLUDE_INTERNAL_EDGES
+            if (nodeEdge->isInternal()) {
+                continue;
+            }
+#endif
+            assert(nodeEdge->getToJunction() == *iter);
+            if (edgeSet->find(nodeEdge) == edgeSet->end()) {
+#ifdef KDTP_KEEP_INCOMING_BOUNDARY_EDGES
+                myIncomingBoundaryEdges.insert(nodeEdge); // incoming boundary edge
+#endif
+#ifdef KDTP_KEEP_BOUNDARY_TO_NODES
+                boundaryToNodesSet.insert(*iter); ; // boundary to-node!
+#endif
+            }
+        }
+#ifdef KDTP_KEEP_BOUNDARY_TO_NODES
+        std::copy(boundaryToNodesSet.begin(), boundaryToNodesSet.end(),
+            std::back_inserter(myBoundaryToNodes));
+#endif
+#endif
+#if defined(KDTP_KEEP_OUTGOING_BOUNDARY_EDGES) || defined(KDTP_KEEP_BOUNDARY_FROM_NODES)
+        const std::vector<const E*>& outgoing = (*iter)->getOutgoing();
+        std::unordered_set<const N*> boundaryFromNodesSet;
+        for (const E* nodeEdge : outgoing) {
+            if (isProhibited(nodeEdge, vehicle)) {
+                continue;
+            }
+#ifdef KDTP_EXCLUDE_INTERNAL_EDGES
+            if (nodeEdge->isInternal()) {
+                continue;
+            }
+#endif
+            assert(nodeEdge->getFromJunction() == *iter);
+            if (edgeSet->find(nodeEdge) == edgeSet->end()) {
+#ifdef KDTP_KEEP_OUTGOING_BOUNDARY_EDGES
+                myOutgoingBoundaryEdges.insert(nodeEdge); // outgoing boundary edge
+#endif
+#ifdef KDTP_KEEP_BOUNDARY_FROM_NODES
+                boundaryFromNodesSet.insert(*iter); // boundary from-node
+#endif
+            }
+        }
+#ifdef KDTP_KEEP_BOUNDARY_FROM_NODES
+        std::copy(boundaryFromNodesSet.begin(), boundaryFromNodesSet.end(), 
+            std::back_inserter(myBoundaryFromNodes));
+#endif
+#endif
+    }
+    delete edgeSet;
+#if defined(KDTP_KEEP_BOUNDARY_NODES) || defined(KDTP_WRITE_QGIS_FILTERS)
+    size_t numberOfBoundaryNodes = myBoundaryNodes.size();
+#ifdef KDTP_DEBUG_LEVEL_1
+    std::cout << "Number of boundary nodes: " << numberOfBoundaryNodes << std::endl;
+#endif
+#endif
+#ifdef KDTP_KEEP_BOUNDARY_FROM_NODES
+#ifdef KDTP_DEBUG_LEVEL_1
+    size_t numberOfBoundaryFromNodes = myBoundaryFromNodes.size();
+    std::cout << "Number of boundary from nodes: " << numberOfBoundaryFromNodes << std::endl;
+#endif
+#endif
+#ifdef KDTP_KEEP_BOUNDARY_TO_NODES
+    size_t numberOfBoundaryToNodes = myBoundaryToNodes.size();
+#ifdef KDTP_DEBUG_LEVEL_1
+    std::cout << "Number of boundary to nodes: " << numberOfBoundaryToNodes << std::endl;
+#endif
+#endif
+#ifdef KDTP_KEEP_BOUNDARY_EDGES
+    size_t numberOfBoundaryEdges = myBoundaryEdges.size();
+#ifdef KDTP_DEBUG_LEVEL_1
+    std::cout << "Number of boundary edges: " << numberOfBoundaryEdges << std::endl;
+#endif
+#endif
+#ifdef KDTP_KEEP_INCOMING_BOUNDARY_EDGES
+#ifdef KDTP_DEBUG_LEVEL_1
+    size_t numberOfIncomingBoundaryEdges = myIncomingBoundaryEdges.size();
+    std::cout << "Number of incoming boundary edges: " << numberOfIncomingBoundaryEdges << std::endl;
+#endif
+#endif
+#ifdef KDTP_KEEP_OUTGOING_BOUNDARY_EDGES
+#ifdef KDTP_DEBUG_LEVEL_1
+    size_t numberOfOutgoingBoundaryEdges = myOutgoingBoundaryEdges.size();
+    std::cout << "Number of outgoing boundary edges: " << numberOfOutgoingBoundaryEdges << std::endl;
+#endif
+#endif
+#ifdef KDTP_WRITE_QGIS_FILTERS
+    k = 0;
+    qgisFilterString.clear();
+    qgisFilterString = "id IN (";
+    // go through the boundary nodes of the cell
+    for (const N* node : myBoundaryNodes) {
+        k++;
+        qgisFilterString += node->getID() + (k < numberOfBoundaryNodes ? ", " : "");
+    }
+#ifndef KDTP_KEEP_BOUNDARY_NODES
+    myBoundaryNodes.clear();
+#endif
+    qgisFilterString += ")";
+    pathAndFileName.str("");
+    pathAndFileName.clear();
+    pathAndFileName << "./filter_boundary_nodes_of_cell_" << myNumber << ".qqf";
+    file.clear();
+    file.open(pathAndFileName.str());
+    content.str("");
+    content.clear(); 
+    content << "<Query>" << qgisFilterString << "</Query>";
+    file << content.str();
+    file.close();
+ #endif
+#ifdef KDTP_DEBUG_LEVEL_1
+    std::cout << "Done. Now calling the constructor recursively to instantiate the subcells (left or lower one first)..." << std::endl;
+#endif
+    size_t medianIndex = partition();
+    completeSpatialInfo();
+    // create subcells
+    if (myLevel < myNumberOfLevels - 1) {
+        // determine min/max X/Y-values to pass on to left or lower subcell
+        double passMinX = -1, passMaxX = -1, passMinY = -1, passMaxY = -1;
+        if (myAxis == Axis::X) { // left subcell
+            passMinX = myMinX;
+            passMaxX = (*mySortedNodes)[medianIndex]->getPosition().x();
+            passMinY = myMinY;
+            passMaxY = myMaxY;
+        }
+        else { // lower subcell
+            passMinX = myMinX;
+            passMaxX = myMaxX;
+            passMinY = myMinY;
+            passMaxY = (*mySortedNodes)[medianIndex]->getPosition().y();
+        }
+#ifdef KDTP_FOR_SYNTHETIC_NETWORKS
+        // notice that nodes with indexes medianIndex and medianIndex+1 may have the same coordinate in the direction of myAxis 
+        // (in that case, they are ordered / distributed between the two subcells with a tie-breaking rule)
+        // consequently, the spatial extent of cells alone does not suffice to decide whether a node belongs to a certain cell or not
+        // therefore, for each of the two subcells, we compute the set of nodes sharing said coordinate (called the set of "spatial conflict nodes")
+        // the size of this set is usually very small compared to the size of the set of all nodes of the subcell  
+        // with the spatial extent of a cell and its spatial conflict nodes set, a valid test whether a node belongs to the cell becomes available
+        // this test is quicker and requires significantly less memory than one based on pre-computed sets of all cell nodes
+        std::pair<std::unordered_set<const N*>*, std::unordered_set<const N*>*> conflictNodes = spatialConflictNodes(medianIndex);
+        // determine northern/eastern/southern/western conflict nodes to pass on to left or lower subcell
+        std::unordered_set<const N*>* passNorthernConflictNodes;
+        std::unordered_set<const N*>* passEasternConflictNodes;
+        std::unordered_set<const N*>* passSouthernConflictNodes;
+        std::unordered_set<const N*>* passWesternConflictNodes;
+        if (myAxis == Axis::X) { // left subcell
+            passNorthernConflictNodes = myNorthernConflictNodes;
+            passEasternConflictNodes = conflictNodes.first;
+            passSouthernConflictNodes = mySouthernConflictNodes;
+            passWesternConflictNodes = myWesternConflictNodes;
+        }
+        else { // lower subcell
+            passNorthernConflictNodes = conflictNodes.first;
+            passEasternConflictNodes = myEasternConflictNodes;
+            passSouthernConflictNodes = mySouthernConflictNodes;
+            passWesternConflictNodes = myWesternConflictNodes;
+        }
+        myLeftOrLowerSubcell = new Cell(myCells, myLevelCells, mySortedNodes, myNumberOfLevels, myLevel + 1, KDTreePartition::flip(myAxis), myFromInclusive, medianIndex + 1, this, 
+            passMinX, passMaxX, passMinY, passMaxY, passNorthernConflictNodes, passEasternConflictNodes, passSouthernConflictNodes, passWesternConflictNodes, true, 
+            vehicle, myHavePermissions, myHaveRestrictions);
+#else
+        myLeftOrLowerSubcell = new Cell(myCells, myLevelCells, mySortedNodes, myNumberOfLevels, myLevel + 1, KDTreePartition::flip(myAxis), myFromInclusive, medianIndex + 1, this, 
+            passMinX, passMaxX, passMinY, passMaxY, true, vehicle, myHavePermissions, myHaveRestrictions);
+#endif
+#ifdef KDTP_DEBUG_LEVEL_1
+        std::cout << "Left or lower call done. Now calling it for the right or upper subcell..." << std::endl;
+#endif
+        // determine min/max X/Y-values to pass on to right or upper subcell
+        passMinX = -1, passMaxX = -1, passMinY = -1, passMaxY = -1;
+        if (myAxis == Axis::X) { // right subcell
+            passMinX = (*mySortedNodes)[medianIndex+1]->getPosition().x();
+            passMaxX = myMaxX;
+            passMinY = myMinY;
+            passMaxY = myMaxY;
+        }
+        else { // upper subcell
+            passMinX = myMinX;
+            passMaxX = myMaxX;
+            passMinY = (*mySortedNodes)[medianIndex+1]->getPosition().y();
+            passMaxY = myMaxY;
+        }
+#ifdef KDTP_FOR_SYNTHETIC_NETWORKS
+        // determine northern/eastern/southern/western conflict nodes to pass on to right or upper subcell
+        if (myAxis == Axis::X) { // right subcell
+            passNorthernConflictNodes = myNorthernConflictNodes;
+            passEasternConflictNodes = myEasternConflictNodes;
+            passSouthernConflictNodes = mySouthernConflictNodes;
+            passWesternConflictNodes = conflictNodes.second;
+        }
+        else { // upper subcell
+            passNorthernConflictNodes = myNorthernConflictNodes;
+            passEasternConflictNodes = myEasternConflictNodes;
+            passSouthernConflictNodes = conflictNodes.second;
+            passWesternConflictNodes = myWesternConflictNodes;
+        }
+        myRightOrUpperSubcell = new Cell(myCells, myLevelCells, mySortedNodes, myNumberOfLevels, myLevel + 1, KDTreePartition::flip(myAxis), medianIndex + 1, myToExclusive, this, 
+        passMinX, passMaxX, passMinY, passMaxY, passNorthernConflictNodes, passEasternConflictNodes, passSouthernConflictNodes, passWesternConflictNodes, false, 
+            vehicle, myHavePermissions, myHaveRestrictions);
+#else
+        myRightOrUpperSubcell = new Cell(myCells, myLevelCells, mySortedNodes, myNumberOfLevels, myLevel + 1, KDTreePartition::flip(myAxis), medianIndex + 1, myToExclusive, this, 
+            passMinX, passMaxX, passMinY, passMaxY, false, vehicle, myHavePermissions, myHaveRestrictions);
+#endif
+#ifdef KDTP_DEBUG_LEVEL_1
+        std::cout << "Right or upper call done. Returning from constructor..." << std::endl;
+#endif
+    } else {
+        // leaves of the k-d tree: subcell pointers equal nullptr
+        myLeftOrLowerSubcell = nullptr;
+        myRightOrUpperSubcell = nullptr;
+    }
+} // end of cell constructor
+
+template<class E, class N, class V>
+double KDTreePartition<E, N, V>::Cell::minAxisValue(Axis axis) const {
+#ifdef KDTP_DEBUG_LEVEL_1
+    double returnValue = -1;
+#endif
+    if (myHasNodesSortedWrtToMyAxis && axis == myAxis) {
+#ifndef KDTP_DEBUG_LEVEL_1
+        return (myAxis == Axis::Y ? (*mySortedNodes)[myFromInclusive]->getPosition().y() 
+            : (*mySortedNodes)[myFromInclusive]->getPosition().x());
+#else
+        returnValue = (myAxis == Axis::Y ? (*mySortedNodes)[myFromInclusive]->getPosition().y() 
+            : (*mySortedNodes)[myFromInclusive]->getPosition().x());
+#endif
+    }
+    double minAxisValue = std::numeric_limits<double>::max();
+    typename std::vector<const N*>::const_iterator first = mySortedNodes->begin() + myFromInclusive;
+    typename std::vector<const N*>::const_iterator last = mySortedNodes->begin() + myToExclusive;
+    typename std::vector<const N*>::const_iterator iter;
+    // go through the nodes of the cell
+    for (iter = first; iter != last; iter++) {
+        double nodeAxisValue; 
+        nodeAxisValue = (axis == Axis::Y ? (*iter)->getPosition().y() : (*iter)->getPosition().x());
+        if (nodeAxisValue < minAxisValue) {
+            minAxisValue = nodeAxisValue;
+        }
+    }
+    assert(minAxisValue < std::numeric_limits<double>::max());
+#ifdef KDTP_DEBUG_LEVEL_1
+    assert( (!myHasNodesSortedWrtToMyAxis || axis != myAxis) || minAxisValue == returnValue);
+#endif
+    return minAxisValue;
+}
+
+template<class E, class N, class V>
+double KDTreePartition<E, N, V>::Cell::minAxisValue() const {
+    return minAxisValue(myAxis);
+}
+
+template<class E, class N, class V>
+double KDTreePartition<E, N, V>::Cell::maxAxisValue(Axis axis) const {
+#ifdef KDTP_DEBUG_LEVEL_1
+    double returnValue = -1;
+#endif
+    if (myHasNodesSortedWrtToMyAxis && axis == myAxis) {
+#ifndef KDTP_DEBUG_LEVEL_1
+        return (myAxis == Axis::Y ? (*mySortedNodes)[myToExclusive - 1]->getPosition().y() 
+            : (*mySortedNodes)[myToExclusive - 1]->getPosition().x());
+#else
+        returnValue = (myAxis == Axis::Y ? (*mySortedNodes)[myToExclusive - 1]->getPosition().y() 
+            : (*mySortedNodes)[myToExclusive - 1]->getPosition().x());
+#endif
+        
+    }
+    double maxAxisValue = -1;
+    typename std::vector<const N*>::const_iterator first = mySortedNodes->begin() + myFromInclusive;
+    typename std::vector<const N*>::const_iterator last = mySortedNodes->begin() + myToExclusive;
+    typename std::vector<const N*>::const_iterator iter;
+    // go through the nodes of the cell
+    for (iter = first; iter != last; iter++) {
+        double nodeAxisValue;
+        nodeAxisValue = (axis == Axis::Y ? (*iter)->getPosition().y() : (*iter)->getPosition().x());
+        if (nodeAxisValue > maxAxisValue) {
+            maxAxisValue = nodeAxisValue;
+        }
+    }
+    assert(maxAxisValue > 0);
+#ifdef KDTP_DEBUG_LEVEL_1
+    assert((!myHasNodesSortedWrtToMyAxis || axis != myAxis) || maxAxisValue == returnValue);
+#endif
+    return maxAxisValue;
+}
+
+template<class E, class N, class V>
+double KDTreePartition<E, N, V>::Cell::maxAxisValue() const
+{
+    return maxAxisValue(myAxis);
+}
+
+template<class E, class N, class V>
+size_t KDTreePartition<E, N, V>::Cell::partition() {
+    typename std::vector<const N*>::iterator first = mySortedNodes->begin() + myFromInclusive;
+    typename std::vector<const N*>::iterator last = mySortedNodes->begin() + myToExclusive;
+    if (myAxis == Axis::Y) {
+        std::sort(first, last, NodeYComparator());
+    } else {
+        std::sort(first, last, NodeXComparator());
+    }
+    myHasNodesSortedWrtToMyAxis = true;
+    if (mySupercell) {
+        // sorting at one level destroys order at higher levels (but preserves the median split property)
+        mySupercell->myHasNodesSortedWrtToMyAxis = false; 
+    }
+    size_t length = myToExclusive - myFromInclusive;
+    size_t medianIndex = myFromInclusive + (length % 2 == 0 ? length / 2 - 1 : (length + 1) / 2 - 1);
+#ifndef KDTP_FOR_SYNTHETIC_NETWORKS
+    // notice that nodes with indexes medianIndex and medianIndex+1 may have the same coordinate in the direction of myAxis - 
+    // in that case, they would be ordered and distributed between the two subcells with a tie-breaking rule, 
+    // and the spatial extent of cells alone would not suffice to decide whether a node belongs to a certain cell or not
+    // for real-world road networks, this should occur very rarely
+    // therefore, a simple but perfectly acceptable remedy is to shift the median index until the nodes with indexes 
+    // medianIndex and medianIndex+1 have different coordinates
+    // this will distort the 50%/50% distribution of nodes just a little bit (and only under very rare circumstances)
+    // hence we can assume zero impact on performance
+    // note that this may happen more frequently for e.g. synthetic networks placing nodes at a regular, constant grid. 
+    // for this case, a different solution is provided, see code within #ifdef KDTP_FOR_SYNTHETIC_NETWORKS ... #endif
+    const N* medianNode = (*mySortedNodes)[medianIndex];
+    const N* afterMedianNode = (*mySortedNodes)[medianIndex+1];
+    double medianNodeCoordinate = myAxis == Axis::X ? medianNode->getPosition().x() 
+        : medianNode->getPosition().y();
+    double afterMedianNodeCoordinate = myAxis == Axis::X ? afterMedianNode->getPosition().x() 
+        : afterMedianNode->getPosition().y();
+    while (medianNodeCoordinate == afterMedianNodeCoordinate && medianIndex<myToExclusive-3) {
+#ifdef KDTP_DEBUG_LEVEL_2
+        std::cout << "Found spatially conflicting nodes." << std::endl; 
+#endif
+        medianIndex++;
+        medianNode = (*mySortedNodes)[medianIndex];
+        afterMedianNode = (*mySortedNodes)[medianIndex + 1];
+        medianNodeCoordinate = myAxis == Axis::X ? medianNode->getPosition().x() 
+            : medianNode->getPosition().y();
+        afterMedianNodeCoordinate = myAxis == Axis::X ? afterMedianNode->getPosition().x() 
+            : afterMedianNode->getPosition().y();
+    }
+#endif
+    myMedianCoordinate = medianNodeCoordinate;
+    return medianIndex;
+}
+
+template<class E, class N, class V>
+void KDTreePartition<E, N, V>::Cell::completeSpatialInfo() {
+    // complete missing information about the cell's spatial extent
+    if (myMinX < 0) {
+        myMinX = minAxisValue(Axis::X);
+    }
+    if (myMaxX < 0) {
+        myMaxX = maxAxisValue(Axis::X);
+    }
+    if (myMinY < 0) {
+        myMinY = minAxisValue(Axis::Y);
+    }
+    if (myMaxY < 0) {
+        myMaxY = maxAxisValue(Axis::Y);
+    }
+    myHasCompleteSpatialInfo = true;
+}
+
+template<class E, class N, class V>
+std::unordered_set<const E*>* KDTreePartition<E, N, V>::Cell::edgeSet(const V* const vehicle) const {
+    std::unordered_set<const E*>* edgeSet = new std::unordered_set<const E*>();
+    typename std::vector<const N*>::const_iterator first = mySortedNodes->begin() + myFromInclusive;
+    typename std::vector<const N*>::const_iterator last = mySortedNodes->begin() + myToExclusive;
+    typename std::vector<const N*>::const_iterator iter;
+    for (iter = first; iter != last; iter++) {
+        const N* edgeNode;
+        const std::vector<const E*>& incomingEdges = (*iter)->getIncoming();
+        for (const E* incomingEdge : incomingEdges) {
+            if (isProhibited(incomingEdge, vehicle)) {
+                continue;
+            }
+#ifdef KDTP_EXCLUDE_INTERNAL_EDGES
+            if (incomingEdge->isInternal()) {
+                continue;
+            }
+#endif
+            edgeNode = incomingEdge->getFromJunction();
+            if (contains(edgeNode)) {
+                edgeSet->insert(incomingEdge);
+            }
+        }
+        const std::vector<const E*>& outgoingEdges = (*iter)->getOutgoing();
+        for (const E* outgoingEdge : outgoingEdges) {
+            if (isProhibited(outgoingEdge, vehicle)) {
+                continue;
+            }
+#ifdef KDTP_EXCLUDE_INTERNAL_EDGES
+            if (outgoingEdge->isInternal()) {
+                continue;
+            }
+#endif
+            edgeNode = outgoingEdge->getToJunction();
+            if (contains(edgeNode)) {
+                edgeSet->insert(outgoingEdge);
+            }
+        }
+    }
+    return edgeSet;
+}
+
+template<class E, class N, class V>
+size_t KDTreePartition<E, N, V>::Cell::numberOfEdgesEndingInCell(const V* const vehicle) const {
+    typename std::vector<const N*>::const_iterator first = mySortedNodes->begin() + myFromInclusive;
+    typename std::vector<const N*>::const_iterator last = mySortedNodes->begin() + myToExclusive;
+    typename std::vector<const N*>::const_iterator iter;
+    size_t edgeCounter = 0;
+    for (iter = first; iter != last; iter++) {
+        const std::vector<const E*>& incomingEdges = (*iter)->getIncoming();
+        for (const E* incomingEdge : incomingEdges) {
+            if (isProhibited(incomingEdge, vehicle)) {
+                continue;
+            }
+#ifdef KDTP_EXCLUDE_INTERNAL_EDGES
+            if (incomingEdge->isInternal()) {
+                continue;
+            }
+            else {
+                edgeCounter++;
+            }
+#endif
+        }
+    }
+    return edgeCounter;
+}
+
+template<class E, class N, class V>
+size_t KDTreePartition<E, N, V>::Cell::numberOfEdgesStartingInCell(const V* const vehicle) const {
+    typename std::vector<const N*>::const_iterator first = mySortedNodes->begin() + myFromInclusive;
+    typename std::vector<const N*>::const_iterator last = mySortedNodes->begin() + myToExclusive;
+    typename std::vector<const N*>::const_iterator iter;
+    size_t edgeCounter = 0;
+    for (iter = first; iter != last; iter++) {
+        const std::vector<const E*>& outgoingEdges = (*iter)->getOutgoing();
+        for (const E* outgoingEdge : outgoingEdges) {
+            if (isProhibited(outgoingEdge, vehicle)) {
+                continue;
+            }
+#ifdef KDTP_EXCLUDE_INTERNAL_EDGES
+           if (outgoingEdge->isInternal()) {
+                continue;
+           }
+           else {
+               edgeCounter++;
+           }
+        }
+#endif
+    }
+    return edgeCounter;
+}
+
+template<class E, class N, class V>
+std::pair<typename std::vector<const N*>::const_iterator, 
+    typename std::vector<const N*>::const_iterator> KDTreePartition<E, N, V>::Cell::nodeIterators() const {
+    typename std::vector<const N*>::const_iterator first = mySortedNodes->begin() + myFromInclusive;
+    typename std::vector<const N*>::const_iterator last = mySortedNodes->begin() + myToExclusive;
+    std::pair<typename std::vector<const N*>::const_iterator, 
+        typename std::vector<const N*>::const_iterator> iterators = std::make_pair(first, last);
+    return iterators;
+}
+
+template<class E, class N, class V>
+std::vector<const N*>* KDTreePartition<E, N, V>::Cell::nodes() const {
+    typename std::vector<const N*>::const_iterator first = mySortedNodes->begin() + myFromInclusive;
+    typename std::vector<const N*>::const_iterator last = mySortedNodes->begin() + myToExclusive;
+    std::vector<const N*>* nodes = new std::vector<const N*>(first, last);
+    return nodes;
+}
+
+#ifdef KDTP_FOR_SYNTHETIC_NETWORKS
+template<class E, class N, class V>
+std::pair<std::unordered_set<const N*>*, 
+    std::unordered_set<const N*>*> KDTreePartition<E, N, V>::Cell::spatialConflictNodes(size_t medianIndex) const {
+    std::unordered_set<const N*>* leftOrLowerSpatialConflictNodes = new std::unordered_set<const N*>();
+    std::unordered_set<const N*>* rightOrUpperSpatialConflictNodes = new std::unordered_set<const N*>();
+    std::pair<std::unordered_set<const N*>*, std::unordered_set<const N*>*> spatialConflictNodes 
+        = std::make_pair(leftOrLowerSpatialConflictNodes, rightOrUpperSpatialConflictNodes);
+    std::vector<const N*>::const_iterator iter, prev;
+    if (myAxis == Axis::X) {
+        if ((*mySortedNodes)[medianIndex]->getPosition().x() == (*mySortedNodes)[medianIndex + 1]->getPosition().x()) {
+            double sharedCoordinate = (*mySortedNodes)[medianIndex]->getPosition().x();
+            std::vector<const N*>::iterator firstLeftOrLower = mySortedNodes->begin() + medianIndex;
+            // this is last since we go backward
+            std::vector<const N*>::iterator last = mySortedNodes->begin() + myFromInclusive - 1;
+            for (iter = firstLeftOrLower; ((*iter)->getPosition().x() == sharedCoordinate) && (iter != last); iter--) {
+                leftOrLowerSpatialConflictNodes->insert(*iter);
+            }
+        }
+    } else {
+        if ((*mySortedNodes)[medianIndex]->getPosition().y() == (*mySortedNodes)[medianIndex + 1]->getPosition().y()) {
+            double sharedCoordinate = (*mySortedNodes)[medianIndex]->getPosition().y();
+            std::vector<const N*>::iterator firstRightOrUpper = mySortedNodes->begin() + medianIndex + 1;
+            std::vector<const N*>::const_iterator last = mySortedNodes->begin() + myToExclusive;
+            for (iter = firstRightOrUpper; ((*iter)->getPosition().y() == sharedCoordinate) && (iter != last); iter++) {
+                rightOrUpperSpatialConflictNodes->insert(*iter);
+            }
+        }
+    }
+    return spatialConflictNodes;
+}
+#endif
+
+template<class E, class N, class V>
+bool KDTreePartition<E, N, V>::Cell::isInBounds(const N* node) const {
+    double nodeX = node->getPosition().x();
+    double nodeY = node->getPosition().y();
+    if (nodeX < myMinX || nodeX > myMaxX || nodeY < myMinY || nodeY > myMaxY) {
+        return false;
+    }
+    return true;
+}
+
+template<class E, class N, class V>
+bool KDTreePartition<E, N, V>::Cell::contains(const N* node) const
+{
+    if (myLevel == 0) { // p.d., the root cell contains all nodes
+        return true;
+    }
+    if (!isInBounds(node)) {
+#ifdef KDTP_DEBUG_LEVEL_2
+        std::cout << "Not in bounds, nX: " << node->getPosition().x() << ", nY: " << node->getPosition().y() << std::endl;
+#endif
+        return false;
+    }
+#ifdef KDTP_DEBUG_LEVEL_2
+    else {
+        std::cout << "Node is in bounds!" << std::endl;
+    }
+#endif
+#ifdef KDTP_FOR_SYNTHETIC_NETWORKS
+    //
+    double nodeX = node->getPosition().x();
+    double nodeY = node->getPosition().y();
+#ifdef KDTP_DEBUG_LEVEL_2
+    std::cout << "Entered contains, nodeX: " << nodeX << ", nodeY: " << nodeY << std::endl;
+#endif
+    double northY = -1;
+    if (myNorthernConflictNodes  && !myNorthernConflictNodes->empty()) {
+        northY = (*(myNorthernConflictNodes->begin()))->getPosition().y();
+    }
+    double eastX = -1;
+    if (myEasternConflictNodes && !myEasternConflictNodes->empty()) {
+        eastX = (*(myEasternConflictNodes->begin()))->getPosition().x();
+    }
+    double southY = -1;
+    if (mySouthernConflictNodes && !mySouthernConflictNodes->empty()) {
+        southY = (*(mySouthernConflictNodes->begin()))->getPosition().y();
+    }
+    double westX = -1;
+    if (myWesternConflictNodes && !myWesternConflictNodes->empty()) {
+        westX = (*(myWesternConflictNodes->begin()))->getPosition().x();
+    }
+#ifdef KDTP_DEBUG_LEVEL_2
+    std::cout << "northY: " << northY << ", eastX: " << eastX << ", southY: " << southY << ", westX: " << westX << std::endl;
+#endif
+    if (nodeX == eastX) { // we have to test the eastern conflict nodes
+#ifdef KDTP_DEBUG_LEVEL_2
+        std::cout << "On eastern bound, nX: " << node->getPosition().x() << ", nY: " << node->getPosition().y() << std::endl;
+#endif
+        return myEasternConflictNodes->find(node) != myEasternConflictNodes->end();
+    }
+    if (nodeX == westX) { // we have to test the western conflict nodes
+#ifdef KDTP_DEBUG_LEVEL_2
+        std::cout << "On western bound, nX: " << node->getPosition().x() << ", nY: " << node->getPosition().y() << std::endl;
+#endif
+        return myWesternConflictNodes->find(node) != myWesternConflictNodes->end();
+    }
+    if (nodeY == northY) { // we have to test the northern conflict nodes
+#ifdef KDTP_DEBUG_LEVEL_2
+        std::cout << "On northern bound, nX: " << node->getPosition().x() << ", nY: " << node->getPosition().y() << std::endl;
+#endif
+        return myNorthernConflictNodes->find(node) != myNorthernConflictNodes->end();
+    }
+    if (nodeY == southY) { // we have to test the southern conflict nodes
+#ifdef KDTP_DEBUG_LEVEL_2
+        std::cout << "On southern bound, nX: " << node->getPosition().x() << ", nY: " << node->getPosition().y() << std::endl;
+#endif
+        return mySouthernConflictNodes->find(node) != myEasternConflictNodes->end();
+    }
+#endif
+#ifdef KDTP_DEBUG_LEVEL_2
+    std::cout << "Node does not lie on a border!" << std::endl;
+#endif
+    return true; // if the node does not lie on a spatial border, the passed in-bounds test suffices
+}
+
+template<class E, class N, class V>
+const typename KDTreePartition<E, N, V>::Cell* KDTreePartition<E, N, V>::searchNode(const N* node) const
+{
+    const typename KDTreePartition<E, N, V>::Cell* cell = myRoot;
+    if (!myRoot->contains(node)) {
+        return nullptr;
+    }
+    while (true) {
+        assert(cell);
+        double nodeCoordinate = cell->getAxis() == Axis::X ? node->getPosition().x() : node->getPosition().y();
+        const typename KDTreePartition<E, N, V>::Cell* nextCell = nodeCoordinate <= cell->getMedianCoordinate() ?
+            cell->getLeftOrLowerSubcell() : cell->getRightOrUpperSubcell();
+        if (nextCell == nullptr) {
+            return cell;
+        }
+        else {
+            cell = nextCell;
+        }
+    }
+}

--- a/src/utils/router/Node2EdgeRouter.h
+++ b/src/utils/router/Node2EdgeRouter.h
@@ -1,0 +1,465 @@
+/****************************************************************************/
+// Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.org/sumo
+// Copyright (C) 2012-2023 German Aerospace Center (DLR) and others.
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0/
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License 2.0 are satisfied: GNU General Public License, version 2
+// or later which is available at
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+/****************************************************************************/
+/// @file    Node2EdgeRouter.h
+/// @author  Ruediger Ebendt
+/// @date    01.01.2024
+///
+// Simple extension of edge-based AStarRouter, adding a) a new method computeNode2Edge, 
+// which computes a shortest path starting at a given node and ending at a given edge, 
+// and b) a new method computeNode2Edges, which computes shortest paths, each starting 
+// at the given node and ending at one of the given edges
+/****************************************************************************/
+#pragma once
+#include <config.h>
+#include <unordered_set>
+#include <utils/common/StdDefs.h>
+#include "AStarRouter.h"
+
+// ===========================================================================
+// class definitions
+// ===========================================================================
+/**
+ * @class Node2EdgeRouter
+ * Computes shortest paths from a node to one edge (using A*) or to all edges 
+ * (using Dijkstra's algorithm)
+ *
+ * The template parameters are:
+ * @param E The edge class to use (MSEdge/ROEdge)
+ * @param V The vehicle class to use (MSVehicle/ROVehicle)
+ *
+ * The router is edge-based. It must know the number of edges for internal reasons 
+ * and whether a missing connection between two given edges (unbuild route) shall 
+ * be reported as an error or as a warning
+ *
+ */
+template<class E, class N, class V>
+class Node2EdgeRouter : public AStarRouter<E, V> {
+public:
+    typedef AbstractLookupTable<E, V> LookupTable;
+ 
+    /** @brief Returns the edge information for the passed edge
+     * @param[in] edge The edge
+     * @note Non-const version
+     */
+    typename SUMOAbstractRouter<E, V>::EdgeInfo* edgeInfo(const E* const edge) {
+        return &(this->myEdgeInfos[edge->getNumericalID()]);
+    }
+    /** @brief Returns the edge information for the passed edge
+     * @param[in] edge The edge
+     * @note Const version
+     */
+    const typename SUMOAbstractRouter<E, V>::EdgeInfo* edgeInfo(const E* const edge) const {
+        return &(this->myEdgeInfos[edge->getNumericalID()]);
+    }
+
+    /** @brief Constructor
+     * @param[in] edges The edges
+     * @param[in] unbuildIsWarning The flag indicating whether network unbuilds should issue warnings or errors
+     * @param[in] operation The operation
+     * @param[in] lookup The lookup table
+     * @param[in] havePermissions The flag indicating whether to respect edge permissions
+     * @param[in] haveRestrictions The flag indicating whether to respect edge restrictions
+     */
+    Node2EdgeRouter(const std::vector<E*>& edges, bool unbuildIsWarning, typename SUMOAbstractRouter<E, V>::Operation operation, 
+        const std::shared_ptr<const LookupTable> lookup = nullptr,
+        const bool havePermissions = false, const bool haveRestrictions = false) :
+        AStarRouter<E, V>(edges, unbuildIsWarning, operation, lookup, havePermissions, haveRestrictions) {
+    }
+
+    /** @brief Cloning constructor
+     * @param[in] edgeInfos The vector of edge information
+     * @param[in] unbuildIsWarning The flag indicating whether network unbuilds should issue warnings or errors
+     * @param[in] operation The operation
+     * @param[in] lookup The lookup table
+     * @param[in] havePermissions The flag indicating whether to respect edge permissions
+     * @param[in] haveRestrictions The flag indicating whether to respect edge restrictions
+     */
+    Node2EdgeRouter(const std::vector<typename SUMOAbstractRouter<E, V>::EdgeInfo>& edgeInfos, bool unbuildIsWarning, typename SUMOAbstractRouter<E, V>::Operation operation, const std::shared_ptr<const LookupTable> lookup = nullptr,
+                const bool havePermissions = false, const bool haveRestrictions = false) :
+        AStarRouter<E, V>(edgeInfos, unbuildIsWarning, operation, lookup, havePermissions, haveRestrictions) {
+    }
+
+    /// @brief Destructor
+    virtual ~Node2EdgeRouter() {
+        WRITE_MESSAGE("The following stats for AStarRouter (which might also be empty) belong to Node2EdgeRouter, a derived class:");
+    }
+
+    /// @brief Cloning method
+    virtual SUMOAbstractRouter<E, V>* clone() {
+        return new Node2EdgeRouter<E, N, V>(this->myEdgeInfos, this->myErrorMsgHandler == MsgHandler::getWarningInstance(), this->myOperation, this->myLookupTable,
+                                     this->myHavePermissions, this->myHaveRestrictions);
+    }
+
+    /** @brief Reset method
+     * @param[in] vehicle The vehicle
+     */
+    virtual void reset(const V* const vehicle) {
+        UNUSED_PARAMETER(vehicle);
+        for (auto& edgeInfo : this->myFrontierList) {
+            edgeInfo->reset();
+        }
+        this->myFrontierList.clear();
+        for (auto& edgeInfo : this->myFound) {
+            edgeInfo->reset();
+        }
+        this->myFound.clear();
+    }
+
+    /** @brief Builds the routes between the given node and all given edges using the minimum travel time
+     * @param[in] fromNode The node which the routes start with
+     * @param[in] toEdges The edges at which the routes end
+     * @param[in] vehicle The vehicle
+     * @param[in] msTime The start time of the routes in milliseconds
+     * @param[in] silent The boolean flag indicating whether the method stays silent or puts out messages
+     */
+    bool computeNode2Edges(const N* fromNode, const std::unordered_set<const E*>& toEdges, const V* const vehicle,
+                 SUMOTime msTime, bool silent = false) {
+        assert(fromNode != nullptr);
+        // check whether fromNode and to can be used
+        bool found = false;
+        bool allVisited = true; // we try to disprove this 
+        for (const E* from : fromNode->getOutgoing()) {
+            if (from->isInternal()) {
+                continue;
+            }
+            if (this->myEdgeInfos[from->getNumericalID()].prohibited || this->isProhibited(from, vehicle)) {
+                if (!silent) {
+                    this->myErrorMsgHandler->inform("Vehicle '" + Named::getIDSecure(vehicle) + "' is not allowed on source edge '" + from->getID() + "'.");
+                }
+            }
+            else {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            return false;
+        }
+        const std::vector<const E*>& fromEdges = fromNode->getOutgoing();
+
+        if (fromEdges.empty() || toEdges.empty()) { // nothing to do here
+            return false;
+        }
+
+        double length = 0.; // dummy for the via edge cost update
+        this->startQuery();
+#ifdef ASTAR_DEBUG_QUERY
+        if (ASTAR_DEBUG_COND) {
+            std::cout << "DEBUG: starting search for '" << Named::getIDSecure(vehicle) << "' speed: " << MIN2(vehicle->getMaxSpeed(), myMaxSpeed * vehicle->getChosenSpeedFactor()) << " time: " << STEPS2TIME(msTime) << "\n";
+        }
+#endif
+
+        const SUMOVehicleClass vClass = vehicle == 0 ? SVC_IGNORING : vehicle->getVClass();
+        init(fromEdges, vehicle, msTime);
+        this->myAmClean = false;
+        // loop
+        int num_visited = 0;
+        while (!this->myFrontierList.empty()) {
+            num_visited += 1;
+            // use the edge with the minimal length
+            auto* const minimumInfo = this->myFrontierList.front();
+            const E* const minEdge = minimumInfo->edge;
+            // check whether the destination edge was already reached
+            if (toEdges.count(minEdge)) {
+                for (const E* to : toEdges) {
+                    const auto& toInfo = this->myEdgeInfos[to->getNumericalID()];
+                    if (!toInfo.visited) {
+                        allVisited = false;
+                        break;
+                    }
+                }
+                if (allVisited) {
+                    this->endQuery(num_visited);
+                    return true;
+                }
+            }
+            std::pop_heap(this->myFrontierList.begin(), this->myFrontierList.end(), this->myComparator);
+            this->myFrontierList.pop_back();
+            this->myFound.push_back(minimumInfo);
+            minimumInfo->visited = true;
+            const double effortDelta = this->getEffort(minEdge, vehicle, minimumInfo->leaveTime);
+            const double leaveTime = minimumInfo->leaveTime + this->getTravelTime(minEdge, vehicle, minimumInfo->leaveTime, effortDelta);
+
+            const double heuristic_remaining = 0;
+            if (heuristic_remaining == UNREACHABLE) {
+                continue;
+            }
+            const double heuristicEffort = minimumInfo->effort + effortDelta + heuristic_remaining;
+            // check all ways from the edge with the minimal length
+            for (const std::pair<const E*, const E*>& follower : minEdge->getViaSuccessors(vClass)) {
+                auto& followerInfo = this->myEdgeInfos[follower.first->getNumericalID()];
+                // check whether it can be used
+                if (followerInfo.prohibited || this->isProhibited(follower.first, vehicle)) {
+                    continue;
+                }
+                double effort = minimumInfo->effort + effortDelta;
+                double time = leaveTime;
+                this->updateViaEdgeCost(follower.second, vehicle, time, effort, length);
+                const double oldEffort = followerInfo.effort;
+                if ((!followerInfo.visited) && effort < oldEffort) {
+                    followerInfo.effort = effort;
+                    // if we use the effort including the via effort below we would count the via twice as shown by the ticket676 test
+                    // but we should never get below the real effort, see #12463
+                    followerInfo.heuristicEffort = MAX2(MIN2(heuristicEffort, followerInfo.heuristicEffort), effort);
+                    followerInfo.leaveTime = time;
+                    followerInfo.prev = minimumInfo;
+                    if (oldEffort == std::numeric_limits<double>::max()) {
+                        this->myFrontierList.push_back(&followerInfo);
+                        std::push_heap(this->myFrontierList.begin(), this->myFrontierList.end(), this->myComparator);
+                    } else {
+                        auto fi = std::find(this->myFrontierList.begin(), this->myFrontierList.end(), &followerInfo);
+                        assert(fi != this->myFrontierList.end());
+                        std::push_heap(this->myFrontierList.begin(), fi + 1, this->myComparator);
+                    }
+                }
+            }
+        }
+        this->endQuery(num_visited);
+        for (const E* to : toEdges) {
+            const auto& toInfo = this->myEdgeInfos[to->getNumericalID()];
+            if (toInfo.visited) {
+                if (!silent) {
+                    this->myErrorMsgHandler->informf("Only some connections between node '%' and the given edges were found.", fromNode->getID());
+                }
+                return true; // at least one connection could be found
+            }
+        }
+        if (!silent) {
+            this->myErrorMsgHandler->informf("No connections between node '%' and the given edges were found.", fromNode->getID());
+        }
+        return false;
+    }
+
+    /** @brief Builds the route between the given node and edge using the minimum travel time
+     * @param[in] fromNode The node the route starts with
+     * @param[in] to The edge at which the route ends
+     * @param[in] vehicle The vehicle
+     * @param[in] msTime The start time of the route in milliseconds
+     * @param[out] into The vector of edges, into which the solution route is written
+     * @param[in] silent The boolean flag indicating whether the method stays silent or puts out messages
+     */
+    bool computeNode2Edge(const N* fromNode, const E* to, const V* const vehicle,
+        SUMOTime msTime, std::vector<const E*>& into, bool silent = false) {
+        assert(fromNode != nullptr && to != nullptr);
+        // check whether fromNode and to can be used
+        bool found = false;
+        for (const E* from : fromNode->getOutgoing()) {
+            if (from->isInternal()) {
+                continue;
+            }
+            if (this->myEdgeInfos[from->getNumericalID()].prohibited || this->isProhibited(from, vehicle)) {
+                if (!silent) {
+                    this->myErrorMsgHandler->inform("Vehicle '" + Named::getIDSecure(vehicle) + "' is not allowed on source edge '" + from->getID() + "'.");
+                }
+            }
+            else {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            return false;
+        }
+        const std::vector<const E*>& fromEdges = fromNode->getOutgoing();
+
+        if (fromEdges.empty()) { // nothing to do here
+            return false;
+        }
+        if (this->myEdgeInfos[to->getNumericalID()].prohibited || this->isProhibited(to, vehicle)) {
+            if (!silent) {
+                this->myErrorMsgHandler->inform("Vehicle '" + Named::getIDSecure(vehicle) + "' is not allowed on destination edge '" + to->getID() + "'.");
+            }
+            return false;
+        }
+        double length = 0.; // dummy for the via edge cost update
+        this->startQuery();
+
+        const SUMOVehicleClass vClass = vehicle == 0 ? SVC_IGNORING : vehicle->getVClass();
+        init(fromEdges, vehicle, msTime);
+        this->myAmClean = false;
+        // loop
+        int num_visited = 0;
+        const bool mayRevisit = this->myLookupTable != nullptr && !this->myLookupTable->consistent();
+        const double speed = vehicle == nullptr ? this->myMaxSpeed : MIN2(vehicle->getMaxSpeed(), this->myMaxSpeed * vehicle->getChosenSpeedFactor());
+        while (!this->myFrontierList.empty()) {
+            num_visited += 1;
+            // use the edge with the minimal length
+            auto* const minimumInfo = this->myFrontierList.front();
+            const E* const minEdge = minimumInfo->edge;
+            // check whether the destination edge was already reached
+            if (minEdge == to) {
+                this->buildPathFrom(minimumInfo, into);
+                this->endQuery(num_visited);
+                return true;
+            }
+            std::pop_heap(this->myFrontierList.begin(), this->myFrontierList.end(), this->myComparator);
+            this->myFrontierList.pop_back();
+            this->myFound.push_back(minimumInfo);
+            minimumInfo->visited = true;
+            const double effortDelta = this->getEffort(minEdge, vehicle, minimumInfo->leaveTime);
+            const double leaveTime = minimumInfo->leaveTime + this->getTravelTime(minEdge, vehicle, minimumInfo->leaveTime, effortDelta);
+
+            // admissible A* heuristic: straight line distance at maximum speed
+            // this is calculated from the end of minEdge so it possibly includes via efforts to the followers
+            const double heuristic_remaining = (this->myLookupTable == nullptr ? minEdge->getDistanceTo(to) / speed :
+                this->myLookupTable->lowerBound(minEdge, to, speed, vehicle->getChosenSpeedFactor(),
+                    minEdge->getMinimumTravelTime(nullptr), to->getMinimumTravelTime(nullptr)));
+            //const double heuristic_remaining = 0.;
+            if (heuristic_remaining == UNREACHABLE) {
+                continue;
+            }
+            const double heuristicEffort = minimumInfo->effort + effortDelta + heuristic_remaining;
+            // check all ways from the edge with the minimal length
+            for (const std::pair<const E*, const E*>& follower : minEdge->getViaSuccessors(vClass)) {
+                auto& followerInfo = this->myEdgeInfos[follower.first->getNumericalID()];
+                // check whether it can be used
+                if (followerInfo.prohibited || this->isProhibited(follower.first, vehicle)) {
+                    continue;
+                }
+                double effort = minimumInfo->effort + effortDelta;
+                double time = leaveTime;
+                this->updateViaEdgeCost(follower.second, vehicle, time, effort, length);
+                const double oldEffort = followerInfo.effort;
+                if ((!followerInfo.visited || mayRevisit) && effort < oldEffort) {
+                    followerInfo.effort = effort;
+                    // if we use the effort including the via effort below we would count the via twice as shown by the ticket676 test
+                    // but we should never get below the real effort, see #12463
+                    followerInfo.heuristicEffort = MAX2(MIN2(heuristicEffort, followerInfo.heuristicEffort), effort);
+                    followerInfo.leaveTime = time;
+                    followerInfo.prev = minimumInfo;
+                    if (oldEffort == std::numeric_limits<double>::max()) {
+                        this->myFrontierList.push_back(&followerInfo);
+                        std::push_heap(this->myFrontierList.begin(), this->myFrontierList.end(), this->myComparator);
+                    }
+                    else {
+                        auto fi = std::find(this->myFrontierList.begin(), this->myFrontierList.end(), &followerInfo);
+                        if (fi == this->myFrontierList.end()) {
+                            assert(mayRevisit);
+                            this->myFrontierList.push_back(&followerInfo);
+                            std::push_heap(this->myFrontierList.begin(), this->myFrontierList.end(), this->myComparator);
+                        }
+                        else {
+                            std::push_heap(this->myFrontierList.begin(), fi + 1, this->myComparator);
+                        }
+                    }
+                }
+            }
+        }
+        this->endQuery(num_visited);
+        if (!silent) {
+            this->myErrorMsgHandler->informf("No connection between node '%' and edge '%' found.", fromNode->getID(), to->getID());
+        }
+        return false;
+    }
+
+    /** @brief Updates the via cost up to a given edge
+     * @param[in] prev The previous edge
+     * @param[in] e The given edge
+     * @param[in] v The vehicle
+     * @param[in,out] time The passed and updated start time in seconds
+     * @param[in,out] effort The passed and updated effort
+     * @param[in,out] length The passed and updated length
+     */
+    void updateViaCostUpToEdge(const E* const prev, const E* const e, const V* const v, double& time, double& effort, double& length) const;
+
+    /** @brief Returns the recomputed cost for traversing the given edges, excluding the last one
+     * @param[in] edges The vector of edges
+     * @param[in] v The vehicle
+     * @param[in] msTime The start time in milliseconds
+     * @param[in,out] lengthp The passed and updated length
+     */
+    double recomputeCostsNoLastEdge(const std::vector<const E*>& edges, const V* const v, SUMOTime msTime, double* lengthp = nullptr) const {
+        const E* lastEdge = edges.back();
+        double time = STEPS2TIME(msTime);
+        double effort = 0.;
+        double length = 0.;
+        if (lengthp == nullptr) {
+            lengthp = &length;
+        }
+        else {
+            *lengthp = 0.;
+        }
+        const E* prev = nullptr;
+        for (const E* const e : edges) {
+            if (e == lastEdge) {
+                break;
+            }
+            if (isProhibited(e, v)) {
+                return -1;
+            }
+            updateViaCost(prev, e, v, time, effort, *lengthp);
+            prev = e;
+        }
+        updateViaCostUpToEdge(prev, lastEdge, v, time, effort, *lengthp);
+        return effort;
+    }
+
+    /// @brief Bulk mode is not supported
+    virtual void setBulkMode(const bool mode) {
+        UNUSED_PARAMETER(mode);
+        throw std::runtime_error("Bulk mode is not supported by the node-to-edge router.");
+    }
+
+protected:
+    /** @brief Initialize the node-to-edge router
+     * @param[in] fromEdges The vector of start edges
+     * @param[in] vehicle The vehicle
+     * @param[in] msTime The start time in milliseconds
+     */
+    void init(std::vector<const E*> fromEdges, const V* const vehicle, const SUMOTime msTime);
+};
+
+// ===========================================================================
+// method definitions
+// ===========================================================================
+
+template<class E, class N, class V>
+void Node2EdgeRouter<E, N, V>::updateViaCostUpToEdge(const E* const prev, const E* const e, const V* const v, double& time, double& effort, double& length) const {
+    assert(prev && e);
+    for (const std::pair<const E*, const E*>& follower : prev->getViaSuccessors()) {
+        if (follower.first == e) {
+            updateViaEdgeCost(follower.second, v, time, effort, length);
+            break;
+        }
+    }
+}
+
+template<class E, class N, class V>
+void Node2EdgeRouter<E, N, V>::init(std::vector<const E*> fromEdges, const V* const vehicle, const SUMOTime msTime) {
+    // all EdgeInfos touched in the previous query are either in myFrontierList or myFound: clean those up
+    for (auto& edgeInfo : this->myFrontierList) {
+        edgeInfo->reset();
+    }
+    this->myFrontierList.clear();
+    for (auto& edgeInfo : this->myFound) {
+        edgeInfo->reset();
+    }
+    this->myFound.clear();
+    for (const E* from : fromEdges) {
+        if (from->isInternal()) {
+            continue;
+        }
+        int edgeID = from->getNumericalID();
+        auto& fromInfo = this->myEdgeInfos[edgeID];
+        if (fromInfo.prohibited || this->isProhibited(from, vehicle)) {
+            continue;
+        }
+        fromInfo.effort = 0.;
+        fromInfo.heuristicEffort = 0.;
+        fromInfo.prev = nullptr;
+        fromInfo.leaveTime = STEPS2TIME(msTime);
+        this->myFrontierList.push_back(&fromInfo);
+    }
+}
+

--- a/src/utils/router/ReversedEdge.h
+++ b/src/utils/router/ReversedEdge.h
@@ -13,6 +13,7 @@
 /****************************************************************************/
 /// @file    ReversedEdge.h
 /// @author  Michael Behrisch
+/// @author  Ruediger Ebendt
 /// @date    29.01.2020
 ///
 // The ReversedEdge is a wrapper around a ROEdge or a MSEdge used for
@@ -48,6 +49,11 @@ public:
                 revSource->myViaSuccessors.push_back(std::make_pair(this, preVia));
             }
         }
+    }
+
+    /// @brief Returns the original edge
+    const E* getOriginalEdge() const {
+        return myOriginal;
     }
 
     /** @brief Returns the index (numeric id) of the edge


### PR DESCRIPTION
Edge-based implementation of "Fast Point-to-Point Shortest Path Computation with Arc-Flags" by Hilger et al.
It is a multi-level, uni-directional arc flag routing method, sometimes also called 'stripped SHARC' (the multi-level part is worked out in more detail in e.g. "SHARC: Fast and Robust Unidirectional routing" by Bauer and Delling).

Could probably be used standalone, or as starting point for a full implementation of SHARC.
 
All files starting with AF* are specialized classes dedicated to the (a)rc (f)lag routing method. This opposes to the naming of some other, more generic helper classes which could also be of use elsewhere: 

- Classes for flipped edges/nodes , where (in contrast to ReversedEdge) also the roles of incoming and outgoing edges of a node/junction are swapped, in order to achieve a full backward graph
- A class for median-based k-d tree partitioning of nodes/junctions (for storing/organizing them, and with a lookup method)