### PR TITLE
add speedRelative to fcd-output

### DIFF
--- a/data/xsd/fcd_file.xsd
+++ b/data/xsd/fcd_file.xsd
@@ -31,6 +31,7 @@
             <xsd:attribute name="type" type="xsd:string" use="optional"/>
 
             <xsd:attribute name="speed" type="nonNegativeFloatType" use="optional"/>
+            <xsd:attribute name="speedRelative" type="nonNegativeFloatType" use="optional"/>
             <xsd:attribute name="pos" type="nonNegativeFloatType" use="optional"/>
             <xsd:attribute name="lane" type="xsd:string" use="optional"/>
             <xsd:attribute name="edge" type="xsd:string" use="optional"/>
@@ -63,6 +64,7 @@
         <xsd:attribute name="type" use="optional" type="xsd:string"/>
 
         <xsd:attribute name="speed" type="nonNegativeFloatType" use="optional"/>
+        <xsd:attribute name="speedRelative" type="nonNegativeFloatType" use="optional"/>
         <xsd:attribute name="pos" type="nonNegativeFloatType" use="optional"/>
         <xsd:attribute name="edge" type="xsd:string" use="optional"/>
         <xsd:attribute name="slope" type="floatType" use="optional"/>

--- a/src/microsim/MSFrame.cpp
+++ b/src/microsim/MSFrame.cpp
@@ -173,6 +173,8 @@ MSFrame::fillOptions() {
     oc.addDescription("fcd-output.distance", "Output", TL("Add kilometrage to the FCD output (linear referencing)"));
     oc.doRegister("fcd-output.acceleration", new Option_Bool(false));
     oc.addDescription("fcd-output.acceleration", "Output", TL("Add acceleration to the FCD output"));
+    oc.doRegister("fcd-output.speed-relative", new Option_Bool(false));
+    oc.addDescription("fcd-output.speed-relative", "Output", TL("Add relative speed (vehicle speed / edge speed limit) to the FCD output"));
     oc.doRegister("fcd-output.max-leader-distance", new Option_Float(-1));
     oc.addDescription("fcd-output.max-leader-distance", "Output", TL("Add leader vehicle information to the FCD output (within the given distance)"));
     oc.doRegister("fcd-output.params", new Option_StringVector());

--- a/src/microsim/devices/MSDevice_FCD.cpp
+++ b/src/microsim/devices/MSDevice_FCD.cpp
@@ -205,6 +205,7 @@ MSDevice_FCD::initOnce() {
     misc.set(SUMO_ATTR_ODOMETER);
     misc.set(SUMO_ATTR_POSITION_LAT);
     misc.set(SUMO_ATTR_SPEED_LAT);
+    misc.set(SUMO_ATTR_SPEEDREL);
     misc.set(SUMO_ATTR_LEADER_ID);
     misc.set(SUMO_ATTR_LEADER_SPEED);
     misc.set(SUMO_ATTR_ARRIVALDELAY);
@@ -234,6 +235,9 @@ MSDevice_FCD::initOnce() {
     myWrittenAttributes.set(SUMO_ATTR_ACCELERATION_LAT, myWrittenAttributes.test(SUMO_ATTR_ACCELERATION) && MSGlobals::gSublane);
     if (oc.getBool("fcd-output.distance")) {
         myWrittenAttributes.set(SUMO_ATTR_DISTANCE);
+    }
+    if (oc.getBool("fcd-output.speed-relative")) {
+        myWrittenAttributes.set(SUMO_ATTR_SPEEDREL);
     }
 
     if (oc.isSet("fcd-output.filter-shapes")) {

--- a/src/microsim/output/MSFCDExport.cpp
+++ b/src/microsim/output/MSFCDExport.cpp
@@ -106,6 +106,10 @@ MSFCDExport::write(OutputDevice& of, const SUMOTime timestep, const SumoXMLTag t
                 of.writeFuncAttr(SUMO_ATTR_SPEED, [ = ]() {
                     return veh->getSpeed();
                 }, mask);
+                of.writeFuncAttr(SUMO_ATTR_SPEEDREL, [ = ]() {
+                    const double speedLimit = veh->getEdge()->getSpeedLimit();
+                    return speedLimit > 0 ? veh->getSpeed() / speedLimit : 0.;
+                }, mask);
                 of.writeFuncAttr(SUMO_ATTR_POSITION, [ = ]() {
                     return veh->getPositionOnLane();
                 }, mask);
@@ -294,6 +298,7 @@ MSFCDExport::writeTransportable(OutputDevice& of, const MSEdge* const e, const M
     of.writeOptionalAttr(SUMO_ATTR_ANGLE, GeomHelper::naviDegree(p->getAngle()), mask);
     of.writeOptionalAttr(SUMO_ATTR_TYPE, p->getVehicleType().getID(), mask);
     of.writeOptionalAttr(SUMO_ATTR_SPEED, p->getSpeed(), mask);
+    of.writeOptionalAttr(SUMO_ATTR_SPEEDREL, e->getSpeedLimit() > 0 ? p->getSpeed() / e->getSpeedLimit() : 0., mask);
     of.writeOptionalAttr(SUMO_ATTR_POSITION, p->getEdgePos(), mask);
     of.writeOptionalAttr(SUMO_ATTR_LANE, "", mask, true);
     of.writeOptionalAttr(SUMO_ATTR_EDGE, e->getID(), mask);


### PR DESCRIPTION
Note: fallback for missing speedLimit is 0, which is not great when division by 0 happens; but I guess this is used somewhere else in the codebase and thus I stick to that