### PR TITLE
Add a function to TL code to search for specific detectors

### DIFF
--- a/src/microsim/MSVehicle.cpp
+++ b/src/microsim/MSVehicle.cpp
@@ -2676,8 +2676,9 @@ MSVehicle::planMoveInternal(const SUMOTime t, MSLeaderInfo ahead, DriveItemVecto
         }
         laneStopOffset = MAX2(POSITION_EPS, laneStopOffset);
         double stopDist = MAX2(0., seen - laneStopOffset);
-        if (yellowOrRed && getDevice(typeid(MSDevice_GLOSA)) != nullptr &&
-            static_cast<MSDevice_GLOSA*>(getDevice(typeid(MSDevice_GLOSA)))->getOverrideSafety()) {
+        if (yellowOrRed && getDevice(typeid(MSDevice_GLOSA)) != nullptr
+            && static_cast<MSDevice_GLOSA*>(getDevice(typeid(MSDevice_GLOSA)))->getOverrideSafety()
+            && static_cast<MSDevice_GLOSA*>(getDevice(typeid(MSDevice_GLOSA)))->isSpeedAdviceActive()) {
             stopDist = std::numeric_limits<double>::max();
         }
         if (newStopDist != std::numeric_limits<double>::max()) {

--- a/src/microsim/traffic_lights/MSActuatedTrafficLightLogic.h
+++ b/src/microsim/traffic_lights/MSActuatedTrafficLightLogic.h
@@ -142,6 +142,9 @@ public:
     /// @brief retrieve all detectors used by this program
     std::map<std::string, double> getDetectorStates() const override;
 
+    /// @brief retrieve a specific detector used by this program
+    double getDetectorState(const std::string laneID) const override;
+
     /// @brief return all named conditions defined for this traffic light
     std::map<std::string, double> getConditions() const override;
 
@@ -284,6 +287,9 @@ protected:
 
     /// Whether the detectors shall be shown in the GUI
     bool myShowDetectors;
+
+    /// Whether all detectors shall be built
+    bool myBuildAllDetectors;
 
     /// Whether any of the phases has multiple targets
     bool myHasMultiTarget;

--- a/src/microsim/traffic_lights/MSDelayBasedTrafficLightLogic.cpp
+++ b/src/microsim/traffic_lights/MSDelayBasedTrafficLightLogic.cpp
@@ -267,6 +267,25 @@ MSDelayBasedTrafficLightLogic::setShowDetectors(bool show) {
     }
 }
 
+std::map<std::string, double>
+MSDelayBasedTrafficLightLogic::getDetectorStates() const {
+    std::map<std::string, double> result;
+    for (auto item : myLaneDetectors) {
+        result[item.second->getID()] = item.second->getCurrentVehicleNumber();
+    }
+    return result;
+}
 
+double
+MSDelayBasedTrafficLightLogic::getDetectorState(std::string laneID) const {
+    double result = 0.0;
+    for (auto item : myLaneDetectors) {
+        if (item.first->getID() == laneID) {
+            result = item.second->getCurrentVehicleNumber();
+            break;
+        }
+    }
+    return result;
+}
 
 /****************************************************************************/

--- a/src/microsim/traffic_lights/MSDelayBasedTrafficLightLogic.h
+++ b/src/microsim/traffic_lights/MSDelayBasedTrafficLightLogic.h
@@ -90,6 +90,12 @@ public:
 
     void setShowDetectors(bool show);
 
+    /// @brief retrieve all detectors used by this program
+    std::map<std::string, double> getDetectorStates() const override;
+
+    /// @brief retrieve a specific detector used by this program
+    double getDetectorState(const std::string laneID) const override;
+
 
 protected:
     /// @name "actuated" algorithm methods

--- a/src/microsim/traffic_lights/MSTrafficLightLogic.h
+++ b/src/microsim/traffic_lights/MSTrafficLightLogic.h
@@ -378,6 +378,11 @@ public:
         return std::map<std::string, double>();
     }
 
+    /// @brief return activation state of a specific detector that affect this traffic light
+    virtual double getDetectorState(const std::string) const {
+        return 0.0;
+    }
+
     /// @brief return all named conditions defined for this traffic light
     virtual std::map<std::string, double> getConditions() const {
         return std::map<std::string, double>();


### PR DESCRIPTION
3 Parts:
- Found a bug in a previous GLOSA commit
- With the param `build-all-detectors`, all detectors of actuated tls get built (delay_based tls always build all detectors)
- The function `getDetectorState` is used to find the corresponding detector of a specific lane/link (we will then use the command `myNextTLSLink->getTLLogic()->getDetectorState(myNextTLSLink->getLaneBefore()->getID())` in the GLOSA device)

solves #15219