### PR TITLE
Removed lonely "T"

### DIFF
--- a/docs/web/docs/Simulation/Output/StatisticOutput.md
+++ b/docs/web/docs/Simulation/Output/StatisticOutput.md
@@ -107,7 +107,6 @@ The following output attributes are generated:
 | **totalTravelTime**    | s          | The total travel time of all vehicles |
 | **totalDepartDelay**   | s          | The total depart delay of all vehicles  |
 
-T
 
 ## pedestrianStatistics
 


### PR DESCRIPTION
This PR removes a lonely "T" from the statistics output documentation