### PR TITLE
Fix build failure with GDAL 3.12.0.

### DIFF
--- a/src/netbuild/NBHeightMapper.cpp
+++ b/src/netbuild/NBHeightMapper.cpp
@@ -196,7 +196,7 @@ NBHeightMapper::loadShapeFile(const std::string& file) {
 
     // triangle coordinates are stored in WGS84 and later matched with network coordinates in WGS84
     // build coordinate transformation
-    OGRSpatialReference* sr_src = layer->GetSpatialRef();
+    const OGRSpatialReference* sr_src = layer->GetSpatialRef();
     OGRSpatialReference sr_dest;
     sr_dest.SetWellKnownGeogCS("WGS84");
     OGRCoordinateTransformation* toWGS84 = OGRCreateCoordinateTransformation(sr_src, &sr_dest);

--- a/src/netimport/NIImporter_ArcView.cpp
+++ b/src/netimport/NIImporter_ArcView.cpp
@@ -143,7 +143,7 @@ NIImporter_ArcView::load() {
     poLayer->ResetReading();
 
     // build coordinate transformation
-    OGRSpatialReference* origTransf = poLayer->GetSpatialRef();
+    const OGRSpatialReference* origTransf = poLayer->GetSpatialRef();
     OGRSpatialReference destTransf;
     // use wgs84 as destination
     destTransf.SetWellKnownGeogCS("WGS84");

--- a/src/polyconvert/PCLoaderArcView.cpp
+++ b/src/polyconvert/PCLoaderArcView.cpp
@@ -147,7 +147,7 @@ PCLoaderArcView::load(const std::string& file, OptionsCont& oc, PCPolyContainer&
     poLayer->ResetReading();
 
     // build coordinate transformation
-    OGRSpatialReference* origTransf = poLayer->GetSpatialRef();
+    const OGRSpatialReference* origTransf = poLayer->GetSpatialRef();
     OGRSpatialReference destTransf;
     // use wgs84 as destination
     destTransf.SetWellKnownGeogCS("WGS84");


### PR DESCRIPTION
Fixes:
```
/build/sumo-1.24.0+dfsg1/src/netimport/NIImporter_ArcView.cpp: In member function 'void NIImporter_ArcView::load()':
/build/sumo-1.24.0+dfsg1/src/netimport/NIImporter_ArcView.cpp:146:61: error: invalid conversion from 'const OGRSpatialReference*' to 'OGRSpatialReference*' [-fpermissive]
  146 |     OGRSpatialReference* origTransf = poLayer->GetSpatialRef();
      |                                       ~~~~~~~~~~~~~~~~~~~~~~^~
      |                                                             |
      |                                                             const OGRSpatialReference*
```

From [MIGRATION_GUIDE.TXT](https://github.com/OSGeo/gdal/blob/master/MIGRATION_GUIDE.TXT):
> * OGRLayer::GetSpatialRef() is now a const method that returns a const OGRSpatialReference*