### PR TITLE
free decal CPU image after GPU upload to avoid double memory usage

### DIFF
--- a/src/utils/gui/settings/GUICompleteSchemeStorage.cpp
+++ b/src/utils/gui/settings/GUICompleteSchemeStorage.cpp
@@ -235,7 +235,6 @@ GUICompleteSchemeStorage::saveDecals(const std::vector<GUISUMOAbstractView::Deca
         // reset GPU resource handles
         d.initialised = false;
         d.glID = -1;
-        d.image = nullptr;
     }
 }
 

--- a/src/utils/gui/windows/GUISUMOAbstractView.cpp
+++ b/src/utils/gui/windows/GUISUMOAbstractView.cpp
@@ -171,10 +171,6 @@ GUISUMOAbstractView::~GUISUMOAbstractView() {
         makeNonCurrent();
     }
 
-    // cleanup decals
-    for (auto& decal : myDecals) {
-        delete decal.image;
-    }
     // remove all elements
     for (auto& additional : myAdditionallyDrawn) {
         additional.first->removeActiveAddVisualisation(this, ~0);
@@ -1769,8 +1765,6 @@ GUISUMOAbstractView::clearDecals() {
             queueTextureDelete(static_cast<unsigned int>(decal.glID));
             decal.glID = -1;
         }
-        delete decal.image;
-        decal.image = nullptr;
         decal.initialised = false;
     }
     myDecals.clear();

--- a/src/utils/gui/windows/GUISUMOAbstractView.cpp
+++ b/src/utils/gui/windows/GUISUMOAbstractView.cpp
@@ -1879,8 +1879,8 @@ GUISUMOAbstractView::drawDecals() {
                 }
                 MFXImageHelper::scalePower2(img, GUITexturesHelper::getMaxTextureSize());
                 decal.glID = GUITexturesHelper::add(img);
+                delete img;
                 decal.initialised = true;
-                decal.image = img;
             } catch (InvalidArgument& e) {
                 WRITE_ERROR("Could not load '" + decal.filename + "'.\n" + e.what());
                 decal.skip2D = true;

--- a/src/utils/gui/windows/GUISUMOAbstractView.h
+++ b/src/utils/gui/windows/GUISUMOAbstractView.h
@@ -417,8 +417,6 @@ public:
         /// @brief whether the decal shall be drawn in screen coordinates, rather than network coordinates
         int glID = -1;
 
-        /// @brief The image pointer for later cleanup
-        FXImage* image = nullptr;
     };
 
     /// @brief The list of decals to show


### PR DESCRIPTION
Decal textures were kept in CPU RAM (via decal.image) after being uploaded to GPU VRAM, causing 2x memory usage per decals lifetime.
The CPU copy was never used after upload, so it has been dead code ever since (including the clean-up of it).

Delete the FXImage immediately after glTexImage2D upload, matching the pattern already used by GUITexturesHelper::getTextureID().