### PR TITLE
docs: fix typo seperate to separate in Routing.md

### DIFF
--- a/docs/web/docs/Simulation/Routing.md
+++ b/docs/web/docs/Simulation/Routing.md
@@ -280,7 +280,7 @@ When loading a network with edge permissions, a separate preprocessing is trigge
 ## CHWrapper
 
 This works like *CH* but performs separate preprocessing for every vehicle class that is encountered, thereby
-enabling routing in multi modal scenarios
+enabling routing in multi modal scenarios.
 
 # Further Options that affect routing
 

--- a/docs/web/docs/Simulation/Routing.md
+++ b/docs/web/docs/Simulation/Routing.md
@@ -275,7 +275,7 @@ when a large number of queries is expected. The algorithm does not
 consider time-dependent weights. Instead, new preprocessing can be
 performed for time-slices of fixed size by setting the option **--weight-period** {{DT_TIME}}.
 
-When loading a network with edge permissions, a seperate preprocessing is triggered for every vehicle class encountered in a routing task (by automatically switching to [CHWrapper](#chwrapper)).
+When loading a network with edge permissions, a separate preprocessing is triggered for every vehicle class encountered in a routing task (by automatically switching to [CHWrapper](#chwrapper)).
 
 ## CHWrapper
 


### PR DESCRIPTION
Correct a spelling error in the CH section of the SUMO routing documentation.