### PR TITLE
fix: replace 122 bare except clauses with except Exception

### DIFF
--- a/tools/contributed/hybridPY/agilepy/lib_base/classman.py
+++ b/tools/contributed/hybridPY/agilepy/lib_base/classman.py
@@ -62,7 +62,7 @@ def save_obj(obj,filename, is_not_save_parent=False):
     #print 'save_obj',is_not_save_parent,filename,obj.parent
     try:
         f=open(filename,'wb')
-    except:
+    except Exception:
         print('WARNING in save: could not open',filename)
         return False
     
@@ -93,7 +93,7 @@ def load_obj(filename,parent=None, is_throw_error = False):
     else:
         try:
             f=open(filename,'rb')
-        except:
+        except Exception:
             print('WARNING in load_obj: could not open',filename)
             return None
     

--- a/tools/contributed/hybridPY/agilepy/lib_base/exports.py
+++ b/tools/contributed/hybridPY/agilepy/lib_base/exports.py
@@ -15,7 +15,7 @@ try:
     IS_EXCEL = True
     
     
-except:
+except Exception:
     print('WARNING: No Exel export possible. Install openpyxl python package.')
     IS_EXCEL = False
 

--- a/tools/contributed/hybridPY/agilepy/lib_base/geometry.py
+++ b/tools/contributed/hybridPY/agilepy/lib_base/geometry.py
@@ -3,7 +3,7 @@ import math
 try:
     from shapely.geometry import MultiPoint, Polygon, Point, LineString
     IS_SHAPELY = True                              
-except:
+except Exception:
     IS_SHAPELY = False
  
 

--- a/tools/contributed/hybridPY/agilepy/lib_base/processes.py
+++ b/tools/contributed/hybridPY/agilepy/lib_base/processes.py
@@ -146,7 +146,7 @@ class Process(cm.BaseObjman):
         
         try:
             f=open(filepath,'wb')
-        except:
+        except Exception:
             print('WARNING in save: could not open',filepath)
             return False
         
@@ -159,7 +159,7 @@ class Process(cm.BaseObjman):
     def load_options(self, filepath):
         try:
             f=open(filepath,'rb')
-        except:
+        except Exception:
             print('WARNING in load_options: could not open',filepath)
             return None
     

