### PR TITLE
fix(netdiff): Properly store generated shapes as additional files

### DIFF
--- a/src/netedit/tools/GNENetDiffTool.cpp
+++ b/src/netedit/tools/GNENetDiffTool.cpp
@@ -75,13 +75,13 @@ GNENetDiffTool::postProcessing() {
         }
         // load shapes
         if (myPythonToolsOptions.getBool("load-shapes-modified")) {
-            loadShapes(myPythonToolsOptions.getString("outprefix") + ".changed.shape.xml");
+            loadShapes(myPythonToolsOptions.getString("outprefix") + ".changed.shape.add.xml");
         }
         if (myPythonToolsOptions.getBool("load-shapes-added")) {
-            loadShapes(myPythonToolsOptions.getString("outprefix") + ".created.shape.xml");
+            loadShapes(myPythonToolsOptions.getString("outprefix") + ".created.shape.add.xml");
         }
         if (myPythonToolsOptions.getBool("load-shapes-deleted")) {
-            loadShapes(myPythonToolsOptions.getString("outprefix") + ".deleted.shape.xml");
+            loadShapes(myPythonToolsOptions.getString("outprefix") + ".deleted.shape.add.xml");
         }
     }
 }

--- a/tests/tools/config.tools
+++ b/tests/tools/config.tools
@@ -135,9 +135,9 @@ diff_xml:diff.xml
 created_sel:diff.created.sel.txt
 deleted_sel:diff.deleted.sel.txt
 changed_sel:diff.changed.sel.txt
-created_shapes:diff.created.shape.xml
-deleted_shapes:diff.deleted.shape.xml
-changed_shapes:diff.changed.shape.xml
+created_shapes:diff.created.shape.add.xml
+deleted_shapes:diff.deleted.shape.add.xml
+changed_shapes:diff.changed.shape.add.xml
 omnet:omnet.xml
 shawn:shawn.xml
 dri:test.dri

--- a/tools/net/netdiff.py
+++ b/tools/net/netdiff.py
@@ -675,9 +675,9 @@ def main(options):
         selectionOutputFiles.append(codecs.open(options.outprefix + '.deleted.sel.txt', 'w', 'utf-8'))
         selectionOutputFiles.append(codecs.open(options.outprefix + '.changed.sel.txt', 'w', 'utf-8'))
     if options.write_shapes:
-        shapeOutputFiles.append(codecs.open(options.outprefix + '.created.shape.xml', 'w', 'utf-8'))
-        shapeOutputFiles.append(codecs.open(options.outprefix + '.deleted.shape.xml', 'w', 'utf-8'))
-        shapeOutputFiles.append(codecs.open(options.outprefix + '.changed.shape.xml', 'w', 'utf-8'))
+        shapeOutputFiles.append(codecs.open(options.outprefix + '.created.shape.add.xml', 'w', 'utf-8'))
+        shapeOutputFiles.append(codecs.open(options.outprefix + '.deleted.shape.add.xml', 'w', 'utf-8'))
+        shapeOutputFiles.append(codecs.open(options.outprefix + '.changed.shape.add.xml', 'w', 'utf-8'))
         for f in shapeOutputFiles:
             sumolib.writeXMLHeader(f, "$Id$", "additional", options=options)  # noqa
 


### PR DESCRIPTION
This is a simple qol improvement for `netdiff`.
Created shape files will now be properly stored as "additionals".