### PR TITLE
Traci: implementing totalPower getter and setter for charging stations

### DIFF
--- a/src/libsumo/ChargingStation.cpp
+++ b/src/libsumo/ChargingStation.cpp
@@ -121,6 +121,12 @@ ChargingStation::getChargeInTransit(const std::string& stopID) {
 }
 
 
+double
+ChargingStation::getTotalPower(const std::string& stopID) {
+    return dynamic_cast<MSChargingStation*>(getChargingStation(stopID))->getTotalChargingPower();
+}
+
+
 void
 ChargingStation::setChargingPower(const std::string& stopID, double power) {
     dynamic_cast<MSChargingStation*>(getChargingStation(stopID))->setChargingPower(power);
@@ -142,6 +148,12 @@ ChargingStation::setChargeDelay(const std::string& stopID, double delay) {
 void
 ChargingStation::setChargeInTransit(const std::string& stopID, bool inTransit) {
     dynamic_cast<MSChargingStation*>(getChargingStation(stopID))->setChargeInTransit(inTransit);
+}
+
+
+void
+ChargingStation::setTotalPower(const std::string& stopID, double totalPower) {
+    dynamic_cast<MSChargingStation*>(getChargingStation(stopID))->setTotalChargingPower(totalPower);
 }
 
 
@@ -198,9 +210,11 @@ ChargingStation::handleVariable(const std::string& objID, const int variable, Va
         case VAR_CS_EFFICIENCY:
             return wrapper->wrapDouble(objID, variable, getEfficiency(objID));
         case VAR_CS_CHARGE_DELAY:
-            return wrapper->wrapDouble(objID, variable, STEPS2TIME(getChargeDelay(objID)));
+            return wrapper->wrapDouble(objID, variable, getChargeDelay(objID));
         case VAR_CS_CHARGE_IN_TRANSIT:
             return wrapper->wrapInt(objID, variable, getChargeInTransit(objID));
+        case VAR_CS_TOTAL_POWER:
+            return wrapper->wrapDouble(objID, variable, getTotalPower(objID));
         case libsumo::VAR_PARAMETER:
             paramData->readUnsignedByte();
             return wrapper->wrapString(objID, variable, getParameter(objID, paramData->readString()));

--- a/src/libsumo/ChargingStation.h
+++ b/src/libsumo/ChargingStation.h
@@ -50,6 +50,7 @@ public:
     static double getEfficiency(const std::string& stopID);
     static double getChargeDelay(const std::string& stopID);
     static int getChargeInTransit(const std::string& stopID);
+    static double getTotalPower(const std::string& stopID);
 
     LIBSUMO_ID_PARAMETER_API
     LIBSUMO_SUBSCRIPTION_API
@@ -58,6 +59,7 @@ public:
     static void setEfficiency(const std::string& stopID, double efficiency);
     static void setChargeDelay(const std::string& stopID, double delay);
     static void setChargeInTransit(const std::string& stopID, bool inTransit);
+    static void setTotalPower(const std::string& stopID, double totalPower);
 
 #ifndef LIBTRACI
 #ifndef SWIG

--- a/src/libsumo/TraCIConstants.h
+++ b/src/libsumo/TraCIConstants.h
@@ -1479,6 +1479,9 @@ TRACI_CONST int VAR_CS_CHARGE_DELAY = 0x9a;
 // parking area access permissions
 TRACI_CONST int VAR_ACCESS_BADGE = 0x9b;
 
+// charging station total power
+TRACI_CONST int VAR_CS_TOTAL_POWER = 0x9c;
+
 } // namespace libsumo
 
 #undef TRACI_CONST

--- a/src/microsim/trigger/MSChargingStation.cpp
+++ b/src/microsim/trigger/MSChargingStation.cpp
@@ -130,6 +130,12 @@ MSChargingStation::getParkingArea() const {
 }
 
 
+double
+MSChargingStation::getTotalChargingPower() const {
+    return myTotalChargingPower;
+}
+
+
 void
 MSChargingStation::setChargingPower(double chargingPower) {
     myNominalChargingPower = chargingPower;
@@ -162,6 +168,20 @@ void
 MSChargingStation::setChargingVehicle(bool value) {
     myChargingVehicle = value;
     if (myTotalChargingPower > 0 && myChargingVehicle && myTotalPowerCheckEvent == nullptr) {
+        myTotalPowerCheckEvent = new WrappingCommand<MSChargingStation>(this, &MSChargingStation::checkTotalPower);
+        MSNet::getInstance()->getEndOfTimestepEvents()->addEvent(myTotalPowerCheckEvent);
+    }
+}
+
+
+void
+MSChargingStation::setTotalChargingPower(double totalPower) {
+    if (totalPower <= 0) {
+        return;
+    }
+    const bool hadLimit = myTotalChargingPower > 0;
+    myTotalChargingPower = totalPower;
+    if (!hadLimit && (myChargeInTransit || myChargingVehicle) && myTotalPowerCheckEvent == nullptr) {
         myTotalPowerCheckEvent = new WrappingCommand<MSChargingStation>(this, &MSChargingStation::checkTotalPower);
         MSNet::getInstance()->getEndOfTimestepEvents()->addEvent(myTotalPowerCheckEvent);
     }

--- a/src/microsim/trigger/MSChargingStation.h
+++ b/src/microsim/trigger/MSChargingStation.h
@@ -137,6 +137,12 @@ public:
     /// @brief set charging in transit
     void setChargeInTransit(bool value);
 
+    /// @brief Get charging station's total power
+    double getTotalChargingPower() const;
+
+    /// @brief set charging station's total power
+    void setTotalChargingPower(double totalPower);
+
     /// @brief enable or disable charging vehicle
     void setChargingVehicle(bool value);
 

--- a/src/traci-server/TraCIServerAPI_ChargingStation.cpp
+++ b/src/traci-server/TraCIServerAPI_ChargingStation.cpp
@@ -41,7 +41,8 @@ TraCIServerAPI_ChargingStation::processSet(TraCIServer& server, tcpip::Storage& 
             variable != libsumo::VAR_CS_POWER &&
             variable != libsumo::VAR_CS_EFFICIENCY &&
             variable != libsumo::VAR_CS_CHARGE_DELAY &&
-            variable != libsumo::VAR_CS_CHARGE_IN_TRANSIT) {
+            variable != libsumo::VAR_CS_CHARGE_IN_TRANSIT &&
+            variable != libsumo::VAR_CS_TOTAL_POWER) {
         return server.writeErrorStatusCmd(libsumo::CMD_SET_CHARGINGSTATION_VARIABLE, "Change ChargingStation State: unsupported variable " + toHex(variable, 2) + " specified", outputStorage);
     }
     // id
@@ -71,6 +72,10 @@ TraCIServerAPI_ChargingStation::processSet(TraCIServer& server, tcpip::Storage& 
             break;
             case libsumo::VAR_CS_CHARGE_IN_TRANSIT: {
                 libsumo::ChargingStation::setChargeInTransit(id, StoHelp::readTypedInt(inputStorage, "Setting charge in transit requires an integer.") != 0);
+            }
+            break;
+            case libsumo::VAR_CS_TOTAL_POWER: {
+                libsumo::ChargingStation::setTotalPower(id, StoHelp::readTypedDouble(inputStorage, "Setting totalPower requires a double."));
             }
             break;
             default:

--- a/tools/traci/_chargingstation.py
+++ b/tools/traci/_chargingstation.py
@@ -99,6 +99,13 @@ class ChargingStationDomain(Domain):
         """
         return self._getUniversal(tc.VAR_CS_CHARGE_IN_TRANSIT, stopID)
 
+    def getTotalPower(self, stopID):
+        """getTotalPower(string) -> double
+
+        Get the total charging power limit for all vehicles.
+        """
+        return self._getUniversal(tc.VAR_CS_TOTAL_POWER, stopID)
+
     def setChargingPower(self, stopID, power):
         """setChargingPower(string, double) -> None
 
@@ -121,8 +128,15 @@ class ChargingStationDomain(Domain):
         self._setCmd(tc.VAR_CS_CHARGE_DELAY, stopID, "d", delay)
 
     def setChargeInTransit(self, stopID, inTransit):
-        """setEfficiency(string, integer) -> None
+        """setChargeInTransit(string, integer) -> None
 
         Sets whether this charging station allows charging while still driving (0=no, 1=yes).
         """
         self._setCmd(tc.VAR_CS_CHARGE_IN_TRANSIT, stopID, "i", inTransit)
+
+    def setTotalPower(self, stopID, totalPower):
+        """setTotalPower(string, double) -> None
+
+        Sets the total charging power limit for all vehicles in this charging station.
+        """
+        self._setCmd(tc.VAR_CS_TOTAL_POWER, stopID, "d", totalPower)

--- a/tools/traci/constants.py
+++ b/tools/traci/constants.py
@@ -1460,6 +1460,9 @@ VAR_CS_CHARGE_DELAY = 0x9a
 #  parking area access permissions
 VAR_ACCESS_BADGE = 0x9b
 
+#  charging station total power
+VAR_CS_TOTAL_POWER = 0x9c
+
 # @name currently wanted lane-change action
 # @{
 # @brief No action desired


### PR DESCRIPTION
Following the recent integration of the `totalPower` limit for `ChargingStations`, this PR implements the corresponding **TraCI getter and setter** methods.

These APIs allow users to dynamically retrieve and modify the total power limit of a charging station during the simulation, which is essential for implementing external smart-charging controllers or power grid management scripts.

**Changes:**
- **C++ Core**: Added `getTotalChargingPower` and `setTotalChargingPower` to `MSChargingStation`.
- **Libsumo/TraCI**: Implemented `VAR_CS_TOTAL_POWER` (0x9c) in `TraCIConstants.h` and updated `ChargingStation` wrappers.
- **Python API**: Added `getTotalPower` and `setTotalPower` methods to the `ChargingStation` domain in the `traci` Python library.