--- a/tools/contributed/hybridPY/agilepy/lib_base/xmlman.py
+++ b/tools/contributed/hybridPY/agilepy/lib_base/xmlman.py
@@ -10,7 +10,7 @@ def write_obj_to_xml(   obj, filepath,
     """
     try:
         fd=open(filepath,'w', encoding="utf-8")
-    except:
+    except Exception:
         print('WARNING in write_obj_to_xml: could not open',filepath)
         return False
     fd.write('<?xml version="1.0" encoding="%s"?>\n'%encoding)

--- a/tools/contributed/hybridPY/agilepy/lib_wx/objpanel.py
+++ b/tools/contributed/hybridPY/agilepy/lib_wx/objpanel.py
@@ -7,7 +7,7 @@ if  __name__ == '__main__':
     # search hybridPY in local directory (where this file is located)
     try:
         APPDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         APPDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
     sys.path.append(os.path.join(APPDIR,'..','..'))
 
@@ -143,7 +143,7 @@ def str_to_obj(s):
     else:
         try:
             return float(s)
-        except:
+        except Exception:
             return s
 
 def str_to_obj_nested(s):
@@ -165,7 +165,7 @@ def str_to_obj_nested(s):
             else:
                 try:
                     return float(s)
-                except:
+                except Exception:
                     return s
         else:
             return x
@@ -932,7 +932,7 @@ class ChoiceWidgetContainer(WidgetContainer):
         try:
             #ind = self._choicenames.index(value)
             ind = self._choicevalues.index(val)
-        except:
+        except Exception:
             print('WARNING in ChoiceWidgetContainer.set_widgetvalue: %s with value "%s" not in choice list'%(self._attrconf.attrname,val))
             return
         #print '  ind',ind,self.valuewidget 

--- a/tools/contributed/hybridPY/agilepy/lib_wx/ogleditor.py
+++ b/tools/contributed/hybridPY/agilepy/lib_wx/ogleditor.py
@@ -45,7 +45,7 @@ import sys, os, types
 if  __name__ == '__main__':
     try:
         FILEDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         FILEDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
     sys.path.append(os.path.join(FILEDIR,"..",".."))
     #IMAGEDIR = os.path.join(APPDIR,"lib_base","images")
@@ -4828,7 +4828,7 @@ class OGLcanvas(glcanvas.GLCanvas):
             self.SetCurrent(self.context)
             self.OnDraw(*args, **kwargs)
             #print 'draw',self.lastx,self.lasty,self.x,self.y
-        except:
+        except Exception:
             print('WARNING in draw: unable to set context, will draw in a later call...')
             
                         

--- a/tools/contributed/hybridPY/agilepy/lib_wx/test_app.py
+++ b/tools/contributed/hybridPY/agilepy/lib_wx/test_app.py
@@ -11,7 +11,7 @@ from wx.lib.wordwrap import wordwrap
 if  __name__ == '__main__':
     try:
         APPDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         APPDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
     AGILEDIR = os.path.join(APPDIR,'..')
     print('APPDIR,AGILEDIR',APPDIR,AGILEDIR)

--- a/tools/contributed/hybridPY/agilepy/lib_wx/test_glcanvas.py
+++ b/tools/contributed/hybridPY/agilepy/lib_wx/test_glcanvas.py
@@ -792,7 +792,7 @@ class WxGLTest_orig(glcanvas.GLCanvas):
 
         try:
             width, height = event.GetSize()
-        except:
+        except Exception:
             width = event.GetSize().width
             height = event.GetSize().height
         

--- a/tools/contributed/hybridPY/agilepy/lib_wx/toolbox.py
+++ b/tools/contributed/hybridPY/agilepy/lib_wx/toolbox.py
@@ -2,7 +2,7 @@ import sys,os, string,time
 if  __name__ == '__main__':
     try:
         FILEDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         FILEDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
     sys.path.append(os.path.join(FILEDIR,"..",".."))
 

--- a/tools/contributed/hybridPY/agilepy/lib_wx/wxmisc.py
+++ b/tools/contributed/hybridPY/agilepy/lib_wx/wxmisc.py
@@ -886,7 +886,7 @@ def get_bitmap(name, size=22):
         name = name + "_"+str(size)
         try:
             return imgImages.catalog[ name ].getBitmap()
-        except:
+        except Exception:
             print('WARNING in get_bitmap: failed to return image',name)
             return wx.NullBitmap
            

--- a/tools/contributed/hybridPY/coremodules/demand/demand.py
+++ b/tools/contributed/hybridPY/coremodules/demand/demand.py
@@ -5,7 +5,7 @@ import time
 if  __name__ == '__main__':
     try:
         APPDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         APPDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
     hybridPYDIR = os.path.join(APPDIR,'..','..')
     sys.path.append(hybridPYDIR)
@@ -38,11 +38,11 @@ try:
     try:
         import pyproj
         is_pyproj = True
-    except:
+    except Exception:
         from mpl_toolkits.basemap import pyproj
         is_pyproj = True
 
-except:
+except Exception:
     is_pyproj = False
 
 class Trips(TripsBase):
@@ -219,7 +219,7 @@ class Demand(cm.BaseObjman):
             try:
                 fd = open(filepath,'r', encoding="utf-8")
                 fd.close()
-            except:
+            except Exception:
                 print('WARNING in import_routes_xml: could not open',filepath)
                 return False
                 
@@ -250,7 +250,7 @@ class Demand(cm.BaseObjman):
             try:
                 fd = open(filepath,'r', encoding="utf-8")
                 fd.close()
-            except:
+            except Exception:
                 print('WARNING in import_routes_xml: could not open',filepath)
                 return False
             
@@ -290,7 +290,7 @@ class Demand(cm.BaseObjman):
             print('export_routes_xml',filepath,demandobjects)
             try:
                 fd = open(filepath,'w', encoding="utf-8")
-            except:
+            except Exception:
                 print('WARNING in export_routes_xml: could not open',filepath)
                 return False
 

--- a/tools/contributed/hybridPY/coremodules/demand/demandbase.py
+++ b/tools/contributed/hybridPY/coremodules/demand/demandbase.py
@@ -1953,7 +1953,7 @@ class TripsBase(DemandobjMixin, am.ArrayObjman):
         print('export_trips_xml',filepath)
         try:
             fd=open(filepath,'w', encoding="utf-8")
-        except:
+        except Exception:
             print('WARNING in write_obj_to_xml: could not open',filepath)
             return False
 

--- a/tools/contributed/hybridPY/coremodules/demand/detectorflows.py
+++ b/tools/contributed/hybridPY/coremodules/demand/detectorflows.py
@@ -469,7 +469,7 @@ class Detectors(am.ArrayObjman):
         print('export_detectors_xml',filepath)
         try:
             fd=open(filepath,'w', encoding="utf-8")
-        except:
+        except Exception:
             print('WARNING in write_obj_to_xml: could not open',filepath)
             return False
 

--- a/tools/contributed/hybridPY/coremodules/demand/origin_to_destination.py
+++ b/tools/contributed/hybridPY/coremodules/demand/origin_to_destination.py
@@ -742,7 +742,7 @@ class OdIntervals(am.ArrayObjman):
         
         try:
             fd=open(filepath,'w', encoding="utf-8")
-        except:
+        except Exception:
             print('WARNING in export_sumoxml: could not open',filepath)
             return False
         
@@ -810,7 +810,7 @@ class OdIntervals(am.ArrayObjman):
         
         try:
             fd=open(filepath,'w', encoding="utf-8")
-        except:
+        except Exception:
             print('WARNING in export_sumoxml: could not open',filepath)
             return False
         #xmltag, xmltag_item, attrname_id = self.xmltag

--- a/tools/contributed/hybridPY/coremodules/demand/vehicles.py
+++ b/tools/contributed/hybridPY/coremodules/demand/vehicles.py
@@ -857,7 +857,7 @@ class VehicleTypes(am.ArrayObjman):
                                   id_sumo += '_'+s
                             #print '      new i:',i,id_sumo+'_%03d'%i
                             row_last['ids_sumo'] = id_sumo+'_%03d'%i
-                    except:
+                    except Exception:
                             id_sumo = id_data[0]
                             for s in id_data[1:]:
                                   id_sumo += '_'+s
@@ -1822,7 +1822,7 @@ class VehicleTypes(am.ArrayObjman):
         
         try:
             fd=open(filepath,'w', encoding="utf-8")
-        except:
+        except Exception:
             print('WARNING in vtypes.export_xml: could not open',filepath)
             return False
         

--- a/tools/contributed/hybridPY/coremodules/demand/virtualpop_wxgui.py
+++ b/tools/contributed/hybridPY/coremodules/demand/virtualpop_wxgui.py
@@ -9,7 +9,7 @@ from . import virtualpop_results_mpl as results_mpl
 try:
     from . import virtualpop_results_mpl as results_mpl
     is_mpl = True # we have matplotlib support
-except:
+except Exception:
     print("WARNING: python matplotlib package not installed, no matplotlib plots.")
     is_mpl = False 
     

--- a/tools/contributed/hybridPY/coremodules/landuse/landuse.py
+++ b/tools/contributed/hybridPY/coremodules/landuse/landuse.py
@@ -3,13 +3,13 @@ from xml.sax import saxutils, parse, handler
 if  __name__ == '__main__':
     try:
         APPDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         APPDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
     hybridPYDIR = os.path.join(APPDIR,'..','..')
     sys.path.append(hybridPYDIR)
 try:
     import pyproj
-except:
+except Exception:
     from mpl_toolkits.basemap import pyproj
 
 # for elevation api
@@ -38,7 +38,7 @@ try:
     #zones clusterization
     from scipy.cluster.vq import  kmeans2
     from scipy.spatial import Voronoi, voronoi_plot_2d
-except:
+except Exception:
     print('No Scipy module installed. Clustarization functions will not work.')
     
 import matplotlib.pyplot as plt
@@ -46,7 +46,7 @@ try:
     from shapely.geometry import MultiPoint, Polygon
     from shapely.ops import unary_union
     IS_SHAPELY = True                              
-except:
+except Exception:
     IS_SHAPELY = False
 
 def qspline(x,a0,a1,a2):
@@ -518,7 +518,7 @@ def download_google_places(latlon,radius,key, places, next_page_token = None):
     #print ('  url=',url_all)
     try:
         response = requests.get(url_all)
-    except:
+    except Exception:
         print('ERROR: there is probably a problem with your Internet connection.')
     
     print ('  response status_code',response.status_code)
@@ -593,7 +593,7 @@ def download_google_places_extra(key, places, day_of_week, openinghours_default,
         #print ('  url=',url_all)
         try:
             response = requests.get(url_all)
-        except:
+        except Exception:
             print('ERROR: there is probably a problem with your Internet connection.')
             
         print ('    response status_code',response.status_code)
@@ -1440,7 +1440,7 @@ class Zones(am.ArrayObjman):
         
         try:
             fd=open(filepath,'w', encoding="utf-8")
-        except:
+        except Exception:
             print('WARNING in write_obj_to_xml: could not open',filepath)
             return False
         #xmltag, xmltag_item, attrname_id = self.xmltag
@@ -1471,7 +1471,7 @@ class Zones(am.ArrayObjman):
         
         try:
             fd=open(filepath,'w', encoding="utf-8")
-        except:
+        except Exception:
             print('WARNING in export_sumoxml: could not open',filepath)
             return False
         #xmltag, xmltag_item, attrname_id = self.xmltag
@@ -2656,7 +2656,7 @@ class Facilities(am.ArrayObjman):
         
         try:
             fd=open(filepath,'w', encoding="utf-8")
-        except:
+        except Exception:
             print('WARNING in write_obj_to_xml: could not open',filepath)
             return False
         #xmltag, xmltag_item, attrname_id = self.xmltag
@@ -3588,7 +3588,7 @@ class Landuse(cm.BaseObjman):
             print('export_polyxml',filepath)
             try:
                 fd=open(filepath,'w', encoding="utf-8")
-            except:
+            except Exception:
                 print('WARNING in export_poly_xml: could not open',filepath)
                 return None
             

--- a/tools/contributed/hybridPY/coremodules/landuse/maps.py
+++ b/tools/contributed/hybridPY/coremodules/landuse/maps.py
@@ -24,24 +24,24 @@ from mpl_toolkits.mplot3d import Axes3D
 try:
     from scipy import interpolate
     is_scipy = True
-except:
+except Exception:
     is_scipy = False
     
 IS_MAPSUPPORT = True
 try:
     from PIL import ImageFilter,Image,ImageChops,ImagePath,ImageDraw
-except:
+except Exception:
     print("WARNING: Maps requires PIL module.")
     IS_MAPSUPPORT = False
     
 try:
     import pyproj
 
-except:
+except Exception:
     try:
         from mpl_toolkits.basemap import pyproj
         
-    except:
+    except Exception:
         print("WARNING: Maps requires pyproj module.")
         IS_MAPSUPPORT = False
         #print __doc__

--- a/tools/contributed/hybridPY/coremodules/misc/matplottools.py
+++ b/tools/contributed/hybridPY/coremodules/misc/matplottools.py
@@ -20,7 +20,7 @@ if 1: # change backend...makes problems with plt
         from mpl.ticker import MaxNLocator
         import mpl.patches as mpatches
         
-    except:
+    except Exception:
         from matplotlib.patches import Arrow,Circle, Wedge, Polygon,FancyArrow
         from matplotlib.collections import PatchCollection
         import matplotlib.colors as colors
@@ -43,7 +43,7 @@ print("Using Matplotlib backend",mpl.get_backend())
 
 try:
     import wx
-except:
+except Exception:
     print('WARNING: no wxwindows support')
     
 import agilepy.lib_base.classman as cm

--- a/tools/contributed/hybridPY/coremodules/misc/shapefile.py
+++ b/tools/contributed/hybridPY/coremodules/misc/shapefile.py
@@ -269,7 +269,7 @@ class Reader:
             if shapeType in (11,21):
                 record.m = unpack("<d", f.read(8))
             
-        except:
+        except Exception:
             pass
         return record
 
@@ -382,13 +382,13 @@ class Reader:
                 else:
                     try:
                         value = int(float(value))
-                    except:
+                    except Exception:
                         value = None
             elif typ == b('D'):
                 try:
                     y, m, d = int(value[:4]), int(value[4:6]), int(value[6:8])
                     value = [y, m, d]
-                except:
+                except Exception:
                     value = value.strip()
             elif typ == b('L'):
                 value = (value in b('YyTt') and b('T')) or \

--- a/tools/contributed/hybridPY/coremodules/misc/shapeformat.py
+++ b/tools/contributed/hybridPY/coremodules/misc/shapeformat.py
@@ -15,11 +15,11 @@ try:
     try:
         import pyproj
         IS_PROJ = True
-    except:
+    except Exception:
         from mpl_toolkits.basemap import pyproj
         IS_PROJ = True
     
-except:
+except Exception:
     IS_PROJ = False
     print('Import error: in order to run the traces plugin please install the following modules:')
     print('   mpl_toolkits.basemap and shapely')
@@ -32,7 +32,7 @@ from pathlib import Path
 try:
     from osgeo import osr
     IS_GDAL = True
-except:
+except Exception:
     IS_GDAL = False
     print('WARNING: python gdal module is not installed.')
 
@@ -589,14 +589,14 @@ class ShapefileImporter(Process):
                 try:
                     print('  use projparams_shape =*%s*'%self.projparams_shape,type(str(self.projparams_shape)),pyproj.Proj(str(self.projparams_shape)))
                     proj_shape = pyproj.Proj(str(self.projparams_shape))
-                except:
+                except Exception:
                     proj_shape = None
                     
             if self.is_use_targetproj:    
                 try:
                     print('  use projparams_target =*%s*'%self._projparams_target,type(str(self._projparams_target)),pyproj.Proj(str(self._projparams_target)))
                     proj_target = pyproj.Proj(str(self._projparams_target))
-                except:
+                except Exception:
                     proj_target = None
 
             
@@ -1074,7 +1074,7 @@ class Shapedata(am.ArrayObjman):
             write_prj_file("%s.prj" % basefilepath, crs)
             return True
             
-        except:
+        except Exception:
             print('WARNING in export_shapefile:\n no projection file written (probably no Internet connection).')
             print('Open shapefile with projection: %s.'%self._projparams.get_value())
             #raise

--- a/tools/contributed/hybridPY/coremodules/network/network.py
+++ b/tools/contributed/hybridPY/coremodules/network/network.py
@@ -7,7 +7,7 @@ from xml.sax import saxutils, parse, handler
 if  __name__ == '__main__':
     try:
         APPDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         APPDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
     hybridPYDIR = os.path.join(APPDIR,'..','..')
     sys.path.append(os.path.join(hybridPYDIR))
@@ -467,7 +467,7 @@ class TrafficLightSystems(am.ArrayObjman):
         print('export_sumoxml',filepath)
         try:
             fd=open(filepath,'w', encoding="utf-8")
-        except:
+        except Exception:
             print('WARNING in export_sumoxml: could not open',filepath)
             return False
 
@@ -859,7 +859,7 @@ class Connections(am.ArrayObjman):
     def export_sumoxml(self, filepath, encoding = 'UTF-8'):
         try:
             fd=open(filepath,'w', encoding="utf-8")
-        except:
+        except Exception:
             print('WARNING in export_sumoxml: could not open',filepath)
             return False
 
@@ -2758,7 +2758,7 @@ class Edges(am.ArrayObjman):
     def export_sumoxml(self, filepath, encoding = 'UTF-8'):
         try:
             fd=open(filepath,'w', encoding="utf-8")
-        except:
+        except Exception:
             print('WARNING in export_sumoxml: could not open',filepath)
             return False
         fd.write('<?xml version="1.0" encoding="%s"?>\n'%encoding)
@@ -2785,7 +2785,7 @@ class Edges(am.ArrayObjman):
             
         try:
             fd=open(filepath,'w', encoding="utf-8")
-        except:
+        except Exception:
             print('WARNING in export_edgeweights_xml: could not open',filepath)
             return ''
         
@@ -3290,7 +3290,7 @@ class Nodes(am.ArrayObjman):
     def export_sumoxml(self, filepath, encoding = 'UTF-8'):
         try:
             fd=open(filepath,'w', encoding="utf-8")
-        except:
+        except Exception:
             print('WARNING in export_sumoxml: could not open',filepath)
             return False
         fd.write('<?xml version="1.0" encoding="%s"?>\n'%encoding)
@@ -3995,7 +3995,7 @@ class Network(cm.BaseObjman):
             try:
                 fd=open(filepath,'w', encoding="utf-8")
 
-            except:
+            except Exception:
                 print('WARNING in write_obj_to_xml: could not open',filepath)
                 return False
 

--- a/tools/contributed/hybridPY/coremodules/network/network_editor-1.py
+++ b/tools/contributed/hybridPY/coremodules/network/network_editor-1.py
@@ -3,7 +3,7 @@ import os, sys, wx
 if  __name__ == '__main__':
     try:
         APPDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         APPDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
     #AGILEDIR = os.path.join(APPDIR,'..','..','agilepy')
     

--- a/tools/contributed/hybridPY/coremodules/network/network_editor.py
+++ b/tools/contributed/hybridPY/coremodules/network/network_editor.py
@@ -3,7 +3,7 @@ import os, sys, wx
 if  __name__ == '__main__':
     try:
         APPDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         APPDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
     #AGILEDIR = os.path.join(APPDIR,'..','..','agilepy')
     

--- a/tools/contributed/hybridPY/coremodules/network/networkxtools.py
+++ b/tools/contributed/hybridPY/coremodules/network/networkxtools.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 try:
     import networkx as nx
     IS_NX = True
-except:
+except Exception:
     IS_NX = False
     
 import numpy as np
@@ -30,7 +30,7 @@ import json
 
 try:
     import pyproj
-except:
+except Exception:
     from mpl_toolkits.basemap import pyproj
 
 
@@ -47,7 +47,7 @@ def load_objfile(filepath):
     f=open(filepath,'rb')
     try:
         f=open(filepath,'rb')
-    except:
+    except Exception:
         print('WARNING in load_obj: could not open',filepath)
         return None
     
@@ -250,12 +250,12 @@ class Road:
         if is_int:
             try:
                 return int(v)
-            except:
+            except Exception:
                 return default
         if is_float:
             try:
                 return float(v)
-            except:
+            except Exception:
                 return default
         
         else:

--- a/tools/contributed/hybridPY/coremodules/network/publictransportnet.py
+++ b/tools/contributed/hybridPY/coremodules/network/publictransportnet.py
@@ -17,10 +17,10 @@ from agilepy.lib_base.geometry import get_length_polypoints,get_dist_point_to_se
 try:
     try:
         import pyproj
-    except:
+    except Exception:
         from mpl_toolkits.basemap import pyproj
 
-except:
+except Exception:
     pyproj = None
     print('Some of the functions cannot be executed because module pypro or mpl_toolkits.basemap is missing.')
     print('Please install these modules if you want to use it.')
@@ -361,7 +361,7 @@ class PtStops(am.ArrayObjman):
         
         try:
             fd=open(filepath,'w', encoding = encoding)
-        except:
+        except Exception:
             print('WARNING in write_obj_to_xml: could not open',filepath)
             return False
         #xmltag, xmltag_item, attrname_id = self.xmltag

--- a/tools/contributed/hybridPY/coremodules/scenario/scenario.py
+++ b/tools/contributed/hybridPY/coremodules/scenario/scenario.py
@@ -3,7 +3,7 @@ import os, sys
 if  __name__ == '__main__':
     try:
         FILEDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         FILEDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
     sys.path.append(os.path.join(FILEDIR,"..",".."))
  
@@ -283,7 +283,7 @@ class Scenario(cm.BaseObjman):
             self.landuse.import_polyxml(self.get_rootfilename(), self.get_workdirpath())
             try:
                 self.demand.import_xml(self.get_rootfilename(), self.get_workdirpath())
-            except:
+            except Exception:
                 print('WARNING: import of demand data failed. Please check for inconsistency with trip/route and network edge IDs.')
         
         def update_netoffset(self, deltaoffset):

--- a/tools/contributed/hybridPY/coremodules/simulation/result_oglviewer.py
+++ b/tools/contributed/hybridPY/coremodules/simulation/result_oglviewer.py
@@ -2,7 +2,7 @@ import os, sys, wx
 if  __name__ == '__main__':
     try:
         APPDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         APPDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
 
     hybridPYDIR = os.path.join(APPDIR,'..','..')

--- a/tools/contributed/hybridPY/coremodules/simulation/simplaconfig.py
+++ b/tools/contributed/hybridPY/coremodules/simulation/simplaconfig.py
@@ -22,7 +22,7 @@ try:
 
     import simpla
 
-except:
+except Exception:
     print('WARNING: No module simpla in syspath. Please provide SUMO_HOME.')
 
     simpla = None

--- a/tools/contributed/hybridPY/coremodules/simulation/sumo.py
+++ b/tools/contributed/hybridPY/coremodules/simulation/sumo.py
@@ -5,7 +5,7 @@ from xml.sax import saxutils, parse, handler
 if  __name__ == '__main__':
     try:
         APPDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         APPDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
     hybridPYDIR = os.path.join(APPDIR,'..','..')
     sys.path.append(hybridPYDIR)
@@ -20,14 +20,14 @@ try:
     import traci.constants as tc
 
 
-except:
+except Exception:
     print('WARNING: No module traci in syspath. Please provide SUMO_HOME.')
 
     traci = None
 
 try:
     import pyproj
-except:
+except Exception:
     from mpl_toolkits.basemap import pyproj
     
 from coremodules.modules_common import *
@@ -1630,7 +1630,7 @@ class SumoTraci(Sumo):
                             # vehicle is inside a junction
                             pass    
                             
-                    except:
+                    except Exception:
                         # delete because no longer in simulation
                         #print ('    >contact failed')
                         ids_sumo_del.add(id_veh_sumo)
@@ -1655,7 +1655,7 @@ class SumoTraci(Sumo):
                             # vehicle is inside a junction
                             pass
                             
-                    except:
+                    except Exception:
                         # delete because no longer in simulation
                         #print ('      ',id_pers_sumo,'no longer in simulation')
                         ids_sumo_del.add(id_pers_sumo)
@@ -2641,7 +2641,7 @@ class Duaiterate(Sumo): # attention, CmlMixin overrides Sumo
             for filename  in os.listdir(self.workdirpath):
                 try:
                     step = int(filename)
-                except:
+                except Exception:
                     step = -1
                 if step > step_max:
                    step_max = step 

--- a/tools/contributed/hybridPY/coremodules/simulation/sumo_virtualpop.py
+++ b/tools/contributed/hybridPY/coremodules/simulation/sumo_virtualpop.py
@@ -12,7 +12,7 @@ import sys, os
 import numpy as np
 try:
         APPDIR = os.path.dirname(os.path.abspath(__file__))
-except:
+except Exception:
     APPDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
 hybridPYDIR = os.path.join(APPDIR,'..','..','hybridPY')
 sys.path.append(hybridPYDIR)

--- a/tools/contributed/hybridPY/coremodules/simulation/sumo_virtualpop_iterate.py
+++ b/tools/contributed/hybridPY/coremodules/simulation/sumo_virtualpop_iterate.py
@@ -61,7 +61,7 @@ def start_iterations(scenariofilepath, n_iter, simscriptfilepath):
 if  __name__ == '__main__':
     try:
         APPDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         APPDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
         
     scenariofilepath = os.path.abspath(sys.argv[1])

--- a/tools/contributed/hybridPY/plugins/hcprt/wxgui.py
+++ b/tools/contributed/hybridPY/plugins/hcprt/wxgui.py
@@ -15,7 +15,7 @@ from . import hcprt
 try:
     from . import results_mpl as results_mpl
     is_mpl = True # we have matplotlib support
-except:
+except Exception:
     print("WARNING: python matplotlib package not installed, no matplotlib plots.")
     is_mpl = False    
 

--- a/tools/contributed/hybridPY/plugins/intersection_analysis/interana.py
+++ b/tools/contributed/hybridPY/plugins/intersection_analysis/interana.py
@@ -239,7 +239,7 @@ class Legs(am.ArrayObjman):
             #    try:
             #        if get_traci_velocity(id_veh_sumo) < speed_stopped:
             #            self.vehicles_time_wait[id_veh_sumo] += time_update
-            #    except:
+            #    except Exception:
             #        pass
             
             # check vehicles in db if time to put from arrival to input queue

--- a/tools/contributed/hybridPY/plugins/mapmatching/mapmatching.py
+++ b/tools/contributed/hybridPY/plugins/mapmatching/mapmatching.py
@@ -20,7 +20,7 @@ from copy import copy, deepcopy
 if  __name__ == '__main__':
     try:
         APPDIR = os.path.dirname(os.path.abspath(__file__))
-    except:
+    except Exception:
         APPDIR = os.path.dirname(os.path.abspath(sys.argv[0]))
     hybridPYDIR = os.path.join(APPDIR,'..','..')
     sys.path.append(hybridPYDIR)
@@ -47,14 +47,14 @@ from agilepy.lib_base.geometry import *
 try:
     try:
         import pyproj
-    except:
+    except Exception:
         from mpl_toolkits.basemap import pyproj
     try:
         from shapely.geometry import Polygon, MultiPolygon, MultiLineString, Point, LineString, MultiPoint
         from shapely.ops import cascaded_union
-    except:
+    except Exception:
         print('Import error: No shapely module available.')
-except:
+except Exception:
     print('Import error: in order to run the traces plugin please install the following modules:')
     print('   mpl_toolkits.basemap and shapely')
     print('Please install these modules if you want to use it.')
@@ -1550,7 +1550,7 @@ class VpCreator(Process):
                          list(range(len(ids_trip)))): 
                     try:
                         ids_only_bike_trip.index(id_pers) 
-                    except:
+                    except Exception:
                         print('plan first walk')
                         ids_walk1[i] , times_end_walk1[i] = virtualpop.get_plans().get_stagetable('walks').append_stage(\
                                                     id_plan, time_from, 
@@ -1590,7 +1590,7 @@ class VpCreator(Process):
                          list(range(len(ids_trip)))): 
                     try:
                         ids_only_bike_trip.index(id_trip) 
-                    except:
+                    except Exception:
                         print('plan first walk')
                         ids_walk1[i] , times_end_walk1[i] = virtualpop.get_plans().get_stagetable('walks').append_stage(\
                                                     id_plan, time_from, 
@@ -1777,7 +1777,7 @@ class VpCreator(Process):
                          ids_person ): 
                     try:
                         ids_only_bike_trip.index(id_pers) 
-                    except:
+                    except Exception:
                         ids_walk2[i] , times_end_walk2[i] = virtualpop.get_plans().get_stagetable('walks').append_stage(\
                                                     id_plan, time_from, 
                                                     id_edge_from = id_edge_from, 
@@ -1814,7 +1814,7 @@ class VpCreator(Process):
                              ids_person ): 
                         try:
                             ids_only_bike_trip.index(id_trip) 
-                        except:
+                        except Exception:
                             ids_walk2[i] , times_end_walk2[i] = virtualpop.get_plans().get_stagetable('walks').append_stage(\
                                                         id_plan, time_from, 
                                                         id_edge_from = id_edge_from, 

--- a/tools/contributed/hybridPY/plugins/mapmatching/results_mpl.py
+++ b/tools/contributed/hybridPY/plugins/mapmatching/results_mpl.py
@@ -19,7 +19,7 @@ import time
 try:
     from scipy import interpolate
     is_scipy = True
-except:
+except Exception:
     is_scipy = False
 
 def is_sublist(l, s):

--- a/tools/contributed/hybridPY/plugins/mapmatching/wxgui.py
+++ b/tools/contributed/hybridPY/plugins/mapmatching/wxgui.py
@@ -17,7 +17,7 @@ from . import mapmatching
 try:
     from . import results_mpl as results_mpl
     is_mpl = True # we have matplotlib support
-except:
+except Exception:
     print("WARNING: python matplotlib package not installed, no matplotlib plots.")
     is_mpl = False   
 

--- a/tools/contributed/hybridPY/plugins/matsim/matsim_base.py
+++ b/tools/contributed/hybridPY/plugins/matsim/matsim_base.py
@@ -4,7 +4,7 @@ import os, sys
 import numpy as np
 try:
     import pyproj
-except:
+except Exception:
     from mpl_toolkits.basemap import pyproj
 import numpy as np
 import agilepy.lib_base.classman as cm

--- a/tools/contributed/hybridPY/plugins/matsim/matsim_config.py
+++ b/tools/contributed/hybridPY/plugins/matsim/matsim_config.py
@@ -8,7 +8,7 @@ from agilepy.lib_base.processes import Process
 from xml.sax import parse, handler
 try:
     import pyproj
-except:
+except Exception:
     from mpl_toolkits.basemap import pyproj
     
 from .matsim_base import  *

--- a/tools/contributed/hybridPY/plugins/matsim/matsim_mapmatch.py
+++ b/tools/contributed/hybridPY/plugins/matsim/matsim_mapmatch.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 try:
     import networkx as nx
     import geonetworkx as gnx
-except:
+except Exception:
     print ('Matsim mapmatching cannot be used. Please install networkx and geonetworkx')
 import matplotlib.pyplot as plt
 
@@ -21,7 +21,7 @@ import math
 
 try:
     import pyproj
-except:
+except Exception:
     from mpl_toolkits.basemap import pyproj
     
 from .matsim_base import  *
@@ -206,7 +206,7 @@ class MapMatcher(Process):
                 while len(result_02[0])> index:
                     try: 
                         cosine = cosine_similarities[vector_set_id.index(result_02[0][index])]
-                    except:
+                    except Exception:
                         cosine = -1
                     if cosine >ortho_cosine_threshold and result_02[1][index]<ortho_dist:
                         if comp_result_02 == None: 
@@ -223,7 +223,7 @@ class MapMatcher(Process):
                 while len(result_04[0])> index:
                     try: 
                         cosine = cosine_similarities[vector_set_id.index(result_04[0][index])]
-                    except:
+                    except Exception:
                         cosine = -1
                     if cosine >ortho_cosine_threshold and result_04[1][index]<ortho_dist:
                         if comp_result_04 == None: 
@@ -241,7 +241,7 @@ class MapMatcher(Process):
                     
                     try: 
                         cosine = cosine_similarities[vector_set_id.index(result_06[0][index])]
-                    except:
+                    except Exception:
                         cosine = -1
 
                     if cosine>ortho_cosine_threshold and result_06[1][index]<ortho_dist:
@@ -257,7 +257,7 @@ class MapMatcher(Process):
                     return_index = comp_result_02
                     try: 
                         return_index = vector_set_id.index(comp_result_02)
-                    except:
+                    except Exception:
                         return_index = None
 
                 if ignore:
@@ -692,7 +692,7 @@ class MapMatcher(Process):
                 G.edges[edge]['id'] = graph.edges[edge]['id']
                 G.edges[edge]['weight'] = graph.edges[edge]['weight']
 
-            except:
+            except Exception:
                 value = merged_edges[edge]
                 id1 = graph[value[0][0]][value[0][1]]['id']
                 id2 = graph[value[1][0]][value[1][1]]['id']
@@ -744,7 +744,7 @@ class MapMatcher(Process):
                     for t in s_t:
                         try:
                             s_id = sumo.get_edge_data(f,t)['id']
-                        except:
+                        except Exception:
                             #print("... no edge in sumo map for matsim edge:", me)
                             pass
                         else:
@@ -772,7 +772,7 @@ class MapMatcher(Process):
                     
                     try:
                         sumo_path = nx.shortest_path(sumo, from_node_sumo, to_node_sumo)
-                    except:
+                    except Exception:
                         continue
                     finally:
                         local_edge_map, local_edge_map_id = match_edges_from_paths(matsim, matsim_path, sumo, sumo_path)
@@ -901,7 +901,7 @@ class MapMatcher(Process):
     def is_within_tolerance(node1, node2,tolerance):
         try: 
             distN1N2 = abs(math.dist(node1, node2))
-        except:
+        except Exception:
             return False
         
         return (distN1N2 <tolerance)

--- a/tools/contributed/hybridPY/plugins/matsim/matsim_network.py
+++ b/tools/contributed/hybridPY/plugins/matsim/matsim_network.py
@@ -11,7 +11,7 @@ from collections import Counter
 from agilepy.lib_base.geometry import *
 try:
     import pyproj
-except:
+except Exception:
     from mpl_toolkits.basemap import pyproj
     
 from .matsim_base import  *

--- a/tools/contributed/hybridPY/plugins/matsim/matsim_network_update.py
+++ b/tools/contributed/hybridPY/plugins/matsim/matsim_network_update.py
@@ -26,14 +26,14 @@ from shapely.geometry import Point, MultiPoint, Polygon, MultiLineString, LineSt
 from shapely.ops import unary_union, polygonize
 try:
     from concave_hull import concave_hull
-except:
+except Exception:
     concave_hull = None
     
 import math
 
 try:
     import pyproj
-except:
+except Exception:
     from mpl_toolkits.basemap import pyproj
     
 from .matsim_base import  *
@@ -1275,7 +1275,7 @@ class MapUpdater(Process):
             while len(result_start[0])> index:
                 try: 
                     cosine = cosine_similarities[vector_set_id.index(result_start[0][index])]
-                except:
+                except Exception:
                     cosine = -1
 
                 if cosine >ortho_cosine_threshold and result_start[1][index]<ortho_dist:
@@ -1294,7 +1294,7 @@ class MapUpdater(Process):
             while len(result_end[0])> index:
                 try: 
                     cosine = cosine_similarities[vector_set_id.index(result_end[0][index])]
-                except:
+                except Exception:
                     cosine = -1
 
                 if cosine >ortho_cosine_threshold and result_end[1][index]<ortho_dist:

--- a/tools/contributed/hybridPY/plugins/matsim/matsim_pt.py
+++ b/tools/contributed/hybridPY/plugins/matsim/matsim_pt.py
@@ -9,7 +9,7 @@ from agilepy.lib_base.processes import Process
 from xml.sax import parse, handler
 try:
     import pyproj
-except:
+except Exception:
     from mpl_toolkits.basemap import pyproj
     
 from .matsim_base import  *

--- a/tools/contributed/hybridPY/plugins/matsim/wxgui.py
+++ b/tools/contributed/hybridPY/plugins/matsim/wxgui.py
@@ -15,7 +15,7 @@ from agilepy.lib_wx.ogleditor import Polylines
 try:
     import matsim_mpl
     is_mpl = True # we have matplotlib support
-except:
+except Exception:
      print("WARNING: python matplotlib package not installed, no matplotlib plots.")
      is_mpl = False    
 

--- a/tools/contributed/hybridPY/plugins/prt/wxgui.py
+++ b/tools/contributed/hybridPY/plugins/prt/wxgui.py
@@ -15,7 +15,7 @@ from . import prt
 try:
     from . import results_mpl as results_mpl
     is_mpl = True # we have matplotlib support
-except:
+except Exception:
     print("WARNING: python matplotlib package not installed, no matplotlib plots.")
     is_mpl = False    
 

--- a/tools/contributed/hybridPY/plugins/trafficlight_control/wxgui.py
+++ b/tools/contributed/hybridPY/plugins/trafficlight_control/wxgui.py
@@ -15,7 +15,7 @@ from . import tlcontrol
 try:
     from . import results_mpl as results_mpl
     is_mpl = True # we have matplotlib support
-except:
+except Exception:
     print("WARNING: python matplotlib package not installed, no matplotlib plots.")
     is_mpl = False   
             

--- a/tools/net/abstractRail.py
+++ b/tools/net/abstractRail.py
@@ -41,7 +41,7 @@ import sumolib.geomhelper as gh  # noqa
 
 try:
     sys.stdout.reconfigure(encoding='utf-8')
-except:  # noqa
+except Exception:  # noqa
     pass
 
 INTERSECT_RANGE = 1e5

--- a/tools/net/patchRailConflicts.py
+++ b/tools/net/patchRailConflicts.py
@@ -31,7 +31,7 @@ from sumolib.options import ArgumentParser  # noqa
 
 try:
     sys.stdout.reconfigure(encoding='utf-8')
-except:  # noqa
+except Exception:  # noqa
     pass
 
 NETCONVERT = sumolib.checkBinary('netconvert')

--- a/tools/net/patchRailPriorities.py
+++ b/tools/net/patchRailPriorities.py
@@ -39,7 +39,7 @@ from createOvertakingReroutes import parseRoutes, findSwitches, findSidings, fil
 
 try:
     sys.stdout.reconfigure(encoding='utf-8')
-except:  # noqa
+except Exception:  # noqa
     pass
 
 NETCONVERT = sumolib.checkBinary('netconvert')

--- a/tools/sumolib/translation.py
+++ b/tools/sumolib/translation.py
@@ -34,7 +34,7 @@ def setLanguage(lang):
         translation = gettext.translation("sumo", localedir=LOCALEDIR, languages=[lang])
         translation.install()
         CURRENT_LANG = translation
-    except:  # noqa
+    except Exception:  # noqa
         CURRENT_LANG = None
 
 

--- a/tools/sumolib/visualization/helpers.py
+++ b/tools/sumolib/visualization/helpers.py
@@ -333,7 +333,7 @@ def closeFigure(fig, ax, options, haveLabels=True, optOut=None):
         show()
     try:
         fig.clf()
-    except:  # noqa
+    except Exception:  # noqa
         pass
     close()
     gc.collect()


### PR DESCRIPTION
## Summary

Replaces **122** bare `except:` clauses with `except Exception:` across **52 files** in `tools/contributed/hybridPY/` and `tools/net/`.

## Why

Bare `except:` catches `SystemExit` and `KeyboardInterrupt`, which can mask Ctrl+C handling and make debugging harder.