### PR TITLE
Adding PERMIT simulator for platooning

### DIFF
--- a/docs/web/docs/Contributed/index.md
+++ b/docs/web/docs/Contributed/index.md
@@ -87,6 +87,11 @@ The following extensions are managed and supported by other parties.
 
 ## Other
 
+
+- [PERMIT](https://github.com/susomena/PERMIT)
+
+    A SUMO Simulator for Platooning Maneuvers in Mixed Traffic Scenarios
+  
 - [TraCI4Matlab](https://mathworks.com/matlabcentral/fileexchange/44805-traci4matlab)
 
     A Matlab interface for connecting and extending information via [TraCI](../TraCI.md)


### PR DESCRIPTION
An open-source repository for PERMIT, a platooning simulator based on the microscopic traffic simulator SUMO and its platooning extension Plexe. This simulator allows to simulate platooning maneuvers and driving in mixed traffic scenarios where automated and non-automated vehicles coexist. The different platooning maneuvers implemented in PERMIT are the join maneuver, the merge maneuver, the leave maneuver and the split maneuver.