### PR TITLE
add/NOx-noise-to-fcd

### DIFF
--- a/docs/web/docs/Simulation/Output/FCDOutput.md
+++ b/docs/web/docs/Simulation/Output/FCDOutput.md
@@ -77,8 +77,20 @@ The values without a tick in the "On" column need to be [enabled explicitly](#fu
 | blockTime | m                   |    |  x   | The time at which the vehicle was blocked from leaving the current segment (or -1 if not blocked)           |
 | tag | string                    |    |      | Whether a vehicle, container or person is being written (mainly useful for tabular output)           |
 
+### Emission Attributes
+
 All attributes from the [emission output](EmissionOutput.md) can be added to the FCD output as well.
 They need to be enabled by using the option **--fcd-output.attributes**, see below.
+
+```xml
+<configuration>
+  ...
+  <output>
+    <fcd-output.attributes value="eclass,CO2,CO,HC,NOx,PMx,fuel,electricity,noise"/>
+  </output>
+  ...
+</configuration>
+```
 
 When the option **--fcd-output.geo** is set, the written (x,y)-coordinates will be the
 lon/lat geo-coordinates.

--- a/src/microsim/devices/MSDevice_FCD.cpp
+++ b/src/microsim/devices/MSDevice_FCD.cpp
@@ -192,9 +192,11 @@ MSDevice_FCD::initOnce() {
     emissions.set(SUMO_ATTR_CO2);
     emissions.set(SUMO_ATTR_CO);
     emissions.set(SUMO_ATTR_HC);
+    emissions.set(SUMO_ATTR_NOX);
     emissions.set(SUMO_ATTR_PMX);
     emissions.set(SUMO_ATTR_FUEL);
     emissions.set(SUMO_ATTR_ELECTRICITY);
+    emissions.set(SUMO_ATTR_NOISE);
     SumoXMLAttrMask misc;
     misc.set(SUMO_ATTR_SIGNALS);
     misc.set(SUMO_ATTR_ACCELERATION);


### PR DESCRIPTION
If I am not wrong the fcd-ouput supports emission outputs as well,. but somehow NOx and Noise were not included. I added these missing attributes and modified the docs accordingly.