### PR TITLE
Missing installation commands in the test setup document

### DIFF
--- a/docs/web/docs/Developer/Tests.md
+++ b/docs/web/docs/Developer/Tests.md
@@ -65,7 +65,6 @@ sudo apt-get install meld geany
 **On Windows:**
 
 Download and install from
-[Meld project page](https://meldmerge.org/) and
 [Geany project page](https://www.geany.org/) by following the provided installation instructions.
 
 After installing these tools, you need to configure TextTest to use them by creating or editing `$HOME/.texttest/config` (see [Customize configuration](#customize-configuration) section below).


### PR DESCRIPTION
Documentation improvements:

* Added instructions to install recommended diff viewer (`tkdiff`) and text editor (`emacs`) using Homebrew, as well as alternatives and configuration tips, in `docs/web/docs/Developer/Tests.md`.

This pull request adds instructions to the developer testing documentation to help users set up recommended tools for viewing test results on macOS. The most important change is the addition of guidance for installing a diff viewer and text editor. With that addition, it will be easier for beginners to run the tests. (Based on my experience:)) 

Closes #17578 
