### PR TITLE
CCH: fixes from running the duarouter test suite with the cch variant

### DIFF
--- a/src/duarouter/RODUACCHMetrics.cpp
+++ b/src/duarouter/RODUACCHMetrics.cpp
@@ -32,7 +32,6 @@ RODUACCHGraph::EffortOperation RODUACCHMetrics::myEffort = nullptr;
 SUMOTime RODUACCHMetrics::myBegin = 0;
 SUMOTime RODUACCHMetrics::myWeightPeriod = SUMOTime_MAX;
 std::map<RODUACCHMetrics::MetricKey, RODUACCHMetrics::ClassMetric> RODUACCHMetrics::myMetrics;
-std::map<std::vector<double>, int> RODUACCHMetrics::myProfiles;
 std::mutex RODUACCHMetrics::myLock;
 
 
@@ -47,7 +46,6 @@ RODUACCHMetrics::init(const RODUACCHGraph* graph, RODUACCHGraph::EffortOperation
     myBegin = begin;
     myWeightPeriod = weightPeriod;
     myMetrics.clear();
-    myProfiles.clear();
 }
 
 
@@ -62,32 +60,28 @@ RODUACCHMetrics::get(SUMOVehicleClass vClass, SUMOTime time, const ROVehicle* ve
     if (myWeightPeriod > 0 && myWeightPeriod != SUMOTime_MAX && time > myBegin) {
         period = (int)((time - myBegin) / myWeightPeriod);
     }
-    // Lazy build on the first query for a (class, period, profile) triple
-    // (duarouter streams vehicles, so classes are not known up front); the
-    // weights are evaluated at the period's begin, so each triple is
-    // customized exactly once. The mutex also serialises concurrent first
-    // queries from parallel routing threads (satisfying primeClassMask's
+    // Lazy build on the first query for a (type, period) pair (duarouter
+    // streams vehicles, so the types are not known up front); the weights are
+    // evaluated at the period's begin with the querying vehicle as the effort
+    // reference, so each pair is customized exactly once and reflects the
+    // type's maximum speed, per-class edge speed restrictions and
+    // restriction-params. The mutex also serialises concurrent first queries
+    // from parallel routing threads (satisfying primeClassMask's
     // synchronization contract); afterwards the map is read-only for that
     // key (references into std::map are stable).
     std::lock_guard<std::mutex> lock(myLock);
-    int profile = 0;
-    if (veh != nullptr && !veh->getType()->paramRestrictions.empty()) {
-        const auto ins = myProfiles.insert(std::make_pair(veh->getType()->paramRestrictions,
-                                           (int)myProfiles.size()));
-        profile = ins.first->second;
-    }
-    const MetricKey key = std::make_tuple(vClass, period, profile);
+    const MetricKey key = std::make_pair(veh == nullptr ? nullptr : veh->getType(), period);
     auto it = myMetrics.find(key);
     if (it == myMetrics.end()) {
         ClassMetric& cm = myMetrics[key];
         const double periodBegin = STEPS2TIME(myBegin + period * myWeightPeriod);
-        myGraph->fillInputWeights(myEffort, vClass, nullptr, periodBegin, cm.weights);
-        if (profile != 0 || (veh != nullptr && !veh->getType()->paramRestrictions.empty())) {
-            // mask the edges that restrict this profile (restricts() depends
-            // only on the type's paramRestrictions vector, evaluated here via
-            // the first vehicle of the profile). arcsOfEdge of a real edge is
-            // exactly the arcs headed by it -- via chains hold internal edges
-            // only -- matching what the exact routers check per relaxation.
+        myGraph->fillInputWeights(myEffort, vClass, veh, periodBegin, cm.weights);
+        if (veh != nullptr && !veh->getType()->paramRestrictions.empty()) {
+            // mask the edges that restrict this type (restricts() depends
+            // only on the type's paramRestrictions vector). arcsOfEdge of a
+            // real edge is exactly the arcs headed by it -- via chains hold
+            // internal edges only -- matching what the exact routers check
+            // per relaxation.
             for (const ROEdge* const e : ROEdge::getAllEdges()) {
                 if (!e->isInternal() && !e->isTazConnector() && e->restricts(veh)) {
                     for (const unsigned a : myGraph->arcsOfEdge(e)) {

--- a/src/duarouter/RODUACCHMetrics.h
+++ b/src/duarouter/RODUACCHMetrics.h
@@ -24,7 +24,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <tuple>
 #include <utility>
 #include <vector>
 #include <utils/common/SUMOTime.h>
@@ -33,6 +32,7 @@
 
 class ROEdge;
 class ROVehicle;
+class SUMOVTypeParameter;
 
 
 // ===========================================================================
@@ -44,18 +44,25 @@ using RODUACCHGraph = CCHGraphBase<ROEdge, ROVehicle>;
 
 /**
  * @class RODUACCHMetrics
- * @brief Lazy per-(vehicle class, weight period) CCH metric store for duarouter.
+ * @brief Lazy per-(vehicle type, weight period) CCH metric store for duarouter.
  *
  * The metric provider handed to CCHRouter (a plain function pointer). On the
- * first query for a (class, period) pair, the metric is customized under a
+ * first query for a (type, period) pair, the metric is customized under a
  * mutex from the graph's fillInputWeights evaluated at the period's begin
- * (which also primes the class's connection mask under that lock) and cached
- * for the rest of the run. Without weight files there is a single period, so
- * exactly one metric per class; with time-dependent weight files this mirrors
- * CHRouterWrapper's one-hierarchy-per-weight-period semantics -- except that
- * only the cheap re-customization is repeated, never the topology build.
- * RoutingKit metrics BORROW their input-weight buffer, so buffer and metric
- * live together in the map (std::map nodes are address-stable).
+ * with the querying vehicle as the effort reference (which also primes the
+ * class's connection mask under that lock) and cached for the rest of the
+ * run. Keying by the TYPE (rather than the class) makes everything the
+ * effort function reads from the vehicle type exact per metric: the type's
+ * maximum speed, per-class edge speed restrictions and restriction-params
+ * values; only individual speed-factor draws within one type share a metric
+ * (the same approximation the CH family makes with its per-class prototype
+ * vehicles, but at finer granularity). Without weight files there is a
+ * single period, so exactly one metric per type; with time-dependent weight
+ * files this mirrors CHRouterWrapper's one-hierarchy-per-weight-period
+ * semantics -- except that only the cheap re-customization is repeated,
+ * never the topology build. RoutingKit metrics BORROW their input-weight
+ * buffer, so buffer and metric live together in the map (std::map nodes are
+ * address-stable).
  */
 class RODUACCHMetrics {
 public:
@@ -82,14 +89,13 @@ private:
         std::vector<unsigned> weights;
         std::unique_ptr<RoutingKit::CustomizableContractionHierarchyMetric> metric;
     };
-    /// @brief (vClass, weight period, restriction profile) -> metric
-    typedef std::tuple<SUMOVehicleClass, int, int> MetricKey;
+    /// @brief (vehicle type, weight period) -> metric; the type pointer is
+    /// stable (types are owned by RONet), nullptr covers vehicle-less queries
+    typedef std::pair<const SUMOVTypeParameter*, int> MetricKey;
     static const RODUACCHGraph* myGraph;
     static RODUACCHGraph::EffortOperation myEffort;
     static SUMOTime myBegin;
     static SUMOTime myWeightPeriod;
     static std::map<MetricKey, ClassMetric> myMetrics;
-    /// @brief dedup of the restriction-profile vectors (empty vector = 0)
-    static std::map<std::vector<double>, int> myProfiles;
     static std::mutex myLock;
 };

--- a/src/duarouter/RODUACCHMetrics.h
+++ b/src/duarouter/RODUACCHMetrics.h
@@ -16,7 +16,7 @@
 /// @date    2026
 ///
 // duarouter's lazy CCH metric store over the shared graph mapping
-// (utils/router/CCHGraphBase.h); RODUACCHGraph is its ROEdge instantiation.
+// (utils/router/CCHGraph.h); RODUACCHGraph is its ROEdge instantiation.
 /****************************************************************************/
 #pragma once
 #include <config.h>
@@ -28,7 +28,7 @@
 #include <vector>
 #include <utils/common/SUMOTime.h>
 #include <utils/common/SUMOVehicleClass.h>
-#include <utils/router/CCHGraphBase.h>
+#include <utils/router/CCHGraph.h>
 
 class ROEdge;
 class ROVehicle;
@@ -39,7 +39,7 @@ class SUMOVTypeParameter;
 // class definitions
 // ===========================================================================
 /// @brief the ROEdge instantiation of the CCH graph mapping
-using RODUACCHGraph = CCHGraphBase<ROEdge, ROVehicle>;
+using RODUACCHGraph = CCHGraph<ROEdge, ROVehicle>;
 
 
 /**

--- a/src/duarouter/duarouter_main.cpp
+++ b/src/duarouter/duarouter_main.cpp
@@ -186,7 +186,8 @@ computeRoutes(RONet& net, ROLoader& loader, OptionsCont& oc) {
             // trip crosses a weight-period boundary re-query on the next
             // period's metric.
             router = new CCHRouter<ROEdge, ROVehicle, RODUACCHGraph>(
-                cchGraph, &RODUACCHMetrics::get, &ROEdge::getTravelTimeStatic, fallback,
+                cchGraph, &RODUACCHMetrics::get, &ROEdge::getTravelTimeStatic,
+                oc.getBool("ignore-errors"), fallback,
                 hasWeights ? &RODUACCHMetrics::periodEnd : nullptr);
         } else if (routingAlgorithm == "arcflag") {
             /// @brief The number of levels in the k-d tree partition

--- a/src/duarouter/duarouter_main.cpp
+++ b/src/duarouter/duarouter_main.cpp
@@ -161,24 +161,24 @@ computeRoutes(RONet& net, ROLoader& loader, OptionsCont& oc) {
                 begin, end, weightPeriod, net.hasPermissions(), oc.getInt("routing-threads"));
         } else if (routingAlgorithm == "CCH") {
             // One weight-independent hierarchy over the union graph; one
-            // customized metric per (vehicle class, weight period), built
+            // customized metric per (vehicle type, weight period), built
             // lazily on first query (see RODUACCHMetrics.h). With
             // time-dependent weight files this follows CHRouterWrapper's
             // per-period semantics, but repeats only the metric
             // customization, never the topology build.
-            // Per-vehicle modifiers cannot live in a shared metric (mirror of
-            // the guard in MSRoutingEngine::initRouter).
-            if (gWeightsRandomFactor > 1 || gRoutingPreferences) {
-                throw ProcessError(TL("Routing algorithm 'CCH' is incompatible with weights.random-factor != 1 and routing preferences. Disable these to use CCH."));
-            }
+            // Because the metrics are keyed by vehicle type, the type and
+            // class specific routing preferences of the effort function are
+            // captured exactly. weights.random-factor freezes one random
+            // realization into each metric, the same approximation
+            // CHRouterWrapper makes when building its hierarchies.
             const bool hasWeights = oc.isSet("weight-files") || oc.isSet("lane-weight-files");
             const SUMOTime weightPeriod = hasWeights ? string2time(oc.getString("weight-period")) : SUMOTime_MAX;
             // Process-lifetime singletons: the topology and metric store are
             // shared by every router clone until duarouter exits.
             RODUACCHGraph* cchGraph = new RODUACCHGraph(ROEdge::getAllEdges());
-            RODUACCHMetrics::init(cchGraph, &ROEdge::getTravelTimeStatic, begin, weightPeriod);
+            RODUACCHMetrics::init(cchGraph, ttFunction, begin, weightPeriod);
             SUMOAbstractRouter<ROEdge, ROVehicle>* fallback = new AStarRouter<ROEdge, ROVehicle, ROMapMatcher>(
-                ROEdge::getAllEdges(), oc.getBool("ignore-errors"), &ROEdge::getTravelTimeStatic,
+                ROEdge::getAllEdges(), oc.getBool("ignore-errors"), ttFunction,
                 nullptr, net.hasPermissions(), oc.isSet("restriction-params"));
             // restriction-params are handled natively: each distinct
             // restriction profile gets its own masked metric (see
@@ -186,7 +186,7 @@ computeRoutes(RONet& net, ROLoader& loader, OptionsCont& oc) {
             // trip crosses a weight-period boundary re-query on the next
             // period's metric.
             router = new CCHRouter<ROEdge, ROVehicle, RODUACCHGraph>(
-                cchGraph, &RODUACCHMetrics::get, &ROEdge::getTravelTimeStatic,
+                cchGraph, &RODUACCHMetrics::get, ttFunction,
                 oc.getBool("ignore-errors"), fallback,
                 hasWeights ? &RODUACCHMetrics::periodEnd : nullptr);
         } else if (routingAlgorithm == "arcflag") {

--- a/src/microsim/MSRouterDefs.h
+++ b/src/microsim/MSRouterDefs.h
@@ -39,9 +39,9 @@ typedef std::vector<MSEdge*> MSEdgeVector;
 typedef std::shared_ptr<const MSRoute> ConstMSRoutePtr;
 typedef RouterProvider<MSEdge, MSLane, MSJunction, SUMOVehicle> MSRouterProvider;
 typedef SUMOAbstractRouter<MSEdge, SUMOVehicle> MSVehicleRouter;
-template<class E, class V> class CCHGraphBase;
-/// @brief the MSEdge instantiation of the CCH graph mapping (utils/router/CCHGraphBase.h)
-using CCHGraph = CCHGraphBase<MSEdge, SUMOVehicle>;
+template<class E, class V> class CCHGraph;
+/// @brief the MSEdge instantiation of the CCH graph mapping (utils/router/CCHGraph.h)
+using MSCCHGraph = CCHGraph<MSEdge, SUMOVehicle>;
 typedef IntermodalRouter<MSEdge, MSLane, MSJunction, SUMOVehicle> MSTransportableRouter;
 typedef PedestrianRouter<MSEdge, MSLane, MSJunction, SUMOVehicle> MSPedestrianRouter;
 typedef MapMatcher<MSEdge, MSLane, MSJunction> MSMapMatcher;

--- a/src/microsim/devices/MSRoutingEngine.cpp
+++ b/src/microsim/devices/MSRoutingEngine.cpp
@@ -47,7 +47,7 @@
 #include <utils/router/CHRouter.h>
 #include <utils/router/CHRouterWrapper.h>
 #include <utils/vehicle/SUMOVehicleParserHelper.h>
-#include <utils/router/CCHGraphBase.h>
+#include <utils/router/CCHGraph.h>
 #include <utils/router/CCHRouter.h>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -85,7 +85,7 @@ SUMOAbstractRouter<MSEdge, SUMOVehicle>::Operation MSRoutingEngine::myEffortFunc
 #ifdef HAVE_FOX
 FXMutex MSRoutingEngine::myRouteCacheMutex;
 #endif
-CCHGraph* MSRoutingEngine::myCCHGraph = nullptr;
+MSCCHGraph* MSRoutingEngine::myCCHGraph = nullptr;
 std::vector<MSRoutingEngine::CCHClass*> MSRoutingEngine::myCCHClasses;
 std::map<SUMOVehicleClass, MSRoutingEngine::CCHClass*> MSRoutingEngine::myCCHByClass;
 std::atomic<bool> MSRoutingEngine::myCCHQueried(false);
@@ -357,7 +357,7 @@ MSRoutingEngine::initCCH() {
             classes.insert(vt->getVehicleClass());
         }
     }
-    myCCHGraph = new CCHGraph(MSEdge::getAllEdges());  // union topology; class masks prime at first fill
+    myCCHGraph = new MSCCHGraph(MSEdge::getAllEdges());  // union topology; class masks prime at first fill
     const OptionsCont& oc = OptionsCont::getOptions();
     myCCHUpdateFactor = oc.getFloat("device.rerouting.cch-update-threshold.factor");
     myCCHUpdateConstant = STEPS2TIME(string2time(oc.getString("device.rerouting.cch-update-threshold.constant")));
@@ -686,7 +686,7 @@ MSRoutingEngine::initRouter(SUMOVehicle* vehicle) {
         // embedded fallback for non-passenger / prohibited / unreachable queries
         SUMOAbstractRouter<MSEdge, SUMOVehicle>* fallback =
             new AStarRouter<MSEdge, SUMOVehicle, MSMapMatcher>(MSEdge::getAllEdges(), true, myEffortFunc, nullptr, true);
-        router = new CCHRouter<MSEdge, SUMOVehicle, CCHGraph>(
+        router = new CCHRouter<MSEdge, SUMOVehicle, MSCCHGraph>(
             myCCHGraph, &MSRoutingEngine::getPublishedCCHMetric, myEffortFunc, true, fallback);
     } else {
         throw ProcessError(TLF("Unknown routing algorithm '%'!", routingAlgorithm));

--- a/src/microsim/devices/MSRoutingEngine.cpp
+++ b/src/microsim/devices/MSRoutingEngine.cpp
@@ -687,7 +687,7 @@ MSRoutingEngine::initRouter(SUMOVehicle* vehicle) {
         SUMOAbstractRouter<MSEdge, SUMOVehicle>* fallback =
             new AStarRouter<MSEdge, SUMOVehicle, MSMapMatcher>(MSEdge::getAllEdges(), true, myEffortFunc, nullptr, true);
         router = new CCHRouter<MSEdge, SUMOVehicle, CCHGraph>(
-            myCCHGraph, &MSRoutingEngine::getPublishedCCHMetric, myEffortFunc, fallback);
+            myCCHGraph, &MSRoutingEngine::getPublishedCCHMetric, myEffortFunc, true, fallback);
     } else {
         throw ProcessError(TLF("Unknown routing algorithm '%'!", routingAlgorithm));
     }

--- a/src/microsim/devices/MSRoutingEngine.h
+++ b/src/microsim/devices/MSRoutingEngine.h
@@ -341,7 +341,7 @@ private:
         std::shared_ptr<RoutingKit::CustomizableContractionHierarchyPartialCustomization> partial;
     };
     /// @brief the immutable shared CCH topology (built once), or nullptr if inactive
-    static CCHGraph* myCCHGraph;
+    static MSCCHGraph* myCCHGraph;
     /// @brief one metric-set per vehicle class present in the demand
     static std::vector<CCHClass*> myCCHClasses;
     static std::map<SUMOVehicleClass, CCHClass*> myCCHByClass;

--- a/src/utils/router/CCHGraph.h
+++ b/src/utils/router/CCHGraph.h
@@ -11,7 +11,7 @@
 // https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
 /****************************************************************************/
-/// @file    CCHGraphBase.h
+/// @file    CCHGraph.h
 /// @author  Pranav Sateesh
 /// @date    2026
 ///
@@ -64,7 +64,7 @@
 // class definitions
 // ===========================================================================
 /**
- * @class CCHGraphBase
+ * @class CCHGraph
  * @brief Metric-independent RoutingKit CCH topology over the PURE road graph.
  *
  * Nodes are the non-internal, non-TAZ edges. TAZ connectors are deliberately
@@ -83,7 +83,7 @@
  * @tparam V the vehicle type of the effort callback (SUMOVehicle / ROVehicle)
  */
 template<class E, class V>
-class CCHGraphBase {
+class CCHGraph {
 public:
     /// @brief effort callback signature, matching SUMOAbstractRouter::Operation
     typedef double (*EffortOperation)(const E* const, const V* const, double);
@@ -98,7 +98,7 @@ public:
      * (including e.g. tram-only rail arcs) exists. Per-class permissions are
      * applied later as inf_weight in the metric, never by removing arcs.
      */
-    explicit CCHGraphBase(const std::vector<E*>& allEdges) {
+    explicit CCHGraph(const std::vector<E*>& allEdges) {
         // 1. dense node indexing over real (non-internal, non-taz) edges.
         unsigned maxNumID = 0;
         for (const E* e : allEdges) {
@@ -220,7 +220,7 @@ public:
 #endif
     }
 
-    virtual ~CCHGraphBase() {}
+    virtual ~CCHGraph() {}
 
     /// @brief the immutable CCH (share const& across clones)
     const RoutingKit::CustomizableContractionHierarchy& cch() const {
@@ -421,10 +421,10 @@ private:
     RoutingKit::CustomizableContractionHierarchy myCCH;
 
 private:
-    CCHGraphBase(const CCHGraphBase&) = delete;
-    CCHGraphBase& operator=(const CCHGraphBase&) = delete;
+    CCHGraph(const CCHGraph&) = delete;
+    CCHGraph& operator=(const CCHGraph&) = delete;
 };
 
 
 template<class E, class V>
-const unsigned CCHGraphBase<E, V>::INVALID_NODE = RoutingKit::invalid_id;
+const unsigned CCHGraph<E, V>::INVALID_NODE = RoutingKit::invalid_id;

--- a/src/utils/router/CCHGraphBase.h
+++ b/src/utils/router/CCHGraphBase.h
@@ -159,14 +159,6 @@ public:
         }
         myArcPerm.assign(myArcTail.size(), 0);
         myPrimedClasses = 0;
-        myHasVia = false;
-        for (const E* via : myArcVia) {
-            if (via != nullptr) {
-                myHasVia = true;
-                break;
-            }
-        }
-
         // 2b. reverse image for sparse re-customization: for every arc, the
         // edges its weight reads at fill time (head edge + folded via chain;
         // the tail edge is deliberately absent from the weight, see the arc
@@ -280,39 +272,17 @@ public:
         return myEdgeToArcs[e->getNumericalID()];
     }
 
-    /** @brief Re-expand a RoutingKit node path into the full edge list,
-     * re-inserting any folded internal/via edges. */
+    /** @brief Map a RoutingKit node path back to the edge sequence.
+     *
+     * The result lists REAL edges only, exactly like the exact routers:
+     * junction-internal edges are never part of SUMO route vectors -- their
+     * cost is folded into the arc weights for the query and re-added from
+     * consecutive real edges by SUMOAbstractRouter::recomputeCosts. */
     void expandNodePath(const std::vector<unsigned>& nodePath,
                         std::vector<const E*>& into) const {
         into.reserve(into.size() + nodePath.size());
-        // Fast path for nets without internal edges (e.g. --no-internal-links):
-        // graph nodes ARE the edges, so the route is a direct id map -- no
-        // per-hop getViaSuccessors lookup (which locks under multithreading).
-        if (!myHasVia) {
-            for (unsigned node : nodePath) {
-                into.push_back(myNodeToEdge[node]);
-            }
-            return;
-        }
-        // Re-insert folded internal/via edges between consecutive real edges so
-        // the returned route is a valid edge sequence.
-        for (size_t i = 0; i < nodePath.size(); i++) {
-            const E* e = myNodeToEdge[nodePath[i]];
-            into.push_back(e);
-            if (i + 1 < nodePath.size()) {
-                const E* next = myNodeToEdge[nodePath[i + 1]];
-                for (const auto& follower : e->getViaSuccessors(SVC_IGNORING)) {
-                    if (follower.first == next) {
-                        const E* via = follower.second;
-                        while (via != nullptr && via->isInternal()) {
-                            into.push_back(via);
-                            const auto& vs = via->getViaSuccessors();
-                            via = vs.empty() ? nullptr : vs.front().second;
-                        }
-                        break;
-                    }
-                }
-            }
+        for (unsigned node : nodePath) {
+            into.push_back(myNodeToEdge[node]);
         }
     }
 
@@ -447,10 +417,6 @@ private:
     std::map<const E*, std::vector<unsigned> > myTazSrcNodes;
     /// @brief TAZ-sink connector edge -> its exit-edge road node ids
     std::map<const E*, std::vector<unsigned> > myTazSnkNodes;
-    /// @brief whether any arc folds a real internal/via edge chain. False for
-    /// --no-internal-links nets: lets path expansion skip the per-hop
-    /// getViaSuccessors lookup (which locks under multithreading).
-    bool myHasVia;
     /// @brief the immutable hierarchy
     RoutingKit::CustomizableContractionHierarchy myCCH;
 

--- a/src/utils/router/CCHGraphBase.h
+++ b/src/utils/router/CCHGraphBase.h
@@ -106,7 +106,14 @@ public:
         }
         myEdgeToNode.assign(maxNumID + 1, INVALID_NODE);
         for (const E* e : allEdges) {
-            if (e->isInternal() || e->isTazConnector()) {
+            // excluded are junction-internal edges and the district STAR
+            // connectors ("<taz>-source"/"-sink", the high-degree phantom
+            // edges -- see the class documentation). Legacy net edges with
+            // function="connector" are ordinary routable geometry for the
+            // exact routers and therefore stay ordinary nodes here; only the
+            // paired district connectors (identified by their
+            // otherTazConnector link) are kept out of the hierarchy.
+            if (e->isInternal() || isStarConnector(e)) {
                 continue;
             }
             const unsigned node = (unsigned)myNodeToEdge.size();
@@ -181,7 +188,7 @@ public:
         // source connector (entry edges), predecessors for a sink connector.
         unsigned nTazSrc = 0, nTazSnk = 0;
         for (const E* e : allEdges) {
-            if (!e->isTazConnector()) {
+            if (!isStarConnector(e)) {
                 continue;
             }
             std::vector<unsigned> srcNodes;
@@ -364,6 +371,13 @@ public:
     }
 
 private:
+    /// @brief whether the edge is a district star connector (the paired
+    /// "<taz>-source"/"-sink" phantom edge) as opposed to a legacy
+    /// function="connector" net edge, which stays routable
+    static bool isStarConnector(const E* e) {
+        return e->isTazConnector() && e->getOtherTazConnector() != nullptr;
+    }
+
     /** @brief Record which arcs @p vClass may traverse in the per-arc
      * CONNECTION-level permission bitmask -- exactly the arcs
      * getViaSuccessors(vClass) yields (edge-level getPermissions() is too

--- a/src/utils/router/CCHRouter.h
+++ b/src/utils/router/CCHRouter.h
@@ -171,7 +171,7 @@ public:
 
         this->startQuery();
         const double t = STEPS2TIME(msTime);
-        if (!runQuery(metric, *sources, *targets, t)) {
+        if (!runQuery(metric, *sources, *targets, vehicle, t)) {
             this->endQuery(0);
             if (!silent && this->myErrorMsgHandler != nullptr) {
                 this->myErrorMsgHandler->informf(TL("No connection between edge '%' and edge '%' found."),
@@ -198,7 +198,7 @@ public:
                     && msTime + TIME2STEPS((double)myQuery.get_distance() / 100.) >= boundary) {
                 MetricPtr altMetric = myMetricProvider(vClass, boundary, vehicle);
                 if (altMetric != nullptr && altMetric != metric
-                        && runQuery(altMetric, *sources, *targets, t)) {
+                        && runQuery(altMetric, *sources, *targets, vehicle, t)) {
                     std::vector<const E*> altPath;
                     buildPath(from, to, fromTaz, toTaz, altPath);
                     visited += (int)altPath.size();
@@ -246,7 +246,7 @@ private:
      * how expensive each entry edge is and picks a different entry than A*.
      * Targets seed 0: the arc INTO a target already carries its effort. */
     bool runQuery(MetricPtr metric, const std::vector<unsigned>& sources,
-                  const std::vector<unsigned>& targets, double t) {
+                  const std::vector<unsigned>& targets, const V* const vehicle, double t) {
         if (metric != myBoundMetric) {
             myQuery.reset(*metric);
             myBoundMetric = metric;
@@ -255,7 +255,7 @@ private:
         }
         const double bigEff = (double)(RoutingKit::inf_weight - 1) / 100.0;
         for (const unsigned s : sources) {
-            const double eff = this->getEffort(myGraph->edgeOf(s), nullptr, t);
+            const double eff = this->getEffort(myGraph->edgeOf(s), vehicle, t);
             const unsigned d = eff < bigEff ? (unsigned)llround(eff * 100.0) : RoutingKit::inf_weight - 1;
             myQuery.add_source(s, d);
         }

--- a/src/utils/router/CCHRouter.h
+++ b/src/utils/router/CCHRouter.h
@@ -87,9 +87,10 @@ public:
      * @param[in] fallback  embedded router for non-CCH cases (OWNED)
      */
     CCHRouter(const GRAPH* graph, MetricProvider provider,
-              Operation operation, SUMOAbstractRouter<E, V>* fallback,
+              Operation operation, const bool unbuildIsWarning,
+              SUMOAbstractRouter<E, V>* fallback,
               PeriodEnd periodEnd = nullptr) :
-        SUMOAbstractRouter<E, V>("CCHRouter", true, operation, nullptr, false, false),
+        SUMOAbstractRouter<E, V>("CCHRouter", unbuildIsWarning, operation, nullptr, false, false),
         myGraph(graph), myMetricProvider(provider), myFallback(fallback),
         myPeriodEnd(periodEnd), myProhibitionActive(false) {
     }

--- a/src/utils/router/CCHRouter.h
+++ b/src/utils/router/CCHRouter.h
@@ -125,11 +125,13 @@ public:
         if (metric == nullptr || (myProhibitionActive && !prohibitionsCoveredByMetric(vClass))) {
             return myFallback->compute(from, to, vehicle, msTime, into, silent);
         }
-        // Endpoints -> node SETS: a TAZ connector expands to its member edges
-        // (phantom-node seeding); a real edge is a single node. TAZ member edges
-        // are the class-union set, so filter to edges this class may enter.
-        const bool fromTaz = from->isTazConnector();
-        const bool toTaz = to->isTazConnector();
+        // Endpoints -> node SETS: a district star connector expands to its
+        // member edges (phantom-node seeding); everything that is a graph
+        // node -- including legacy function="connector" net edges -- routes
+        // as a single node. TAZ member edges are the class-union set, so
+        // filter to edges this class may enter.
+        const bool fromTaz = from->isTazConnector() && myGraph->nodeOf(from) == GRAPH::INVALID_NODE;
+        const bool toTaz = to->isTazConnector() && myGraph->nodeOf(to) == GRAPH::INVALID_NODE;
         std::vector<unsigned> srcBuf, tgtBuf;
         const std::vector<unsigned>* sources;
         const std::vector<unsigned>* targets;

--- a/src/utils/router/CMakeLists.txt
+++ b/src/utils/router/CMakeLists.txt
@@ -6,7 +6,7 @@ set(utils_router_STAT_SRCS
    PedestrianEdge.h
    PublicTransportEdge.h
    StopEdge.h
-   CCHGraphBase.h
+   CCHGraph.h
    CCHRouter.h
    CHBuilder.h
    CHRouter.h

--- a/tests/duarouter/closingLane/one_straight/alts.duarouter.cch
+++ b/tests/duarouter/closingLane/one_straight/alts.duarouter.cch
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on 2026-08-28T08:17:32.706576+01:00 by Eclipse SUMO duarouter v1.27.1-0000000000
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+This file may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License 2.0 are satisfied: GNU General Public License, version 2
+or later which is available at
+https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+<duarouterConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/duarouterConfiguration.xsd">
+
+    <input>
+        <net-file value="input_net.net.xml"/>
+        <additional-files value="input_additional.add.xml"/>
+        <route-files value="input_routes.rou.xml"/>
+    </input>
+
+    <output>
+        <output-file value="routes.rou.xml"/>
+        <write-license value="true"/>
+    </output>
+
+    <processing>
+        <routing-algorithm value="CCH"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+        <no-step-log value="true"/>
+    </report>
+
+</duarouterConfiguration>
+-->
+
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <vehicle id="before_closing" depart="0.00">
+        <routeDistribution last="0">
+            <route cost="107.91" probability="1.00000000" edges="beg middle end"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="close_en_route" depart="990.00">
+        <routeDistribution last="0">
+            <route cost="107.91" probability="1.00000000" edges="beg middle end"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="closed_on_depart" depart="1100.00">
+        <routeDistribution last="0">
+            <route cost="107.91" probability="1.00000000" edges="beg middle end"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="opened_en_route" depart="1990.00">
+        <routeDistribution last="0">
+            <route cost="107.91" probability="1.00000000" edges="beg middle end"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="opened_on_depart" depart="2100.00">
+        <routeDistribution last="0">
+            <route cost="107.91" probability="1.00000000" edges="beg middle end"/>
+        </routeDistribution>
+    </vehicle>
+</routes>

--- a/tests/duarouter/closingLane/one_straight/routes.duarouter.cch
+++ b/tests/duarouter/closingLane/one_straight/routes.duarouter.cch
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on 2026-08-28T08:17:32.705157+01:00 by Eclipse SUMO duarouter v1.27.1-0000000000
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+This file may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License 2.0 are satisfied: GNU General Public License, version 2
+or later which is available at
+https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+<duarouterConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/duarouterConfiguration.xsd">
+
+    <input>
+        <net-file value="input_net.net.xml"/>
+        <additional-files value="input_additional.add.xml"/>
+        <route-files value="input_routes.rou.xml"/>
+    </input>
+
+    <output>
+        <output-file value="routes.rou.xml"/>
+        <write-license value="true"/>
+    </output>
+
+    <processing>
+        <routing-algorithm value="CCH"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+        <no-step-log value="true"/>
+    </report>
+
+</duarouterConfiguration>
+-->
+
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <vehicle id="before_closing" depart="0.00">
+        <route edges="beg middle end"/>
+    </vehicle>
+    <vehicle id="close_en_route" depart="990.00">
+        <route edges="beg middle end"/>
+    </vehicle>
+    <vehicle id="closed_on_depart" depart="1100.00">
+        <route edges="beg middle end"/>
+    </vehicle>
+    <vehicle id="opened_en_route" depart="1990.00">
+        <route edges="beg middle end"/>
+    </vehicle>
+    <vehicle id="opened_on_depart" depart="2100.00">
+        <route edges="beg middle end"/>
+    </vehicle>
+</routes>

--- a/tests/duarouter/config.duarouter.cch
+++ b/tests/duarouter/config.duarouter.cch
@@ -1,3 +1,4 @@
 [run_dependent_text]
 output:DijkstraRouter{REPLACE CCHRouter}
+output:AStarRouter{REPLACE CCHRouter}
 output: queries and explored [0-9\.]+ edges{REPLACE queries}

--- a/tests/duarouter/errors/testsuite.duarouter.cch
+++ b/tests/duarouter/errors/testsuite.duarouter.cch
@@ -1,0 +1,66 @@
+# Tests for importing trips with an empty vehicle class
+empty_vclass
+
+# Tests what happens if the net is not given
+no_net
+
+# Tests what happens if the net is not available
+false_net
+
+# Tests what happens if the output is not given
+no_output
+
+# Tests what happens if the output can not be written
+false_output
+
+# Tests what happens if the input is not given
+no_input
+no_input_ignore
+
+# Tests what happens if an unknown option is passed
+unknown_option
+
+# Tests what happens if an unknown measure is passed as weights attribute
+#unknown_measure
+
+# Tests what happens if the given alternatives do not exist
+false_input_alts
+
+# Tests what happens if the given flows do not exist
+false_input_flows
+
+# Tests what happens if the given sumo-routes do not exist
+false_input_sumo
+
+# Tests what happens if the given trip-definitions do not exist
+false_input_trips
+
+# Default departlane is false
+default_departlane_false
+
+# Default departpos is false
+default_departpos_false
+
+# Default departspeed is false
+default_departspeed_false
+
+# Default arrivallane is false
+default_arrivallane_false
+
+# Default arrivalpos is false
+default_arrivalpos_false
+
+# Default arrivalspeed is false
+default_arrivalspeed_false
+
+# given an unknown vType should be an error
+unknown_vType
+
+# unknown vType should be replaced by DEFAULT_VEHTYPE when ignoring errors
+unknown_vType_ignore
+
+# Tests what happens if invalid stops are loaded (duplicate IDs)
+invalid_stops
+
+# Tests what happens if invalid vTypes without attributes are present
+empty_vtype

--- a/tests/duarouter/function/costs/alts.duarouter.cch
+++ b/tests/duarouter/function/costs/alts.duarouter.cch
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on 2026-08-28T08:44:28.232195+01:00 by Eclipse SUMO duarouter v1.27.1-0000000000
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+This file may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License 2.0 are satisfied: GNU General Public License, version 2
+or later which is available at
+https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+<duarouterConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/duarouterConfiguration.xsd">
+
+    <input>
+        <net-file value="input_net.net.xml"/>
+        <route-files value="input_routes.rou.xml"/>
+    </input>
+
+    <output>
+        <output-file value="routes.rou.xml"/>
+        <write-license value="true"/>
+        <write-costs value="true"/>
+    </output>
+
+    <processing>
+        <routing-algorithm value="CCH"/>
+        <weights.random-factor value="2"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+        <no-step-log value="true"/>
+    </report>
+
+</duarouterConfiguration>
+-->
+
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <person id="ped.0" depart="0.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1256.39"/>
+    </person>
+    <person id="ped.1" depart="1.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1310.06"/>
+    </person>
+    <person id="ped.2" depart="2.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1400.88"/>
+    </person>
+    <person id="ped.3" depart="3.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1498.57"/>
+    </person>
+    <person id="ped.4" depart="4.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1302.85"/>
+    </person>
+    <person id="ped.5" depart="5.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1450.19"/>
+    </person>
+    <person id="ped.6" depart="6.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1282.73"/>
+    </person>
+    <person id="ped.7" depart="7.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1351.75"/>
+    </person>
+    <person id="ped.8" depart="8.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1431.11"/>
+    </person>
+    <person id="ped.9" depart="9.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1324.44"/>
+    </person>
+    <person id="ped.10" depart="10.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1351.54"/>
+    </person>
+    <person id="ped.11" depart="11.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1350.68"/>
+    </person>
+    <person id="ped.12" depart="12.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1263.72"/>
+    </person>
+    <person id="ped.13" depart="13.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1406.22"/>
+    </person>
+    <person id="ped.14" depart="14.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1450.31"/>
+    </person>
+    <person id="ped.15" depart="15.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1343.18"/>
+    </person>
+    <person id="ped.16" depart="16.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1292.96"/>
+    </person>
+    <person id="ped.17" depart="17.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1266.25"/>
+    </person>
+    <person id="ped.18" depart="18.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1229.62"/>
+    </person>
+    <person id="ped.19" depart="19.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1423.90"/>
+    </person>
+    <vehicle id="cars.0" depart="30.00">
+        <routeDistribution last="0">
+            <route cost="96.29" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.1" depart="31.00">
+        <routeDistribution last="0">
+            <route cost="113.78" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.2" depart="32.00">
+        <routeDistribution last="0">
+            <route cost="100.46" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.3" depart="33.00">
+        <routeDistribution last="0">
+            <route cost="105.81" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.4" depart="34.00">
+        <routeDistribution last="0">
+            <route cost="101.75" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.5" depart="35.00">
+        <routeDistribution last="0">
+            <route cost="99.82" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.6" depart="36.00">
+        <routeDistribution last="0">
+            <route cost="117.75" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.7" depart="37.00">
+        <routeDistribution last="0">
+            <route cost="114.05" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.8" depart="38.00">
+        <routeDistribution last="0">
+            <route cost="113.83" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.9" depart="39.00">
+        <routeDistribution last="0">
+            <route cost="104.48" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.10" depart="40.00">
+        <routeDistribution last="0">
+            <route cost="117.16" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.11" depart="41.00">
+        <routeDistribution last="0">
+            <route cost="99.75" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.12" depart="42.00">
+        <routeDistribution last="0">
+            <route cost="117.20" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.13" depart="43.00">
+        <routeDistribution last="0">
+            <route cost="119.48" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.14" depart="44.00">
+        <routeDistribution last="0">
+            <route cost="107.81" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.15" depart="45.00">
+        <routeDistribution last="0">
+            <route cost="109.07" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.16" depart="46.00">
+        <routeDistribution last="0">
+            <route cost="108.19" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.17" depart="47.00">
+        <routeDistribution last="0">
+            <route cost="96.95" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.18" depart="48.00">
+        <routeDistribution last="0">
+            <route cost="101.10" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.19" depart="49.00">
+        <routeDistribution last="0">
+            <route cost="111.49" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+</routes>

--- a/tests/duarouter/function/costs/routes.duarouter.cch
+++ b/tests/duarouter/function/costs/routes.duarouter.cch
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on 2026-08-28T08:44:28.231373+01:00 by Eclipse SUMO duarouter v1.27.1-0000000000
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+This file may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License 2.0 are satisfied: GNU General Public License, version 2
+or later which is available at
+https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+<duarouterConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/duarouterConfiguration.xsd">
+
+    <input>
+        <net-file value="input_net.net.xml"/>
+        <route-files value="input_routes.rou.xml"/>
+    </input>
+
+    <output>
+        <output-file value="routes.rou.xml"/>
+        <write-license value="true"/>
+        <write-costs value="true"/>
+    </output>
+
+    <processing>
+        <routing-algorithm value="CCH"/>
+        <weights.random-factor value="2"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+        <no-step-log value="true"/>
+    </report>
+
+</duarouterConfiguration>
+-->
+
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <person id="ped.0" depart="0.00">
+        <walk cost="1256.39" edges="A0B0 B0A0 B0C0 C1C0 C1D1 D1D2 D3D2 E3D3 E4E3 E5E4 E5F5"/>
+    </person>
+    <person id="ped.1" depart="1.00">
+        <walk cost="1310.06" edges="A0B0 A1A0 A1A2 B2A2 C2B2 C2C3 C3D3 D4D3 D4D5 D5E5 E5F5"/>
+    </person>
+    <person id="ped.2" depart="2.00">
+        <walk cost="1400.88" edges="A0B0 B0A0 C0B0 C0C1 C1C2 C2C3 D3C3 D4D3 D5D4 D5E5 E5F5"/>
+    </person>
+    <person id="ped.3" depart="3.00">
+        <walk cost="1498.57" edges="A0B0 A0A1 A1B1 B2B1 B3B2 B3B4 C4B4 D4C4 E4D4 E5E4 E5F5"/>
+    </person>
+    <person id="ped.4" depart="4.00">
+        <walk cost="1302.85" edges="A0B0 B0A0 C0B0 C1C0 C2C1 C2C3 C3C4 D4C4 E4D4 E4E5 E5F5"/>
+    </person>
+    <person id="ped.5" depart="5.00">
+        <walk cost="1450.19" edges="A0B0 B1B0 B1C1 C1C2 D2C2 D2D3 D4D3 D4D5 E5D5 E5F5"/>
+    </person>
+    <person id="ped.6" depart="6.00">
+        <walk cost="1282.73" edges="A0B0 B0A0 B0C0 D0C0 D1D0 D1E1 E1E2 E3E2 E3E4 E5E4 E5F5"/>
+    </person>
+    <person id="ped.7" depart="7.00">
+        <walk cost="1351.75" edges="A0B0 A1A0 A1A2 A2B2 C2B2 C2D2 D2D3 D4D3 D5D4 D5E5 E5F5"/>
+    </person>
+    <person id="ped.8" depart="8.00">
+        <walk cost="1431.11" edges="A0B0 A0A1 A1B1 B2B1 B2B3 B3C3 C4C3 C4C5 D5C5 E5D5 E5F5"/>
+    </person>
+    <person id="ped.9" depart="9.00">
+        <walk cost="1324.44" edges="A0B0 B0B1 B1C1 C1C2 C2D2 E2D2 E3E2 E4E3 E4E5 E5F5"/>
+    </person>
+    <person id="ped.10" depart="10.00">
+        <walk cost="1351.54" edges="A0B0 A1A0 A2A1 B2A2 B3B2 C3B3 C4C3 D4C4 D4E4 E4E5 E5F5"/>
+    </person>
+    <person id="ped.11" depart="11.00">
+        <walk cost="1350.68" edges="A0B0 A1A0 A1A2 A2A3 A3A4 A4B4 B4B5 C5B5 D5C5 E5D5 E5F5"/>
+    </person>
+    <person id="ped.12" depart="12.00">
+        <walk cost="1263.72" edges="A0B0 B1B0 B1B2 B2B3 B4B3 B4B5 C5B5 D5C5 D5E5 E5F5"/>
+    </person>
+    <person id="ped.13" depart="13.00">
+        <walk cost="1406.22" edges="A0B0 A0A1 B1A1 B1B2 B3B2 B4B3 C4B4 D4C4 D5D4 E5D5 E5F5"/>
+    </person>
+    <person id="ped.14" depart="14.00">
+        <walk cost="1450.31" edges="A0B0 B0B1 B1C1 C2C1 C2C3 C3C4 D4C4 D4E4 E5E4 E5F5"/>
+    </person>
+    <person id="ped.15" depart="15.00">
+        <walk cost="1343.18" edges="A0B0 C0B0 C1C0 C2C1 C2D2 D3D2 D3D4 D4E4 E4E5 E5F5"/>
+    </person>
+    <person id="ped.16" depart="16.00">
+        <walk cost="1292.96" edges="A0B0 B0A0 B0B1 B2B1 B3B2 B4B3 B4B5 C5B5 C5D5 E5D5 E5F5"/>
+    </person>
+    <person id="ped.17" depart="17.00">
+        <walk cost="1266.25" edges="A0B0 B0B1 B1B2 B3B2 B3C3 C3D3 D4D3 E4D4 E4E5 E5F5"/>
+    </person>
+    <person id="ped.18" depart="18.00">
+        <walk cost="1229.62" edges="A0B0 A1A0 A2A1 A2B2 B2B3 B4B3 B5B4 C5B5 D5C5 E5D5 E5F5"/>
+    </person>
+    <person id="ped.19" depart="19.00">
+        <walk cost="1423.90" edges="A0B0 B0A0 B0C0 C0C1 C1D1 D2D1 D3D2 D3D4 D4D5 E5D5 E5F5"/>
+    </person>
+    <vehicle id="cars.0" depart="30.00">
+        <route cost="96.29" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.1" depart="31.00">
+        <route cost="113.78" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.2" depart="32.00">
+        <route cost="100.46" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.3" depart="33.00">
+        <route cost="105.81" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.4" depart="34.00">
+        <route cost="101.75" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.5" depart="35.00">
+        <route cost="99.82" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.6" depart="36.00">
+        <route cost="117.75" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.7" depart="37.00">
+        <route cost="114.05" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.8" depart="38.00">
+        <route cost="113.83" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.9" depart="39.00">
+        <route cost="104.48" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.10" depart="40.00">
+        <route cost="117.16" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.11" depart="41.00">
+        <route cost="99.75" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.12" depart="42.00">
+        <route cost="117.20" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.13" depart="43.00">
+        <route cost="119.48" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.14" depart="44.00">
+        <route cost="107.81" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.15" depart="45.00">
+        <route cost="109.07" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.16" depart="46.00">
+        <route cost="108.19" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.17" depart="47.00">
+        <route cost="96.95" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.18" depart="48.00">
+        <route cost="101.10" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.19" depart="49.00">
+        <route cost="111.49" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+</routes>

--- a/tests/duarouter/function/measure/testsuite.duarouter.cch
+++ b/tests/duarouter/function/measure/testsuite.duarouter.cch
@@ -1,0 +1,21 @@
+#dijkstra_CO
+#dijkstra_CO2
+#dijkstra_fuel
+#dijkstra_HC
+#dijkstra_NOx
+#dijkstra_PMx
+
+# use custom weight attribute
+#dijkstra_custom
+
+# This are the correct (plain) one
+dijkstra_TT
+dijkstra_edge_priority_inactive
+dijkstra_edge_priority
+
+# ensure that priority is also used with the RailwayRouter
+dijkstra_edge_priority_rail
+dijkstra_plain
+
+# Further tests for time line processing
+#timeline

--- a/tests/duarouter/function/random-factor/alts.duarouter.cch
+++ b/tests/duarouter/function/random-factor/alts.duarouter.cch
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on 2026-08-28T08:44:28.231430+01:00 by Eclipse SUMO duarouter v1.27.1-0000000000
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+This file may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License 2.0 are satisfied: GNU General Public License, version 2
+or later which is available at
+https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+<duarouterConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/duarouterConfiguration.xsd">
+
+    <input>
+        <net-file value="input_net.net.xml"/>
+        <route-files value="input_routes.rou.xml"/>
+    </input>
+
+    <output>
+        <output-file value="routes.rou.xml"/>
+        <write-license value="true"/>
+    </output>
+
+    <processing>
+        <routing-algorithm value="CCH"/>
+        <weights.random-factor value="2"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+        <no-step-log value="true"/>
+    </report>
+
+</duarouterConfiguration>
+-->
+
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <person id="ped.0" depart="0.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1256.39"/>
+    </person>
+    <person id="ped.1" depart="1.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1310.06"/>
+    </person>
+    <person id="ped.2" depart="2.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1400.88"/>
+    </person>
+    <person id="ped.3" depart="3.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1498.57"/>
+    </person>
+    <person id="ped.4" depart="4.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1302.85"/>
+    </person>
+    <person id="ped.5" depart="5.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1450.19"/>
+    </person>
+    <person id="ped.6" depart="6.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1282.73"/>
+    </person>
+    <person id="ped.7" depart="7.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1351.75"/>
+    </person>
+    <person id="ped.8" depart="8.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1431.11"/>
+    </person>
+    <person id="ped.9" depart="9.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1324.44"/>
+    </person>
+    <person id="ped.10" depart="10.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1351.54"/>
+    </person>
+    <person id="ped.11" depart="11.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1350.68"/>
+    </person>
+    <person id="ped.12" depart="12.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1263.72"/>
+    </person>
+    <person id="ped.13" depart="13.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1406.22"/>
+    </person>
+    <person id="ped.14" depart="14.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1450.31"/>
+    </person>
+    <person id="ped.15" depart="15.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1343.18"/>
+    </person>
+    <person id="ped.16" depart="16.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1292.96"/>
+    </person>
+    <person id="ped.17" depart="17.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1266.25"/>
+    </person>
+    <person id="ped.18" depart="18.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1229.62"/>
+    </person>
+    <person id="ped.19" depart="19.00">
+        <personTrip from="A0B0" to="E5F5" walkFactor="0.75" costs="1423.90"/>
+    </person>
+    <vehicle id="cars.0" depart="30.00">
+        <routeDistribution last="0">
+            <route cost="96.29" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.1" depart="31.00">
+        <routeDistribution last="0">
+            <route cost="113.78" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.2" depart="32.00">
+        <routeDistribution last="0">
+            <route cost="100.46" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.3" depart="33.00">
+        <routeDistribution last="0">
+            <route cost="105.81" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.4" depart="34.00">
+        <routeDistribution last="0">
+            <route cost="101.75" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.5" depart="35.00">
+        <routeDistribution last="0">
+            <route cost="99.82" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.6" depart="36.00">
+        <routeDistribution last="0">
+            <route cost="117.75" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.7" depart="37.00">
+        <routeDistribution last="0">
+            <route cost="114.05" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.8" depart="38.00">
+        <routeDistribution last="0">
+            <route cost="113.83" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.9" depart="39.00">
+        <routeDistribution last="0">
+            <route cost="104.48" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.10" depart="40.00">
+        <routeDistribution last="0">
+            <route cost="117.16" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.11" depart="41.00">
+        <routeDistribution last="0">
+            <route cost="99.75" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.12" depart="42.00">
+        <routeDistribution last="0">
+            <route cost="117.20" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.13" depart="43.00">
+        <routeDistribution last="0">
+            <route cost="119.48" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.14" depart="44.00">
+        <routeDistribution last="0">
+            <route cost="107.81" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.15" depart="45.00">
+        <routeDistribution last="0">
+            <route cost="109.07" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.16" depart="46.00">
+        <routeDistribution last="0">
+            <route cost="108.19" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.17" depart="47.00">
+        <routeDistribution last="0">
+            <route cost="96.95" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.18" depart="48.00">
+        <routeDistribution last="0">
+            <route cost="101.10" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+    <vehicle id="cars.19" depart="49.00">
+        <routeDistribution last="0">
+            <route cost="111.49" probability="1.00000000" edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+        </routeDistribution>
+    </vehicle>
+</routes>

--- a/tests/duarouter/function/random-factor/routes.duarouter.cch
+++ b/tests/duarouter/function/random-factor/routes.duarouter.cch
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on 2026-08-28T08:44:28.230282+01:00 by Eclipse SUMO duarouter v1.27.1-0000000000
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+This file may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License 2.0 are satisfied: GNU General Public License, version 2
+or later which is available at
+https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+<duarouterConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/duarouterConfiguration.xsd">
+
+    <input>
+        <net-file value="input_net.net.xml"/>
+        <route-files value="input_routes.rou.xml"/>
+    </input>
+
+    <output>
+        <output-file value="routes.rou.xml"/>
+        <write-license value="true"/>
+    </output>
+
+    <processing>
+        <routing-algorithm value="CCH"/>
+        <weights.random-factor value="2"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+        <no-step-log value="true"/>
+    </report>
+
+</duarouterConfiguration>
+-->
+
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <person id="ped.0" depart="0.00">
+        <walk edges="A0B0 B0A0 B0C0 C1C0 C1D1 D1D2 D3D2 E3D3 E4E3 E5E4 E5F5"/>
+    </person>
+    <person id="ped.1" depart="1.00">
+        <walk edges="A0B0 A1A0 A1A2 B2A2 C2B2 C2C3 C3D3 D4D3 D4D5 D5E5 E5F5"/>
+    </person>
+    <person id="ped.2" depart="2.00">
+        <walk edges="A0B0 B0A0 C0B0 C0C1 C1C2 C2C3 D3C3 D4D3 D5D4 D5E5 E5F5"/>
+    </person>
+    <person id="ped.3" depart="3.00">
+        <walk edges="A0B0 A0A1 A1B1 B2B1 B3B2 B3B4 C4B4 D4C4 E4D4 E5E4 E5F5"/>
+    </person>
+    <person id="ped.4" depart="4.00">
+        <walk edges="A0B0 B0A0 C0B0 C1C0 C2C1 C2C3 C3C4 D4C4 E4D4 E4E5 E5F5"/>
+    </person>
+    <person id="ped.5" depart="5.00">
+        <walk edges="A0B0 B1B0 B1C1 C1C2 D2C2 D2D3 D4D3 D4D5 E5D5 E5F5"/>
+    </person>
+    <person id="ped.6" depart="6.00">
+        <walk edges="A0B0 B0A0 B0C0 D0C0 D1D0 D1E1 E1E2 E3E2 E3E4 E5E4 E5F5"/>
+    </person>
+    <person id="ped.7" depart="7.00">
+        <walk edges="A0B0 A1A0 A1A2 A2B2 C2B2 C2D2 D2D3 D4D3 D5D4 D5E5 E5F5"/>
+    </person>
+    <person id="ped.8" depart="8.00">
+        <walk edges="A0B0 A0A1 A1B1 B2B1 B2B3 B3C3 C4C3 C4C5 D5C5 E5D5 E5F5"/>
+    </person>
+    <person id="ped.9" depart="9.00">
+        <walk edges="A0B0 B0B1 B1C1 C1C2 C2D2 E2D2 E3E2 E4E3 E4E5 E5F5"/>
+    </person>
+    <person id="ped.10" depart="10.00">
+        <walk edges="A0B0 A1A0 A2A1 B2A2 B3B2 C3B3 C4C3 D4C4 D4E4 E4E5 E5F5"/>
+    </person>
+    <person id="ped.11" depart="11.00">
+        <walk edges="A0B0 A1A0 A1A2 A2A3 A3A4 A4B4 B4B5 C5B5 D5C5 E5D5 E5F5"/>
+    </person>
+    <person id="ped.12" depart="12.00">
+        <walk edges="A0B0 B1B0 B1B2 B2B3 B4B3 B4B5 C5B5 D5C5 D5E5 E5F5"/>
+    </person>
+    <person id="ped.13" depart="13.00">
+        <walk edges="A0B0 A0A1 B1A1 B1B2 B3B2 B4B3 C4B4 D4C4 D5D4 E5D5 E5F5"/>
+    </person>
+    <person id="ped.14" depart="14.00">
+        <walk edges="A0B0 B0B1 B1C1 C2C1 C2C3 C3C4 D4C4 D4E4 E5E4 E5F5"/>
+    </person>
+    <person id="ped.15" depart="15.00">
+        <walk edges="A0B0 C0B0 C1C0 C2C1 C2D2 D3D2 D3D4 D4E4 E4E5 E5F5"/>
+    </person>
+    <person id="ped.16" depart="16.00">
+        <walk edges="A0B0 B0A0 B0B1 B2B1 B3B2 B4B3 B4B5 C5B5 C5D5 E5D5 E5F5"/>
+    </person>
+    <person id="ped.17" depart="17.00">
+        <walk edges="A0B0 B0B1 B1B2 B3B2 B3C3 C3D3 D4D3 E4D4 E4E5 E5F5"/>
+    </person>
+    <person id="ped.18" depart="18.00">
+        <walk edges="A0B0 A1A0 A2A1 A2B2 B2B3 B4B3 B5B4 C5B5 D5C5 E5D5 E5F5"/>
+    </person>
+    <person id="ped.19" depart="19.00">
+        <walk edges="A0B0 B0A0 B0C0 C0C1 C1D1 D2D1 D3D2 D3D4 D4D5 E5D5 E5F5"/>
+    </person>
+    <vehicle id="cars.0" depart="30.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.1" depart="31.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.2" depart="32.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.3" depart="33.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.4" depart="34.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.5" depart="35.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.6" depart="36.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.7" depart="37.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.8" depart="38.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.9" depart="39.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.10" depart="40.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.11" depart="41.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.12" depart="42.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.13" depart="43.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.14" depart="44.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.15" depart="45.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.16" depart="46.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.17" depart="47.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.18" depart="48.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+    <vehicle id="cars.19" depart="49.00">
+        <route edges="A5B5 B5C5 C5D5 D5E5 E5E4 E4E3 E3E2 E2E1 E1E0 E0F0"/>
+    </vehicle>
+</routes>

--- a/tests/duarouter/function/routing/testsuite.duarouter.cch
+++ b/tests/duarouter/function/routing/testsuite.duarouter.cch
@@ -1,0 +1,40 @@
+# Test whether vehicles respect the fifo principle on routing
+#fifo
+
+# Test whether vehicles respect the fifo principle with interpolation
+#fifo_interpolate
+
+# when routing based on stored traveltimes the vehicles maximum speed must still be considered
+traveltime_always_checks_vehspeed
+
+# tests for validating particular aspects of chrouter against dijkstra
+# - tests/duarouter establishes the base line
+# - tests/duarouter.chrouter must produce the same results
+chrouter
+
+# landmark routing
+#astar_landmark
+#astar_landmark_save
+
+# input landmarks are given as geo-coordinates
+#astar_landmark_save_geo
+#astar_landmark_save_parallel
+
+# input landmarks are given as geo-coordinates
+#astar_landmark_save_geo_parallel
+
+# landmark routing with taz
+#astar_landmark_taz
+
+# landmark routing with taz but the taz were not included when building the table
+#astar_landmark_taz_missing
+#astar_landmark_table_incomplete
+
+# missing landmark edge
+#astar_landmark_missing
+
+# landmark routing
+#astar_landmark_random_wights
+
+# testing lane weight files
+lane_weight_files

--- a/tests/duarouter/meta/with_log/log.duarouter.cch
+++ b/tests/duarouter/meta/with_log/log.duarouter.cch
@@ -1,0 +1,5 @@
+Loading net ... done.
+Skipped until: 0.00
+Routes found between time steps 0.00 and 0.00.
+CCHRouter answered 2 queries and explored 4.00 edges on average.
+CCHRouter spent 0.00s answering queries (0.00ms on average).

--- a/tests/duarouter/meta/write_config/cfg.duarouter.cch
+++ b/tests/duarouter/meta/write_config/cfg.duarouter.cch
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on 2026-08-28T08:17:28.394143+01:00 by Eclipse SUMO duarouter v1.27.1-0000000000
+-->
+
+<duarouterConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/duarouterConfiguration.xsd">
+
+    <input>
+        <net-file value="input_net.net.xml"/>
+        <route-files value="input_alts.rou.alt.xml"/>
+    </input>
+
+    <output>
+        <output-file value="routes.rou.xml"/>
+    </output>
+
+    <processing>
+        <routing-algorithm value="CCH"/>
+    </processing>
+
+</duarouterConfiguration>


### PR DESCRIPTION
Follow-up to #18250. I ran the duarouter suite with the cch variant and found three real bugs:

- Edges declared with function="connector" in the net were excluded from the hierarchy as if they were district connectors. They are normal routable edges for the exact routers, so TAZ entry/exit selection went wrong (trips/TAZ/taz_weights). Now only the paired "-source"/"-sink" district connectors stay out of the graph.
- The metrics were filled with a null reference vehicle, which ignored the type's maximum speed, the vClass specific speed limits and restriction-params (vclasses/vClass_specific_speeds, trips/restrictionParams). There is now one metric per vehicle type and the queries pass the vehicle.
- The path expansion re-inserted internal edges into the returned route. Routes never contain internal edges, so identical routes compared unequal (duplicate alternatives in the vclasses tests) and nets with internal links would have gotten invalid routes.

After the fixes I compared all 350 tests that write alternatives (4474 vehicles) against the dijkstra results: 4465 are identical in route and cost, 3 pick a different path with the same cost (the astar_landmark tests) and 6 differ in cost for known reasons: closingLane/one_straight matches what alts.duarouter.chwrapper already codifies for time-bounded closures, fifo and fifo_interpolate change weights below the weight-period (they are not in the chwrapper suite either) and trips/stops/jumps/jump is off by 0.01, the rounding unit of the metric.

What remains in the cch variant are the option rejections that the other variants also exclude (measure, random-factor, preferences) and the verbose/error output wording, which needs .cch reference files like chrouter and chwrapper have. I can generate those if you want.