### PR TITLE
Feature/cch upstream

### DIFF
--- a/docs/web/docs/Routing_Algorithms.md
+++ b/docs/web/docs/Routing_Algorithms.md
@@ -7,7 +7,7 @@ title: Routing Algorithms
 Applications that perform routing ([sumo](sumo.md),
 [sumo-gui](sumo-gui.md), [duarouter](duarouter.md),
 [marouter](marouter.md)) support the option **--routing-algorithm** for selecting among
-the following values (**CCH** is only available for sumo/sumo-gui and duarouter):
+the following values:
 
 ## Dijkstra (`dijkstra`)
 
@@ -61,14 +61,15 @@ enabling routing in multi modal scenarios.
 
 [Customizable Contraction Hierarchies](https://doi.org/10.1145/2886843)
 (CCH) is a preprocessing-based routing algorithm, available in
-[sumo](sumo.md) and [duarouter](duarouter.md). It splits Contraction
-Hierarchies into a one-time, weight-independent topology build (the nested
-dissection order) and a much cheaper "customization" step that recomputes
-edge weights over that fixed topology. This makes it attractive when edge
-weights change repeatedly over a simulation run (unlike plain *CH*, which
-must rebuild the whole hierarchy for every **--weight-period**).
+[sumo](sumo.md), [duarouter](duarouter.md) and [marouter](marouter.md). It
+splits Contraction Hierarchies into a one-time, weight-independent topology
+build (the nested dissection order) and a much cheaper "customization" step
+that recomputes edge weights over that fixed topology. This makes it
+attractive when edge weights change repeatedly over a simulation run or an
+assignment (unlike plain *CH*, which must rebuild the whole hierarchy for
+every **--weight-period**).
 
-In both applications one metric is customized per vehicle *type* (not per
+In all three applications one metric is customized per vehicle *type* (not per
 vehicle class). Everything the travel time function reads from the type is
 therefore exact per metric: the type's maximum speed, vClass-specific edge
 speed limits, [routing preferences](Simulation/Routing.md#routing_by_travel_time_and_routingtype)
@@ -100,6 +101,12 @@ instead of a fresh draw per query as with *dijkstra* and *astar*).
   (one metric per vehicle type and weight period, built lazily on first use)
   and **--restriction-params** (the restricted edges are masked to infinite
   weight per affected vehicle type).
+- In **marouter**, one metric is customized for the default vehicle type and
+  re-customized whenever an assignment iteration has updated the travel
+  times, so every iteration routes on the same travel times a *dijkstra* run
+  would use (*CH* rebuilds its whole hierarchy at that point instead). As
+  with *CH*, the metric does not see the k shortest path penalties of
+  **--paths**, so a warning is issued for **--paths** greater than 1.
 
 !!! caution
     CCH support differs meaningfully between sumo and duarouter; see the
@@ -109,9 +116,9 @@ instead of a fresh draw per query as with *dijkstra* and *astar*).
 
 The table below summarizes which routing features are supported by each
 **--routing-algorithm** value. "partial" means the feature is only supported
-by one of the two applications that implement CCH ([sumo](sumo.md) /
-[duarouter](duarouter.md)); see the [CCH](#cch-customizable-contraction-hierarchies)
-section above for the exact split.
+by some of the applications that implement CCH ([sumo](sumo.md),
+[duarouter](duarouter.md), [marouter](marouter.md)); see the
+[CCH](#cch-customizable-contraction-hierarchies) section above for the exact split.
 
 | Feature | dijkstra | astar / ALT | CH | CHWrapper | CCH |
 |---|---|---|---|---|---|

--- a/docs/web/docs/Routing_Algorithms.md
+++ b/docs/web/docs/Routing_Algorithms.md
@@ -68,28 +68,38 @@ edge weights over that fixed topology. This makes it attractive when edge
 weights change repeatedly over a simulation run (unlike plain *CH*, which
 must rebuild the whole hierarchy for every **--weight-period**).
 
+In both applications one metric is customized per vehicle *type* (not per
+vehicle class). Everything the travel time function reads from the type is
+therefore exact per metric: the type's maximum speed, vClass-specific edge
+speed limits, [routing preferences](Simulation/Routing.md#routing_by_travel_time_and_routingtype)
+and **--weights.priority-factor**. Only the individual speed factor of the
+vehicles within a type is approximated by the type's reference vehicle, and
+**--weights.random-factor** freezes one random realization into each metric
+(the same approximation *CHWrapper* makes when building its hierarchies,
+instead of a fresh draw per query as with *dijkstra* and *astar*).
+
 - In **sumo**, CCH replaces the periodic hierarchy rebuild of *CH*/*CHWrapper*
   with a metric re-customization that runs whenever the [rerouting
   device](Demand/Automatic_Routing.md) adapts edge weights
-  (**--device.rerouting.adaptation-interval**). The metric always reflects
-  live simulated speeds; there is no support for **--weight-files** /
-  **--weight-period** time-dependent weights. One metric per vehicle class
-  present in the demand is customized and published; a query for a class
-  without a metric, or a query carrying a per-request prohibition (e.g. a
+  (**--device.rerouting.adaptation-interval**), so the metrics always reflect
+  the device's current edge weights (**--device.rerouting.bike-speeds**
+  included, through the metrics of the bicycle types). The re-customization
+  is partial: an edge is only propagated into the metric once its weight has
+  moved by more than **--device.rerouting.cch-update-threshold.factor**
+  (relative) and **--device.rerouting.cch-update-threshold.constant**
+  (absolute, in seconds) since it was last applied; the defaults (1 and 0)
+  propagate every change. **--device.rerouting.cch-ensemble** {{DT_INT}} keeps
+  that many metrics per type, each with its own frozen
+  **--weights.random-factor** realization, and assigns every vehicle to one of
+  them by a stable hash of its id, which restores the route diversity of the
+  random factor at the cost of more customization work. A query for a type
+  without a metric yet, or a query carrying a per-request prohibition (e.g. a
   [rerouter](Simulation/Rerouter.md) closure) that is not already a live
   permission change, transparently falls back to an embedded A\* search.
-  Because of this, **--weights.random-factor**, routing preferences and
-  **--device.rerouting.bike-speeds** are rejected when combined with CCH (the
-  shared metric has no per-vehicle state to encode them); **--weights.priority-factor**
-  is supported, since it only depends on the (static) edge.
 - In **duarouter**, CCH supports **--weight-files** / **--weight-period**
-  (one metric per vehicle type and weight period, built lazily on first use),
-  **--weights.priority-factor**, routing preferences (exact, since metrics
-  are keyed by vehicle type) and **--weights.random-factor** (one random
-  realization is frozen per metric, the same approximation *CHWrapper* makes
-  when building its hierarchies -- not exact per-vehicle randomization).
-  **--restriction-params** is supported by masking the restricted edges to
-  infinite weight per affected vehicle type.
+  (one metric per vehicle type and weight period, built lazily on first use)
+  and **--restriction-params** (the restricted edges are masked to infinite
+  weight per affected vehicle type).
 
 !!! caution
     CCH support differs meaningfully between sumo and duarouter; see the
@@ -110,6 +120,6 @@ section above for the exact split.
 | **--restriction-params** | yes | yes | no | yes | partial (duarouter only) |
 | Per-query prohibitions (rerouter / TraCI closures not already reflected as a live permission change) | yes | yes | yes | yes | falls back to embedded A\* |
 | **--weights.priority-factor** | yes | yes | yes | yes | yes |
-| **--weights.random-factor** | yes (exact, per query) | yes (exact, per query) | not supported | not supported | partial: duarouter approximates (one frozen realization per metric); sumo rejects |
-| Routing preferences | yes | yes | not supported | not supported | partial: duarouter exact (keyed by vehicle type); sumo rejects |
-| **--device.rerouting.bike-speeds** (sumo only) | yes | yes | not supported | not supported | rejected |
+| **--weights.random-factor** | yes (exact, per query) | yes (exact, per query) | not supported | not supported | approximated: one frozen realization per metric (sumo keeps several with **--device.rerouting.cch-ensemble**) |
+| Routing preferences | yes | yes | not supported | not supported | yes (exact, metrics are keyed by vehicle type) |
+| **--device.rerouting.bike-speeds** (sumo only) | yes | yes | not supported | not supported | yes |

--- a/docs/web/docs/marouter.md
+++ b/docs/web/docs/marouter.md
@@ -158,7 +158,7 @@ configuration:
 | **--max-alternatives** {{DT_INT}} | Prune the number of alternatives to INT; *default:* **5** |
 | **--with-taz** {{DT_BOOL}} | Use origin and destination zones (districts) for in- and output; *default:* **false** |
 | **--routing-threads** {{DT_INT}} | The number of parallel execution threads used for routing; *default:* **0** |
-| **--routing-algorithm** {{DT_STR}} | Select among routing algorithms ['dijkstra', 'astar', 'CH', 'CHWrapper']; *default:* **dijkstra** |
+| **--routing-algorithm** {{DT_STR}} | Select among routing algorithms ['dijkstra', 'astar', 'CH', 'CHWrapper', 'CCH']; *default:* **dijkstra** |
 | **--restriction-params** {{DT_STR_LIST}} | Comma separated list of param keys to compare for additional restrictions |
 | **--weights.interpolate** {{DT_BOOL}} | Interpolate edge weights at interval boundaries; *default:* **false** |
 | **--weights.expand** {{DT_BOOL}} | Expand the end of the last loaded weight interval to infinity; *default:* **false** |

--- a/src/duarouter/CMakeLists.txt
+++ b/src/duarouter/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(duarouter_SRCS
    duarouter_main.cpp
-   RODUACCHMetrics.cpp
-   RODUACCHMetrics.h
    RODUAEdgeBuilder.cpp
    RODUAEdgeBuilder.h
    RODUAFrame.cpp

--- a/src/duarouter/duarouter_main.cpp
+++ b/src/duarouter/duarouter_main.cpp
@@ -61,7 +61,7 @@
 #include "RODUAEdgeBuilder.h"
 #include <router/ROLane.h>
 #include <router/RONode.h>
-#include "RODUACCHMetrics.h"
+#include <router/ROCCHMetrics.h>
 #include "RODUAFrame.h"
 
 
@@ -162,7 +162,7 @@ computeRoutes(RONet& net, ROLoader& loader, OptionsCont& oc) {
         } else if (routingAlgorithm == "CCH") {
             // One weight-independent hierarchy over the union graph; one
             // customized metric per (vehicle type, weight period), built
-            // lazily on first query (see RODUACCHMetrics.h). With
+            // lazily on first query (see ROCCHMetrics.h). With
             // time-dependent weight files this follows CHRouterWrapper's
             // per-period semantics, but repeats only the metric
             // customization, never the topology build.
@@ -175,20 +175,20 @@ computeRoutes(RONet& net, ROLoader& loader, OptionsCont& oc) {
             const SUMOTime weightPeriod = hasWeights ? string2time(oc.getString("weight-period")) : SUMOTime_MAX;
             // Process-lifetime singletons: the topology and metric store are
             // shared by every router clone until duarouter exits.
-            RODUACCHGraph* cchGraph = new RODUACCHGraph(ROEdge::getAllEdges());
-            RODUACCHMetrics::init(cchGraph, ttFunction, begin, weightPeriod);
+            ROCCHGraph* cchGraph = new ROCCHGraph(ROEdge::getAllEdges());
+            ROCCHMetrics::init(cchGraph, ttFunction, begin, weightPeriod);
             SUMOAbstractRouter<ROEdge, ROVehicle>* fallback = new AStarRouter<ROEdge, ROVehicle, ROMapMatcher>(
                 ROEdge::getAllEdges(), oc.getBool("ignore-errors"), ttFunction,
                 nullptr, net.hasPermissions(), oc.isSet("restriction-params"));
             // restriction-params are handled natively: each distinct
             // restriction profile gets its own masked metric (see
-            // RODUACCHMetrics::get); the period-end hook lets queries whose
+            // ROCCHMetrics::get); the period-end hook lets queries whose
             // trip crosses a weight-period boundary re-query on the next
             // period's metric.
-            router = new CCHRouter<ROEdge, ROVehicle, RODUACCHGraph>(
-                cchGraph, &RODUACCHMetrics::get, ttFunction,
+            router = new CCHRouter<ROEdge, ROVehicle, ROCCHGraph>(
+                cchGraph, &ROCCHMetrics::get, ttFunction,
                 oc.getBool("ignore-errors"), fallback,
-                hasWeights ? &RODUACCHMetrics::periodEnd : nullptr);
+                hasWeights ? &ROCCHMetrics::periodEnd : nullptr);
         } else if (routingAlgorithm == "arcflag") {
             /// @brief The number of levels in the k-d tree partition
             constexpr auto NUMBER_OF_LEVELS = 5; //or 4 or 8

--- a/src/marouter/ROMAFrame.cpp
+++ b/src/marouter/ROMAFrame.cpp
@@ -243,7 +243,7 @@ ROMAFrame::checkOptions() {
         WRITE_ERRORF(TL("Invalid route choice method '%'."), oc.getString("route-choice-method"));
         return false;
     }
-    if (oc.getInt("paths") > 1 && (oc.getString("routing-algorithm") == "CH" || oc.getString("routing-algorithm") == "CHWrapper")) {
+    if (oc.getInt("paths") > 1 && (oc.getString("routing-algorithm") == "CH" || oc.getString("routing-algorithm") == "CHWrapper" || oc.getString("routing-algorithm") == "CCH")) {
         WRITE_WARNING(TL("Contraction hierarchies do not work with k shortest path search (please use a different routing algorithm)!"));
     }
     return true;

--- a/src/marouter/marouter_main.cpp
+++ b/src/marouter/marouter_main.cpp
@@ -51,12 +51,14 @@
 #include <utils/router/AStarRouter.h>
 #include <utils/router/CHRouter.h>
 #include <utils/router/CHRouterWrapper.h>
+#include <utils/router/CCHRouter.h>
 #include <utils/xml/XMLSubSys.h>
 #include <od/ODCell.h>
 #include <od/ODDistrict.h>
 #include <od/ODDistrictCont.h>
 #include <od/ODDistrictHandler.h>
 #include <od/ODMatrix.h>
+#include <router/ROCCHMetrics.h>
 #include <router/ROEdge.h>
 #include <router/ROLoader.h>
 #include <router/RONet.h>
@@ -176,6 +178,23 @@ computeRoutes(RONet& net, OptionsCont& oc, ODMatrix& matrix) {
             router = new CHRouterWrapper<ROEdge, ROVehicle>(
                 ROEdge::getAllEdges(), oc.getBool("ignore-errors"), &ROEdge::getTravelTimeStatic,
                 begin, end, weightPeriod, net.hasPermissions(), oc.getInt("routing-threads"));
+        } else if (routingAlgorithm == "CCH") {
+            // One weight-independent hierarchy over the union graph and one
+            // customized metric for the default vehicle's type, filled from
+            // the travel times of the current assignment iteration.
+            // ROMAAssignments resets the router after every iteration (where
+            // CH rebuilds its whole hierarchy); the reset hook flags the
+            // metric for re-customization at the next query, so every
+            // iteration routes on exactly the travel times a Dijkstra query
+            // would see. Like CH, the metric cannot follow the k shortest
+            // path penalties (see ROMAFrame::checkOptions).
+            ROCCHGraph* cchGraph = new ROCCHGraph(ROEdge::getAllEdges());
+            ROCCHMetrics::init(cchGraph, &ROEdge::getTravelTimeStatic, begin, SUMOTime_MAX);
+            SUMOAbstractRouter<ROEdge, ROVehicle>* fallback = new AStarRouter<ROEdge, ROVehicle, ROMapMatcher>(
+                ROEdge::getAllEdges(), oc.getBool("ignore-errors"), &ROEdge::getTravelTimeStatic, nullptr, net.hasPermissions());
+            router = new CCHRouter<ROEdge, ROVehicle, ROCCHGraph>(
+                cchGraph, &ROCCHMetrics::get, &ROEdge::getTravelTimeStatic,
+                oc.getBool("ignore-errors"), fallback, nullptr, &ROCCHMetrics::reset);
         } else {
             throw ProcessError(TLF("Unknown routing Algorithm '%'!", routingAlgorithm));
         }

--- a/src/router/CMakeLists.txt
+++ b/src/router/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(router_STAT_SRCS
    ROAbstractEdgeBuilder.h
+   ROCCHMetrics.cpp
+   ROCCHMetrics.h
    ROEdge.cpp
    ROEdge.h
    ROFrame.cpp
@@ -29,4 +31,5 @@ set(router_STAT_SRCS
 )
 
 add_library(router STATIC ${router_STAT_SRCS})
+target_link_libraries(router foreign_routingkit)
 set_property(TARGET router PROPERTY PROJECT_LABEL "z_router")

--- a/src/router/ROCCHMetrics.cpp
+++ b/src/router/ROCCHMetrics.cpp
@@ -11,42 +11,42 @@
 // https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
 /****************************************************************************/
-/// @file    RODUACCHMetrics.cpp
+/// @file    ROCCHMetrics.cpp
 /// @author  Pranav Sateesh
 /// @date    2026
 ///
-// duarouter's CCH metric store (see RODUACCHMetrics.h).
+// The CCH metric store of the router applications (see ROCCHMetrics.h).
 /****************************************************************************/
 #include <config.h>
 
-#include "RODUACCHMetrics.h"
+#include "ROCCHMetrics.h"
 
-#include <router/ROEdge.h>
-#include <router/ROVehicle.h>
+#include "ROEdge.h"
+#include "ROVehicle.h"
 
 // ===========================================================================
 // static member definitions
 // ===========================================================================
-RODUACCHMetricFamily* RODUACCHMetrics::myFamily = nullptr;
+ROCCHMetricFamily* ROCCHMetrics::myFamily = nullptr;
 
 
 // ===========================================================================
-// RODUACCHMetrics method definitions
+// ROCCHMetrics method definitions
 // ===========================================================================
 void
-RODUACCHMetrics::init(const RODUACCHGraph* graph, RODUACCHGraph::EffortOperation effort,
-                      SUMOTime begin, SUMOTime weightPeriod) {
+ROCCHMetrics::init(const ROCCHGraph* graph, ROCCHGraph::EffortOperation effort,
+                   SUMOTime begin, SUMOTime weightPeriod) {
     delete myFamily;
     // no reference-vehicle factory: each (type, period) pair is customized
-    // exactly once, so the first querying vehicle of a type is that type's
-    // effort reference
-    myFamily = new RODUACCHMetricFamily(graph, effort, begin, weightPeriod,
-                                        nullptr, &RODUACCHMetrics::patchRestrictions);
+    // exactly once per fill, so the first querying vehicle of a type is that
+    // type's effort reference
+    myFamily = new ROCCHMetricFamily(graph, effort, begin, weightPeriod,
+                                     nullptr, &ROCCHMetrics::patchRestrictions);
 }
 
 
 const RoutingKit::CustomizableContractionHierarchyMetric*
-RODUACCHMetrics::get(SUMOVehicleClass vClass, SUMOTime time, const ROVehicle* veh) {
+ROCCHMetrics::get(SUMOVehicleClass vClass, SUMOTime time, const ROVehicle* veh) {
     if (myFamily == nullptr) {
         return nullptr;  // not initialised -> caller falls back to A*
     }
@@ -58,14 +58,22 @@ RODUACCHMetrics::get(SUMOVehicleClass vClass, SUMOTime time, const ROVehicle* ve
 
 
 SUMOTime
-RODUACCHMetrics::periodEnd(SUMOTime time) {
+ROCCHMetrics::periodEnd(SUMOTime time) {
     return myFamily == nullptr ? SUMOTime_MAX : myFamily->periodEnd(time);
 }
 
 
 void
-RODUACCHMetrics::patchRestrictions(const RODUACCHGraph* graph, const ROVehicle* veh,
-                                   std::vector<unsigned>& weights) {
+ROCCHMetrics::reset(const ROVehicle* /* veh */) {
+    if (myFamily != nullptr) {
+        myFamily->flagStale();
+    }
+}
+
+
+void
+ROCCHMetrics::patchRestrictions(const ROCCHGraph* graph, const ROVehicle* veh,
+                                std::vector<unsigned>& weights) {
     if (veh == nullptr || veh->getType()->paramRestrictions.empty()) {
         return;
     }

--- a/src/router/ROCCHMetrics.h
+++ b/src/router/ROCCHMetrics.h
@@ -11,16 +11,20 @@
 // https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
 /****************************************************************************/
-/// @file    RODUACCHMetrics.h
+/// @file    ROCCHMetrics.h
 /// @author  Pranav Sateesh
 /// @date    2026
 ///
-// duarouter's CCH metric store: thin static trampolines (CCHRouter's
-// MetricProvider and PeriodEnd hooks are plain function pointers) over the
-// shared CCHMetricFamily in STATIC mode -- lazy per-(vehicle type, weight
-// period) customization, filled with the querying vehicle, with the
-// restriction-params edges of a type masked to inf_weight by a post-fill
-// patch. See utils/router/CCHMetricFamily.h for the semantics.
+// The CCH metric store of the router applications (duarouter, marouter):
+// thin static trampolines (CCHRouter's MetricProvider, PeriodEnd and reset
+// hooks are plain function pointers) over the shared CCHMetricFamily in
+// STATIC mode -- lazy per-(vehicle type, weight period) customization,
+// filled with the querying vehicle, with the restriction-params edges of a
+// type masked to inf_weight by a post-fill patch. marouter has no weight
+// periods but changes the travel times after every assignment iteration and
+// resets its router there: the reset flags every metric for
+// re-customization on the next query. See utils/router/CCHMetricFamily.h
+// for the semantics.
 /****************************************************************************/
 #pragma once
 #include <config.h>
@@ -39,21 +43,21 @@ class SUMOVTypeParameter;
 // class definitions
 // ===========================================================================
 /// @brief the ROEdge instantiation of the CCH graph mapping
-using RODUACCHGraph = CCHGraph<ROEdge, ROVehicle>;
+using ROCCHGraph = CCHGraph<ROEdge, ROVehicle>;
 /// @brief the ROEdge instantiation of the CCH metric store, keyed by the
 /// vehicle-type parameters (stable pointers, owned by RONet)
-using RODUACCHMetricFamily = CCHMetricFamily<ROEdge, ROVehicle, SUMOVTypeParameter>;
+using ROCCHMetricFamily = CCHMetricFamily<ROEdge, ROVehicle, SUMOVTypeParameter>;
 
 
 /**
- * @class RODUACCHMetrics
- * @brief function-pointer front end of duarouter's STATIC metric family
+ * @class ROCCHMetrics
+ * @brief function-pointer front end of the router applications' STATIC metric family
  */
-class RODUACCHMetrics {
+class ROCCHMetrics {
 public:
     /// @brief install the shared graph, effort function and weight-period
     /// grid (call once, before routing); weightPeriod SUMOTime_MAX = static
-    static void init(const RODUACCHGraph* graph, RODUACCHGraph::EffortOperation effort,
+    static void init(const ROCCHGraph* graph, ROCCHGraph::EffortOperation effort,
                      SUMOTime begin, SUMOTime weightPeriod);
 
     /// @brief the metric for the vehicle's type at a query time, built on
@@ -65,11 +69,16 @@ public:
     /// (SUMOTime_MAX when the weights are static); CCHRouter's PeriodEnd hook
     static SUMOTime periodEnd(SUMOTime time);
 
+    /// @brief the edge weights changed behind the metrics (marouter after an
+    /// assignment iteration, through CCHRouter::reset): every metric is
+    /// refilled and re-customized on the next query; CCHRouter's ResetHook
+    static void reset(const ROVehicle* veh);
+
 private:
     /// @brief post-fill hook: mask the edges that restrict the querying
     /// vehicle's type to inf_weight (restriction-params)
-    static void patchRestrictions(const RODUACCHGraph* graph, const ROVehicle* veh,
+    static void patchRestrictions(const ROCCHGraph* graph, const ROVehicle* veh,
                                   std::vector<unsigned>& weights);
 
-    static RODUACCHMetricFamily* myFamily;
+    static ROCCHMetricFamily* myFamily;
 };

--- a/src/router/ROFrame.cpp
+++ b/src/router/ROFrame.cpp
@@ -180,10 +180,7 @@ ROFrame::fillOptions(OptionsCont& oc, const bool isDUA, const bool isMA) {
 
     if (isDUA || isMA) {
         oc.doRegister("routing-algorithm", new Option_String("dijkstra"));
-        // CCH is only implemented for duarouter
-        oc.addDescription("routing-algorithm", "Processing",
-                          isDUA ? TL("Select among routing algorithms ['dijkstra', 'astar', 'CH', 'CHWrapper', 'CCH']")
-                          : TL("Select among routing algorithms ['dijkstra', 'astar', 'CH', 'CHWrapper']"));
+        oc.addDescription("routing-algorithm", "Processing", TL("Select among routing algorithms ['dijkstra', 'astar', 'CH', 'CHWrapper', 'CCH']"));
     }
 
     oc.doRegister("restriction-params", new Option_StringVector());

--- a/src/utils/router/CCHMetricFamily.h
+++ b/src/utils/router/CCHMetricFamily.h
@@ -31,9 +31,11 @@
 //
 // STATIC -- weights never change while a (type, weight period) pair is in
 //   use. Metrics are customized lazily on the first query of a pair under a
-//   mutex and cached (duarouter and the simulation's free-flow routers).
-//   A runtime permission change re-customizes every cached metric on the
-//   next query (flagPermissionsStale).
+//   mutex and cached (duarouter, marouter and the simulation's free-flow
+//   routers). When the efforts do change between queries -- a runtime
+//   permission flip, marouter's travel times after an assignment iteration
+//   -- the host flags it (flagStale) and every cached metric is refilled
+//   and re-customized on the next query.
 //
 // LIVE -- weights track an adaptive speed table (the rerouting device).
 //   Metrics are double-buffered: worker threads acquire-load the published
@@ -183,27 +185,21 @@ public:
      * serialises concurrent first queries from parallel routing threads
      * (satisfying primeClassMask's synchronization contract); afterwards the
      * map is read-only for that key (map references are address-stable).
-     * A pending permission flip first re-customizes every cached metric from
-     * the live permissions (main-thread callers only -- see
-     * flagPermissionsStale). */
+     * A pending flagStale() first refills and re-customizes every cached
+     * metric from the live efforts and permissions -- in place, so the
+     * flagging host guarantees that no query is in flight (the simulation's
+     * main thread, marouter's reset between two iterations). */
     MetricPtr get(const K* key, SUMOVehicleClass vClass, SUMOTime time, const V* veh) {
         std::lock_guard<std::mutex> lock(myStaticLock);
-        if (myPermissionsStale) {
-            const double now = STEPS2TIME(time);
+        if (myStale) {
             for (auto& item : myStaticMetrics) {
                 StaticMetric& sm = item.second;
-                myGraph->fillInputWeights(myFillEffort, sm.vClass,
-                                          sm.refVehicle != nullptr ? sm.refVehicle : veh, now, sm.weights);
+                fillStatic(sm, item.first.second, time, sm.refVehicle != nullptr ? sm.refVehicle : veh, veh);
                 sm.metric->customize();
             }
-            myPermissionsStale = false;
+            myStale = false;
         }
-        // period 0 covers everything before begin and the whole run when the
-        // weights are static
-        int period = 0;
-        if (myWeightPeriod > 0 && myWeightPeriod != SUMOTime_MAX && time > myBegin) {
-            period = (int)((time - myBegin) / myWeightPeriod);
-        }
+        const int period = periodOf(time);
         const std::pair<const K*, int> mapKey(key, period);
         auto it = myStaticMetrics.find(mapKey);
         if (it == myStaticMetrics.end()) {
@@ -214,15 +210,7 @@ public:
                 sm.refVehicle = myFactory(key, 0);
                 ref = sm.refVehicle;
             }
-            // the weights are evaluated at the period's begin, so each pair
-            // is customized exactly once (a single period evaluates at begin,
-            // where free-flow style efforts are time-invariant anyway)
-            const double fillTime = myWeightPeriod == SUMOTime_MAX
-                                    ? STEPS2TIME(time) : STEPS2TIME(myBegin + period * myWeightPeriod);
-            myGraph->fillInputWeights(myFillEffort, vClass, ref, fillTime, sm.weights);
-            if (myPatch != nullptr) {
-                myPatch(myGraph, veh, sm.weights);
-            }
+            fillStatic(sm, period, time, ref, veh);
             sm.metric.reset(new RoutingKit::CustomizableContractionHierarchyMetric(
                                 myGraph->cch(), sm.weights));
             sm.metric->customize();
@@ -237,16 +225,22 @@ public:
         if (myWeightPeriod <= 0 || myWeightPeriod == SUMOTime_MAX) {
             return SUMOTime_MAX;
         }
-        const int period = time > myBegin ? (int)((time - myBegin) / myWeightPeriod) : 0;
-        return myBegin + (period + 1) * myWeightPeriod;
+        return myBegin + (periodOf(time) + 1) * myWeightPeriod;
     }
 
-    /// @brief a runtime permission change invalidated the cached metrics;
-    /// every metric is re-customized from the live permissions on the next
-    /// get(). The caller must also invalidate the graph's class masks.
-    void flagPermissionsStale() {
+    /** @brief the efforts behind the cached metrics changed -- a runtime
+     * permission change in the simulation (the caller must also invalidate
+     * the graph's class masks), or marouter's travel times after an
+     * assignment iteration (CCHRouter::reset): every cached metric is
+     * refilled and re-customized on the next get(). */
+    void flagStale() {
         std::lock_guard<std::mutex> lock(myStaticLock);
-        myPermissionsStale = true;
+        myStale = true;
+    }
+
+    /// @brief flagStale() under the simulation's name for the permission case
+    void flagPermissionsStale() {
+        flagStale();
     }
     /// @}
 
@@ -530,7 +524,52 @@ private:
         /// @brief OWNED reference vehicle (nullptr when filling with the
         /// querying vehicle)
         V* refVehicle = nullptr;
+        /// @brief whether the first fill (which runs the patch) is done
+        bool filled = false;
+        /// @brief the (arc, weight) pairs the patch wrote on the first fill,
+        /// re-applied on every refill
+        std::vector<std::pair<unsigned, unsigned> > patched;
     };
+
+    /// @brief the weight period containing @p time: 0 is everything before
+    /// begin and the whole run when the weights are static
+    int periodOf(SUMOTime time) const {
+        if (myWeightPeriod > 0 && myWeightPeriod != SUMOTime_MAX && time > myBegin) {
+            return (int)((time - myBegin) / myWeightPeriod);
+        }
+        return 0;
+    }
+
+    /** @brief (re)fill a STATIC metric's input weights from the live efforts.
+     * A weight-period grid evaluates at the period's begin, so each pair is
+     * customized once per fill; a single period evaluates at the query time
+     * -- free-flow efforts are time-invariant anyway, and marouter's
+     * per-iteration travel times are exactly what a Dijkstra query at that
+     * time sees. The patch runs once, on the first fill, and what it wrote is
+     * re-applied on every refill: the masked set depends only on the
+     * metric's type, whereas the vehicle triggering a refill may be of
+     * another type. */
+    void fillStatic(StaticMetric& sm, int period, SUMOTime time, const V* ref, const V* veh) {
+        const double fillTime = myWeightPeriod == SUMOTime_MAX
+                                ? STEPS2TIME(time) : STEPS2TIME(myBegin + period * myWeightPeriod);
+        myGraph->fillInputWeights(myFillEffort, sm.vClass, ref, fillTime, sm.weights);
+        if (!sm.filled) {
+            sm.filled = true;
+            if (myPatch != nullptr) {
+                const std::vector<unsigned> unpatched(sm.weights);
+                myPatch(myGraph, veh, sm.weights);
+                for (unsigned a = 0; a < (unsigned)sm.weights.size(); a++) {
+                    if (sm.weights[a] != unpatched[a]) {
+                        sm.patched.emplace_back(a, sm.weights[a]);
+                    }
+                }
+            }
+        } else {
+            for (const auto& p : sm.patched) {
+                sm.weights[p.first] = p.second;
+            }
+        }
+    }
 
     /// @brief stable 64-bit FNV-1a for the ensemble slot assignment
     static uint64_t fnv1a(const std::string& s) {
@@ -573,7 +612,9 @@ private:
     SUMOTime myWeightPeriod;
     std::map<std::pair<const K*, int>, StaticMetric> myStaticMetrics;
     std::mutex myStaticLock;
-    bool myPermissionsStale = false;
+    /// @brief the efforts changed behind the cached metrics: refill and
+    /// re-customize them all on the next get() (see flagStale)
+    bool myStale = false;
     /// @}
 
     /// @name LIVE state

--- a/src/utils/router/CCHRouter.h
+++ b/src/utils/router/CCHRouter.h
@@ -82,6 +82,11 @@ public:
     /// whose trip crosses into the next period and re-query on that
     /// period's metric (see the boundary handling in compute()).
     typedef SUMOTime(*PeriodEnd)(SUMOTime);
+    /// @brief the host's efforts changed behind the metrics and it reset the
+    /// router (SUMOAbstractRouter::reset -- marouter does so after every
+    /// assignment iteration, which is where CH rebuilds its hierarchy): the
+    /// metric store should re-customize before the next query
+    typedef void (*ResetHook)(const V*);
     typedef typename SUMOAbstractRouter<E, V>::Operation Operation;
     typedef typename SUMOAbstractRouter<E, V>::Prohibitions Prohibitions;
 
@@ -90,14 +95,16 @@ public:
      * @param[in] provider  static accessor for the published metric snapshot
      * @param[in] operation the effort callback (same one A-star and CH use)
      * @param[in] fallback  embedded router for non-CCH cases (OWNED)
+     * @param[in] periodEnd weight-period boundary hook (nullptr = static weights)
+     * @param[in] onReset   hook run by reset() (nullptr = nobody to notify)
      */
     CCHRouter(const GRAPH* graph, MetricProvider provider,
               Operation operation, const bool unbuildIsWarning,
               SUMOAbstractRouter<E, V>* fallback,
-              PeriodEnd periodEnd = nullptr) :
+              PeriodEnd periodEnd = nullptr, ResetHook onReset = nullptr) :
         SUMOAbstractRouter<E, V>("CCHRouter", unbuildIsWarning, operation, nullptr, false, false),
         myGraph(graph), myMetricProvider(provider), myFallback(fallback),
-        myPeriodEnd(periodEnd), myProhibitionActive(false) {
+        myPeriodEnd(periodEnd), myOnReset(onReset), myProhibitionActive(false) {
     }
 
     /// @brief clone constructor: share graph + provider, clone the fallback, fresh query scratch
@@ -105,6 +112,7 @@ public:
         SUMOAbstractRouter<E, V>(other),
         myGraph(other->myGraph), myMetricProvider(other->myMetricProvider),
         myFallback(other->myFallback->clone()), myPeriodEnd(other->myPeriodEnd),
+        myOnReset(other->myOnReset),
         myProhibitionActive(other->myProhibitionActive), myProhibited(other->myProhibited) {
     }
 
@@ -114,6 +122,17 @@ public:
 
     virtual SUMOAbstractRouter<E, V>* clone() {
         return new CCHRouter<E, V, GRAPH>(this);
+    }
+
+    /// @brief the host's efforts changed (see ResetHook): notify the metric
+    /// store and reset the fallback's caches. Must not run while another
+    /// clone is mid-query; marouter resets once its worker threads have
+    /// finished the iteration.
+    virtual void reset(const V* const vehicle) {
+        if (myOnReset != nullptr) {
+            myOnReset(vehicle);
+        }
+        myFallback->reset(vehicle);
     }
 
     bool compute(const E* from, const E* to, const V* const vehicle,
@@ -347,6 +366,7 @@ private:
     MetricPtr myBoundMetric = nullptr;       // metric myQuery is currently bound to
     SUMOAbstractRouter<E, V>* myFallback;    // owned
     PeriodEnd myPeriodEnd;                   // may be nullptr (static weights)
+    ResetHook myOnReset;                     // may be nullptr (nobody to notify)
     bool myProhibitionActive;
     Prohibitions myProhibited;               // last set installed via prohibit()
 

--- a/tests/marouter/incremental/cch/options.marouter
+++ b/tests/marouter/incremental/cch/options.marouter
@@ -1,0 +1,1 @@
+-m input_od_vm.fma -n input_net.net.xml -a input_taz.taz.xml --output routes.rou.xml --routing-algorithm CCH

--- a/tests/marouter/incremental/cch/output.marouter
+++ b/tests/marouter/incremental/cch/output.marouter
@@ -1,0 +1,1 @@
+Success.

--- a/tests/marouter/incremental/cch/routes.marouter
+++ b/tests/marouter/incremental/cch/routes.marouter
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on 2026-09-04T20:22:47.700275+01:00 by Eclipse SUMO marouter v1.27.1-0000000000
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+This file may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License 2.0 are satisfied: GNU General Public License, version 2
+or later which is available at
+https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+<marouterConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/marouterConfiguration.xsd">
+
+    <input>
+        <net-file value="input_net.net.xml"/>
+        <additional-files value="input_taz.taz.xml"/>
+        <od-matrix-files value="input_od_vm.fma"/>
+    </input>
+
+    <output>
+        <output-file value="routes.rou.xml"/>
+        <write-license value="true"/>
+    </output>
+
+    <processing>
+        <routing-algorithm value="CCH"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+    </report>
+
+</marouterConfiguration>
+-->
+
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <flow id="0" begin="0.00" end="86400.00" number="800" type="1" fromTaz="91" toTaz="93" departLane="free" departSpeed="max">
+        <routeDistribution>
+            <route cost="289.16" probability="360.00000000" edges="D1 L2 L5 L8 L9 L14 L15 L16 D3"/>
+            <route cost="289.17" probability="440.00000000" edges="D1 L2 L5 L7 L6 L10 L13 L15 L16 D3"/>
+        </routeDistribution>
+    </flow>
+    <flow id="1" begin="0.00" end="86400.00" number="200" type="1" fromTaz="92" toTaz="93" departLane="free" departSpeed="max">
+        <routeDistribution>
+            <route cost="286.08" probability="90.00000000" edges="D2 L3 L5 L8 L9 L14 L15 L16 D3"/>
+            <route cost="286.09" probability="110.00000000" edges="D2 L3 L5 L7 L6 L10 L13 L15 L16 D3"/>
+        </routeDistribution>
+    </flow>
+</routes>

--- a/tests/marouter/incremental/cch_threading/options.marouter
+++ b/tests/marouter/incremental/cch_threading/options.marouter
@@ -1,0 +1,1 @@
+-m input_od_vm.fma -n input_net.net.xml -a input_taz.taz.xml --output routes.rou.xml --routing-algorithm CCH --routing-threads 2

--- a/tests/marouter/incremental/cch_threading/output.marouter
+++ b/tests/marouter/incremental/cch_threading/output.marouter
@@ -1,0 +1,1 @@
+Success.

--- a/tests/marouter/incremental/cch_threading/routes.marouter
+++ b/tests/marouter/incremental/cch_threading/routes.marouter
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on 2026-09-04T20:22:47.790928+01:00 by Eclipse SUMO marouter v1.27.1-0000000000
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+This file may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License 2.0 are satisfied: GNU General Public License, version 2
+or later which is available at
+https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+<marouterConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/marouterConfiguration.xsd">
+
+    <input>
+        <net-file value="input_net.net.xml"/>
+        <additional-files value="input_taz.taz.xml"/>
+        <od-matrix-files value="input_od_vm.fma"/>
+    </input>
+
+    <output>
+        <output-file value="routes.rou.xml"/>
+        <write-license value="true"/>
+    </output>
+
+    <processing>
+        <routing-threads value="2"/>
+        <routing-algorithm value="CCH"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+    </report>
+
+</marouterConfiguration>
+-->
+
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <flow id="0" begin="0.00" end="86400.00" number="800" type="1" fromTaz="91" toTaz="93" departLane="free" departSpeed="max">
+        <routeDistribution>
+            <route cost="289.16" probability="360.00000000" edges="D1 L2 L5 L8 L9 L14 L15 L16 D3"/>
+            <route cost="289.17" probability="440.00000000" edges="D1 L2 L5 L7 L6 L10 L13 L15 L16 D3"/>
+        </routeDistribution>
+    </flow>
+    <flow id="1" begin="0.00" end="86400.00" number="200" type="1" fromTaz="92" toTaz="93" departLane="free" departSpeed="max">
+        <routeDistribution>
+            <route cost="286.08" probability="90.00000000" edges="D2 L3 L5 L8 L9 L14 L15 L16 D3"/>
+            <route cost="286.09" probability="110.00000000" edges="D2 L3 L5 L7 L6 L10 L13 L15 L16 D3"/>
+        </routeDistribution>
+    </flow>
+</routes>

--- a/tests/marouter/incremental/testsuite.marouter
+++ b/tests/marouter/incremental/testsuite.marouter
@@ -12,3 +12,9 @@ iter50
 
 # multi threaded call of the incremental assignment
 threading
+
+# incremental assignment with CCH routing (the metric is re-customized after every iteration)
+cch
+
+# multi threaded incremental assignment with CCH routing
+cch_threading

--- a/tests/marouter/meta/help/output.marouter
+++ b/tests/marouter/meta/help/output.marouter
@@ -97,7 +97,8 @@ Processing Options:
   --routing-threads INT               The number of parallel execution threads
                                        used for routing
   --routing-algorithm STR             Select among routing algorithms
-                                       ['dijkstra', 'astar', 'CH', 'CHWrapper']
+                                       ['dijkstra', 'astar', 'CH', 'CHWrapper',
+                                       'CCH']
   --restriction-params STR[]          Comma separated list of param keys to
                                        compare for additional restrictions
   --weights.interpolate               Interpolate edge weights at interval

--- a/tests/marouter/meta/write_template_commented_full/cfg.marouter
+++ b/tests/marouter/meta/write_template_commented_full/cfg.marouter
@@ -153,7 +153,7 @@
         <!-- The number of parallel execution threads used for routing -->
         <routing-threads value="0" type="INT"/>
 
-        <!-- Select among routing algorithms [&apos;dijkstra&apos;, &apos;astar&apos;, &apos;CH&apos;, &apos;CHWrapper&apos;] -->
+        <!-- Select among routing algorithms [&apos;dijkstra&apos;, &apos;astar&apos;, &apos;CH&apos;, &apos;CHWrapper&apos;, &apos;CCH&apos;] -->
         <routing-algorithm value="dijkstra" type="STR"/>
 
         <!-- Comma separated list of param keys to compare for additional restrictions -->

--- a/tests/marouter/meta/write_template_full/cfg.marouter
+++ b/tests/marouter/meta/write_template_full/cfg.marouter
@@ -61,7 +61,7 @@
         <max-alternatives value="5" type="INT" help="Prune the number of alternatives to INT"/>
         <with-taz value="false" type="BOOL" help="Use origin and destination zones (districts) for in- and output"/>
         <routing-threads value="0" type="INT" help="The number of parallel execution threads used for routing"/>
-        <routing-algorithm value="dijkstra" type="STR" help="Select among routing algorithms [&apos;dijkstra&apos;, &apos;astar&apos;, &apos;CH&apos;, &apos;CHWrapper&apos;]"/>
+        <routing-algorithm value="dijkstra" type="STR" help="Select among routing algorithms [&apos;dijkstra&apos;, &apos;astar&apos;, &apos;CH&apos;, &apos;CHWrapper&apos;, &apos;CCH&apos;]"/>
         <restriction-params value="" type="STR[]" help="Comma separated list of param keys to compare for additional restrictions"/>
         <weights.interpolate value="false" synonymes="interpolate" deprecated="interpolate" type="BOOL" help="Interpolate edge weights at interval boundaries"/>
         <weights.expand value="false" synonymes="expand-weights" deprecated="expand-weights" type="BOOL" help="Expand the end of the last loaded weight interval to infinity"/>

--- a/tests/marouter/sue/testsuite.marouter
+++ b/tests/marouter/sue/testsuite.marouter
@@ -3,3 +3,6 @@ plain
 
 # SUE assignment with CH routing does not work
 warn_CH
+
+# SUE assignment with CCH routing: like CH, the metric does not see the k shortest path penalties
+warn_CCH

--- a/tests/marouter/sue/warn_CCH/config.marouter
+++ b/tests/marouter/sue/warn_CCH/config.marouter
@@ -1,0 +1,2 @@
+[relative_float_tolerance]
+routes:0.13

--- a/tests/marouter/sue/warn_CCH/errors.marouter
+++ b/tests/marouter/sue/warn_CCH/errors.marouter
@@ -1,0 +1,1 @@
+Warning: Contraction hierarchies do not work with k shortest path search (please use a different routing algorithm)!

--- a/tests/marouter/sue/warn_CCH/options.marouter
+++ b/tests/marouter/sue/warn_CCH/options.marouter
@@ -1,0 +1,1 @@
+-m input_od_vm.fma -n input_net.net.xml -a input_taz.taz.xml --output routes.rou.xml --assignment-method SUE --paths 3 --routing-algorithm CCH

--- a/tests/marouter/sue/warn_CCH/output.marouter
+++ b/tests/marouter/sue/warn_CCH/output.marouter
@@ -1,0 +1,1 @@
+Success.

--- a/tests/marouter/sue/warn_CCH/routes.marouter
+++ b/tests/marouter/sue/warn_CCH/routes.marouter
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on 2026-09-04T20:22:48.001604+01:00 by Eclipse SUMO marouter v1.27.1-0000000000
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+This file may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License 2.0 are satisfied: GNU General Public License, version 2
+or later which is available at
+https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
+<marouterConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/marouterConfiguration.xsd">
+
+    <input>
+        <net-file value="input_net.net.xml"/>
+        <additional-files value="input_taz.taz.xml"/>
+        <od-matrix-files value="input_od_vm.fma"/>
+    </input>
+
+    <output>
+        <output-file value="routes.rou.xml"/>
+        <write-license value="true"/>
+    </output>
+
+    <processing>
+        <routing-algorithm value="CCH"/>
+        <assignment-method value="SUE"/>
+        <paths value="3"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+    </report>
+
+</marouterConfiguration>
+-->
+
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <flow id="0" begin="0.00" end="86400.00" number="100" type="1" fromTaz="91" toTaz="93" departLane="free" departSpeed="max">
+        <routeDistribution>
+            <route cost="272.60" probability="100.00000000" edges="D1 L2 L5 L7 L6 L10 L13 L15 L16 D3"/>
+        </routeDistribution>
+    </flow>
+</routes>


### PR DESCRIPTION
1. CCH is now available in marouter: the new branch in marouter_main builds one metric for the default vehicle type and the k-paths warning covers CCH like CH.

2. CCHRouter gained a reset hook, so marouter's existing per-iteration router reset re-customizes the metric from the new travel times before the next query.

3. The static metric family got a general flagStale(), refills at the correct fill time per period, and re-applies the restriction masks it recorded on the first fill.

4. duarouter's metric store moved into the shared router library as ROCCHMetrics, so duarouter and marouter use the same code and marouter links RoutingKit through it.

5. Docs corrected and extended: sumo does accept random-factor, preferences and bike-speeds with CCH, the threshold and ensemble options are described, marouter is listed, and three marouter CCH tests plus updated meta references were added.