### PR TITLE
Docker tutorial: Refer to latest stable image instead of bleeding-edge

### DIFF
--- a/docs/web/docs/Tutorials/Containerized_SUMO.md
+++ b/docs/web/docs/Tutorials/Containerized_SUMO.md
@@ -16,14 +16,14 @@ The way to do this is highly dependent on your individual setup, so we will not 
 You can either get the latest docker image from the SUMO docker registry by using
 
 ```shell
-  docker pull ghcr.io/eclipse-sumo/sumo:main
+  docker pull ghcr.io/eclipse-sumo/sumo:latest
 ```
 
 or build your own local version of the image by checking out the [SUMO repository](https://github.com/eclipse-sumo/sumo) and executing:
 
 ```shell
   cd build_config/docker
-  docker build -t ghcr.io/eclipse-sumo/sumo:main -f Dockerfile.ubuntu.git .
+  docker build -t ghcr.io/eclipse-sumo/sumo:latest -f Dockerfile.ubuntu.git .
 ```
 
 ## Creating simulation files
@@ -102,7 +102,7 @@ The command to start the container might look like this:
   docker run \
       --rm \
       -v $SIMULATION_FILES_DIR:$SIMULATION_FILES_DIR \
-      ghcr.io/eclipse-sumo/sumo:main \
+      ghcr.io/eclipse-sumo/sumo:latest \
       sumo --configuration-file $SIMULATION_FILES_DIR/hello.sumocfg --full-output $SIMULATION_FILES_DIR/result.xml
 ```
 


### PR DESCRIPTION
As suggested by/discussed with @behrisch in #16007 

Now the latest image works with the tutorial and therefore the stable image is preferrable to the potentially unstable one.

relates to #15861 